### PR TITLE
fix(hub): discover models against the endpoint the provider actually uses

### DIFF
--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -665,6 +665,7 @@ pub fn run() {
             detail::list_models,
             models_admin::probe_local_providers,
             models_admin::test_provider,
+            models_admin::suggested_base_url,
             models_admin::add_models,
             models_admin::remove_model,
             models_admin::update_model,

--- a/mur-hub-gui/src-tauri/src/models_admin.rs
+++ b/mur-hub-gui/src-tauri/src/models_admin.rs
@@ -105,31 +105,108 @@ pub fn provider_secret_ref(reg: &ModelRegistry, provider: &str) -> Option<Secret
         .and_then(|e| e.secret.clone())
 }
 
+/// Base URL already stored for `provider`, if any.
+///
+/// A provider fronted by a proxy (mur-model-gateway, LiteLLM, a self-hosted
+/// relay) has its endpoint in the registry, not at the vendor's canonical
+/// host. Discovery must reuse it or it dials the vendor directly with a
+/// gateway token and gets a 401.
+pub fn provider_base_url(reg: &ModelRegistry, provider: &str) -> Option<String> {
+    reg.models
+        .values()
+        .find(|e| e.provider == provider && e.base_url.is_some())
+        .and_then(|e| e.base_url.clone())
+}
+
+/// Endpoint the Model Library should offer for `provider` before the user
+/// edits it: an existing registry entry wins, else the local OAuth bridge
+/// (mur-model-gateway / cc-proxy) when it is enabled and listening.
+///
+/// The bridge is Anthropic-specific — it swaps `x-api-key` for the Bearer +
+/// betas shape subscription tokens need — so it is only suggested there. A
+/// machine with no registry entry and no bridge gets `None`, and the caller
+/// keeps the vendor's canonical host (the plain API-key path).
+pub fn suggest_base_url(provider: &str) -> Option<String> {
+    if let Some(url) = ModelRegistry::default_path()
+        .ok()
+        .and_then(|p| ModelRegistry::load_from(&p).ok())
+        .and_then(|reg| provider_base_url(&reg, provider))
+    {
+        return Some(url);
+    }
+    if !provider.eq_ignore_ascii_case("anthropic") {
+        return None;
+    }
+    let cfg = mur_common::config::Config::load_or_default(&mur_home().join("config.yaml"));
+    mur_gui_core::oauth_bridge::resolve_bridge_url(
+        &cfg.cc_proxy,
+        std::env::var("ANTHROPIC_BASE_URL").ok().as_deref(),
+        mur_gui_core::oauth_bridge::bridge_is_listening,
+    )
+}
+
+/// Prefill for the Model Library's BASE URL field. See [`suggest_base_url`].
+#[tauri::command]
+pub fn suggested_base_url(provider: String) -> Option<String> {
+    suggest_base_url(&provider)
+}
+
+/// A subscription token sent as `x-api-key` to the vendor host always 401s —
+/// it has to traverse the bridge. Say that instead of echoing the raw body.
+fn explain_oauth_misroute(key: Option<&str>, base: &str, bridge_url: &str) -> Option<String> {
+    let key = key?;
+    if !key.contains("sk-ant-oat") || !base.contains("api.anthropic.com") {
+        return None;
+    }
+    Some(format!(
+        "This looks like an Anthropic subscription token (sk-ant-oat…), which \
+         api.anthropic.com rejects when sent directly. Either point BASE URL at \
+         your mur-model-gateway ({bridge_url}), or paste a standard API key \
+         (sk-ant-api…) to call Anthropic directly."
+    ))
+}
+
 #[tauri::command]
 pub async fn test_provider(
     provider: String,
-    base_url: String,
+    base_url: Option<String>,
     api_key: Option<String>,
 ) -> Result<Vec<EnrichedModelView>, String> {
+    let path = ModelRegistry::default_path().map_err(|e| e.to_string())?;
+    let reg = ModelRegistry::load_from(&path).ok();
+
     // Explicit key from the UI wins. Otherwise (re-exploring a connected
     // provider with no key field) resolve the provider's stored SecretRef so
     // re-explore no longer 401s.
     let key: Option<String> = match api_key.filter(|k| !k.is_empty()) {
         Some(k) => Some(k),
-        None => {
-            let path = ModelRegistry::default_path().map_err(|e| e.to_string())?;
-            match ModelRegistry::load_from(&path)
-                .ok()
-                .and_then(|reg| provider_secret_ref(&reg, &provider))
-            {
-                Some(secret) => secret.resolve_to_string().await,
-                None => None,
-            }
-        }
+        None => match reg
+            .as_ref()
+            .and_then(|reg| provider_secret_ref(reg, &provider))
+        {
+            Some(secret) => secret.resolve_to_string().await,
+            None => None,
+        },
     };
 
+    // Same fallback as add_models: an empty field means "whatever this provider
+    // already uses", not "the vendor's canonical host".
+    let base = base_url
+        .filter(|u| !u.trim().is_empty())
+        .or_else(|| suggest_base_url(&provider))
+        .ok_or_else(|| format!("no base URL for provider {provider}"))?;
+
+    if let Some(msg) = explain_oauth_misroute(
+        key.as_deref(),
+        &base,
+        &mur_common::config::Config::load_or_default(&mur_home().join("config.yaml"))
+            .cc_proxy
+            .url,
+    ) {
+        return Err(msg);
+    }
+
     let home = mur_home();
-    let base = base_url.clone();
     let prov = provider.clone();
     let prov2 = provider.clone();
     // discover_models uses reqwest::blocking — run it off the async runtime.
@@ -171,12 +248,9 @@ pub fn add_models(
     // Resolve base_url: use the provided value, or fall back to an existing
     // registry entry for the same provider (handles connected providers whose
     // base_url was already stored), or leave None.
-    let resolved_base_url = base_url.clone().or_else(|| {
-        reg.models
-            .values()
-            .find(|e| e.provider == provider)
-            .and_then(|e| e.base_url.clone())
-    });
+    let resolved_base_url = base_url
+        .clone()
+        .or_else(|| provider_base_url(&reg, &provider));
     for pick in picks {
         let price = model_prices::lookup(&home, &provider, &pick.model, is_local);
         let entry = ModelEntry {
@@ -348,5 +422,84 @@ mod tests {
     fn apply_cost_update_errors_on_unknown_ref() {
         let mut reg = ModelRegistry::default();
         assert!(apply_cost_update(&mut reg, "missing", Some(0.001), None).is_err());
+    }
+
+    fn reg_with(provider: &str, base_url: Option<&str>) -> ModelRegistry {
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            format!("{provider}_a"),
+            ModelEntry {
+                provider: provider.into(),
+                model: "m".into(),
+                base_url: base_url.map(str::to_string),
+                ..Default::default()
+            },
+        );
+        reg
+    }
+
+    #[test]
+    fn provider_base_url_returns_the_gateway_endpoint_in_use() {
+        let reg = reg_with("anthropic", Some("http://127.0.0.1:8088"));
+        assert_eq!(
+            provider_base_url(&reg, "anthropic").as_deref(),
+            Some("http://127.0.0.1:8088")
+        );
+        // Untouched providers must not inherit it.
+        assert_eq!(provider_base_url(&reg, "openai"), None);
+    }
+
+    #[test]
+    fn provider_base_url_skips_entries_without_one() {
+        let mut reg = reg_with("anthropic", None);
+        reg.models.insert(
+            "anthropic_b".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "m2".into(),
+                base_url: Some("http://127.0.0.1:8088".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            provider_base_url(&reg, "anthropic").as_deref(),
+            Some("http://127.0.0.1:8088")
+        );
+    }
+
+    const BRIDGE: &str = "http://127.0.0.1:8088";
+
+    #[test]
+    fn oauth_token_against_the_vendor_host_is_explained_not_echoed() {
+        let msg = explain_oauth_misroute(
+            Some("sk-ant-oat03-EXAMPLE"),
+            "https://api.anthropic.com/v1",
+            BRIDGE,
+        );
+        assert!(msg.is_some_and(|m| m.contains(BRIDGE)));
+    }
+
+    #[test]
+    fn oauth_token_through_the_gateway_is_allowed() {
+        assert_eq!(
+            explain_oauth_misroute(Some("sk-ant-oat03-EXAMPLE"), BRIDGE, BRIDGE),
+            None
+        );
+    }
+
+    #[test]
+    fn plain_api_key_against_the_vendor_host_is_allowed() {
+        assert_eq!(
+            explain_oauth_misroute(
+                Some("sk-ant-api03-EXAMPLE"),
+                "https://api.anthropic.com/v1",
+                BRIDGE
+            ),
+            None
+        );
+        assert_eq!(
+            explain_oauth_misroute(None, "https://api.anthropic.com/v1", BRIDGE),
+            None
+        );
     }
 }

--- a/mur-hub-gui/ui/src/components/ModelLibraryPanels.tsx
+++ b/mur-hub-gui/ui/src/components/ModelLibraryPanels.tsx
@@ -6,12 +6,39 @@
  * exported so ModelLibrary.tsx can import them.
  */
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { ModelOption } from "./modelPicker";
 import { formatCost } from "./modelPicker";
 import { togglePick, type CloudPreset } from "./modelLibraryHelpers";
 import { useT } from "../i18n";
+
+/**
+ * Endpoint the backend suggests for `provider` before the user edits the
+ * field: an existing registry entry, else a live local OAuth bridge
+ * (mur-model-gateway). `null` until it answers, and for a provider with
+ * neither — callers fall back to the vendor default.
+ *
+ * A provider behind a gateway must not be discovered against the vendor host:
+ * its stored token is a gateway token and the vendor answers 401. Asking the
+ * backend keeps that precedence in one place (`suggest_base_url`).
+ */
+function useSuggestedBaseUrl(provider: string): string | null {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let live = true;
+    setUrl(null);
+    invoke<string | null>("suggested_base_url", { provider })
+      .then((u) => {
+        if (live) setUrl(u ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [provider]);
+  return url;
+}
 
 // ── Tauri command return types ─────────────────────────────────────────────
 
@@ -381,9 +408,11 @@ export function ConnectedPanel({
   const color = providerColor(providerKey);
 
   const provModels = registryModels.filter((m) => m.provider === providerKey);
-  const existingBaseUrl = "";
+  const suggested = useSuggestedBaseUrl(providerKey);
 
-  const [baseUrl, setBaseUrl] = useState(existingBaseUrl);
+  const [baseUrlEdit, setBaseUrlEdit] = useState<string | null>(null);
+  // The suggestion arrives async — read through to it until the user types.
+  const baseUrl = baseUrlEdit ?? suggested ?? "";
   const [discovered, setDiscovered] = useState<EnrichedModelView[]>([]);
   const [picks, setPicks] = useState<Set<string>>(new Set());
   const [testing, setTesting] = useState(false);
@@ -465,7 +494,7 @@ export function ConnectedPanel({
           type="url"
           value={baseUrl}
           placeholder="https://…"
-          onChange={(e) => setBaseUrl(e.target.value)}
+          onChange={(e) => setBaseUrlEdit(e.target.value)}
         />
         <div className="ml-hint">{t("lib.baseUrlHint")}</div>
       </div>
@@ -625,7 +654,12 @@ export function NewProviderPanel({
 }) {
   const provModels = registryModels.filter((m) => m.provider === preset.key);
   const { t } = useT();
-  const [baseUrl, setBaseUrl] = useState(preset.baseUrl);
+  const [baseUrlEdit, setBaseUrlEdit] = useState<string | null>(null);
+  // A gateway-backed provider must not be re-tested against the vendor host,
+  // so the endpoint already in use outranks the preset default. The suggestion
+  // arrives async — read through to it until the user types.
+  const suggested = useSuggestedBaseUrl(preset.key);
+  const baseUrl = baseUrlEdit ?? suggested ?? preset.baseUrl;
   const [apiKey, setApiKey] = useState("");
   const [secretKind, setSecretKind] = useState<SecretKind>("keychain");
   const [testing, setTesting] = useState(false);
@@ -641,7 +675,7 @@ export function NewProviderPanel({
   const prevKey = useRef(preset.key);
   if (prevKey.current !== preset.key) {
     prevKey.current = preset.key;
-    setBaseUrl(preset.baseUrl);
+    setBaseUrlEdit(null);
     setApiKey("");
     setSecretKind("keychain");
     setTesting(false);
@@ -724,7 +758,7 @@ export function NewProviderPanel({
           className="ml-input"
           type="url"
           value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
+          onChange={(e) => setBaseUrlEdit(e.target.value)}
         />
         <div className="ml-hint">{t("lib.baseUrlHint")}</div>
       </div>


### PR DESCRIPTION
## Problem

Model Library → Add Provider → Anthropic → **Test connection & explore** fails with

```
401 Unauthorized from https://api.anthropic.com/v1/models:
{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}
```

on a machine where `~/.mur/models.yaml` already points every Anthropic alias at a local
mur-model-gateway:

```yaml
claude_opus:
  provider: anthropic
  base_url: http://127.0.0.1:8088
  secret: file:/Users/…/.mur/secrets/anthropic.key
```

The Hub was sending the *gateway's* token to the *vendor's* host. Anthropic 401s, correctly.

## Three places the same fact disagreed

| Where | What it did |
|---|---|
| `NewProviderPanel` | seeded BASE URL from the preset (`https://api.anthropic.com/v1`), never looked at the registry |
| `test_provider` | resolved the provider's stored `SecretRef` but *not* its stored `base_url` — unlike `add_models` directly beside it |
| `ConnectedPanel` | passed `const existingBaseUrl = ""` → `undefined` into a required `String` Tauri arg |

## Fix

One precedence chain, server-side, in `suggest_base_url`:

1. an existing registry entry for that provider,
2. else the local OAuth bridge when `cc_proxy` is enabled *and* listening — Anthropic only, since that bridge exists to swap `x-api-key` for the Bearer + betas shape subscription tokens need,
3. else `None`, so the caller keeps the vendor's canonical host (the plain API-key path).

The UI reads it through a new `suggested_base_url` command instead of deriving it a second
time, with `baseUrlEdit ?? suggested ?? fallback` so the async answer can't clobber typing.
`test_provider`'s `base_url` is now `Option<String>`: an empty field means "whatever this
provider already uses", matching `add_models`.

Two cases that used to fail now work:

- **gateway installed, registry already configured** — discovery dials `127.0.0.1:8088`.
- **gateway installed, registry still empty** (the literal new-user report) — the TCP listening probe finds it.

And a subscription token aimed at the vendor host gets a sentence explaining the misroute
instead of the raw 401 body. The bridge URL in that message comes from `cfg.cc_proxy.url`,
not a literal.

## Not in scope

Making `sk-ant-oat…` work with **no** gateway would mean moving the Bearer + betas swap into
`mur-core/src/model_discovery.rs::auth_headers()` *and* `mur-agent-runtime/src/llm/anthropic.rs`
together — otherwise Test connection would pass while the agent 401s on its first message.
Separate PR.

## Verification

| Check | Result |
|---|---|
| `cargo test -p mur-hub-gui --lib models_admin` | 10 passed (5 new) |
| hub UI `vitest run` | 183 passed / 22 files |
| `tsc -b --force` | clean (negative control confirmed it read the edited file) |
| `eslint` on changed files | clean |
| `cargo fmt` | applied |

`cargo clippy --all-targets -D warnings` is red on this checkout with 3 pre-existing
`field_reassign_with_default` errors in `mur-hub-gui/src-tauri/src/model_switch.rs`
(lines 125/141/151) — a file this PR does not touch, and green in CI as recently as #909,
so it is local clippy-version skew, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)