### PR TITLE
fix(skills): mur-settlement shipped an unparseable procedure

### DIFF
--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1827,10 +1827,19 @@ mod sync_skill_tests {
         // A reporting rule has to be in context when the turn ends, so the
         // trigger is load-bearing: shipped with only `manual` it would never
         // fire and the skill would be dead weight nobody notices.
+        //
+        // Assert it through the parser, not on the raw text. A `contains`
+        // check passes on a file the loader rejects — which is exactly what
+        // happened while this skill shipped an unparseable `procedure: []`.
         let body = std::fs::read_to_string(&path).unwrap();
+        let m = mur_common::skill::parse_canonical(&body)
+            .unwrap_or_else(|e| panic!("mur-settlement must parse: {e}\n{body}"));
         assert!(
-            body.contains("session_start"),
-            "mur-settlement must load at session start, got: {body}"
+            m.triggers
+                .iter()
+                .any(|t| t.kind == mur_common::skill::types::TriggerKind::SessionStart),
+            "mur-settlement must load at session start, got: {:?}",
+            m.triggers
         );
     }
 
@@ -2066,6 +2075,36 @@ mod builtin_skill_tests {
                 "{name}: body {body_lines} lines (budget 150)"
             );
         }
+    }
+
+    /// Every built-in skill YAML must deserialize into a `SkillManifest`.
+    ///
+    /// The case list above — and the two other lists in this file — are
+    /// hand-maintained, so a skill is only covered if someone remembers to add
+    /// it. `mur_settlement.yaml` shipped a `procedure: []` (an empty sequence
+    /// where the schema wants a `Procedure` struct) and no test noticed: it was
+    /// in none of the lists, and its own test asserted on a raw substring
+    /// rather than parsing. `ensure_mur_skill` still wrote the file, so the
+    /// only symptom was a WARN during `mur sync` and the skill silently missing
+    /// from retrieval.
+    ///
+    /// Reading the directory instead of a literal list is what makes this
+    /// unmissable: a new skill is covered the moment it lands.
+    #[test]
+    fn every_builtin_skill_yaml_parses() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/skills");
+        let mut checked = 0;
+        for entry in std::fs::read_dir(&dir).expect("read src/skills") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&path).expect("read skill yaml");
+            mur_common::skill::parse_canonical(&raw)
+                .unwrap_or_else(|e| panic!("{} does not parse: {e}", path.display()));
+            checked += 1;
+        }
+        assert!(checked > 0, "no built-in skill YAML found in {dir:?}");
     }
 }
 

--- a/mur-core/src/skills/mur_settlement.yaml
+++ b/mur-core/src/skills/mur_settlement.yaml
@@ -63,7 +63,6 @@ content:
     "all done" above a card that says *output may be incomplete* is the single
     worst thing you can produce, because now the user cannot tell which half to
     believe.
-  procedure: []
 triggers:
   # session_start, not manual: a reporting rule is only useful if it is already
   # in context when the turn ends. A `manual` trigger would never fire and the


### PR DESCRIPTION
## Problem

Every `mur sync`, on every install:

```
WARN mur::retrieve::skill_candidates: parse skill.yaml failed
  path=~/.mur/skills/mur-settlement/skill.yaml
  error=yaml parse: content.procedure: invalid type: sequence,
        expected struct Procedure at line 66 column 14
```

`mur_settlement.yaml` had `procedure: []`. `content.procedure` is
`Option<Procedure>` — a struct with `steps`, not a sequence.

`ensure_mur_skill` wrote the file anyway, so nothing failed loudly: the skill
was just silently missing from retrieval while the WARN scrolled past on every
sync. A settlement/reporting rule that never loads is exactly the kind of
failure that hides in plain sight.

The field is optional and a reporting rule has no steps, so it is dropped
rather than filled in.

## Why no test caught it

Three tests cover built-in skills, and each hand-maintains its own
`include_str!` list:

| Test | Covers mur-settlement? |
|---|---|
| `new_builtin_skills_parse_and_respect_disclosure_budgets` | no |
| `dev_skill_keyword_triggers_compile` | no |
| `deep_research_skills_parse_scope_fleet_with_nonempty_procedure` | no |

And its own test was worse than not existing:

```rust
let body = std::fs::read_to_string(&path).unwrap();
assert!(body.contains("session_start"), ...);
```

That substring is still present in the broken file. The test was green the
entire time the skill was unloadable.

## Fix

- **`every_builtin_skill_yaml_parses`** — reads `src/skills/*.yaml` at test
  time and runs `parse_canonical` on each. A directory sweep requires nobody to
  remember anything: a new built-in skill is covered the moment it lands. All
  57 currently parse.
- The settlement test now parses and asserts on
  `TriggerKind::SessionStart`, not on raw text.

## Verification

Negative control, because a green run on its own proves nothing here:

| State | Result |
|---|---|
| `procedure: []` restored | `NEGCTL_EXIT=100` — both tests FAIL with `content.procedure: invalid type: sequence, expected struct Procedure at line 66 column 14` |
| `procedure: []` removed | 7/7 pass (`every_builtin_skill_yaml_parses`, the settlement test, and the three pre-existing list-based tests) |

Run as `cargo nextest run -p mur-core --lib` with `ORT_STRATEGY=download`,
`MUR_WEB_DIST`, `RUST_MIN_STACK=33554432`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)