### PR TITLE
fix(official): point users at `mur auth login`, not the removed `mur login`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ LanceDB vector index is always rebuildable via `mur internals reindex`.
   - Design, phase history, and the Spike-1 overlap decision: `docs/superpowers/specs/2026-06-19-mur-fleet-design.md`, `docs/superpowers/specs/2026-06-29-parallel-tracks-p3-concurrent-merge-design.md`, `docs/superpowers/validation/spike1-overlap-rate.md`.
 
 - `mur model {add|list|show|remove|migrate|prices|role}` — `~/.mur/models.yaml` provider/model registry. `add` accepts `--input-cost`/`--output-cost` (USD per 1k tokens) and auto-fills pricing + context window from the models.dev catalog unless `--no-fetch`; `prices {refresh|show}` manages the cached catalog (`~/.mur/cache/model-prices.json`). The Hub GUI **Model Library** (mur-hub-gui) connects cloud providers (key → Keychain) and auto-detects local runtimes, discovers models via `/v1/models`, and adds them as registry aliases. See `docs/superpowers/specs/2026-04-29-model-registry-and-secret-refs-design.md` and `2026-06-17-mur-model-library-design.md`.
-- `mur official {list|install <id>}` — browse and install official MUR agents/fleets from the app.mur.run catalog. Install requires `mur login`; pro-tier items require an active subscription. Downloads carry an account-bound `OfficialLicense` (stored in `~/.mur/licenses/`); the fleet/agent import paths refuse official-marked bundles without a matching license (anti-sharing gate; expiry gates downloads only, never installed content). See `docs/superpowers/specs/2026-07-20-official-catalog-design.md`.
+- `mur official {list|install <id>}` — browse and install official MUR agents/fleets from the app.mur.run catalog. Install requires `mur auth login`; pro-tier items require an active subscription. Downloads carry an account-bound `OfficialLicense` (stored in `~/.mur/licenses/`); the fleet/agent import paths refuse official-marked bundles without a matching license (anti-sharing gate; expiry gates downloads only, never installed content). See `docs/superpowers/specs/2026-07-20-official-catalog-design.md`.
 - `mur deep-research {setup|""} [question]` — simplified web research UX: `setup` (one-time wizard for model, workers, budget, egress), `""` (status panel), or ask a question (preflight start + guarded run). `provision`/`run` remain as the advanced flag-based path. Egress consent is explicit: `setup`/`provision --grant-egress` only.
 
 For detailed agent / companion / GUI export / runtime internals, read `docs/architecture/runtime-overview.md` only when the task requires it.
@@ -126,7 +126,7 @@ Before changing anything that pins, verifies, or launches an MCP server, read `d
 - `Pattern` implements `Deref<Target = KnowledgeBase>` — access fields directly
 - YAML writes use temp file + rename for atomicity (`store/yaml.rs`)
 - `tracing` for structured logging; enable with `RUST_LOG=debug`
-- Plans live in `plans/` and `docs/superpowers/plans/`. OpenSpec change specs in `openspec/changes/`.
+- Plans live in `docs/superpowers/plans/`. OpenSpec change specs in `openspec/changes/`.
 - **Unified Channel v3a–v3d** implemented on branch `feat/unified-channel-v3b` (v3d on `feat/unified-channel-v3d`):
   - v3a: DAG executor emits attributed `StateChange`/`ToolCall`/`ToolResult` events as `ChannelActor::System`.
   - v3b: Deterministic `idem_key`, `run_id` per workflow run.

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -1257,7 +1257,7 @@ pub enum ProjectAction {
 pub enum OfficialAction {
     /// List official agents and fleets from app.mur.run
     List,
-    /// Download, verify, and install an official item (requires `mur login`)
+    /// Download, verify, and install an official item (requires `mur auth login`)
     Install {
         /// Catalog id, e.g. agents/researcher or fleets/deep-research
         id: String,

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -124,7 +124,7 @@ fn official_gate_agent(
     }
     let Some(user) = logged_in_user else {
         bail!(
-            "this is official MUR content — log in (`mur login`) and get it from app.mur.run via `mur official install`"
+            "this is official MUR content — log in (`mur auth login`) and get it from app.mur.run via `mur official install`"
         );
     };
     let item = format!("agents/{agent_slug}");

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -147,7 +147,7 @@ fn official_gate(
     }
     let Some(user) = logged_in_user else {
         bail!(
-            "this is official MUR content — log in (`mur login`) and get it from app.mur.run via `mur official install`"
+            "this is official MUR content — log in (`mur auth login`) and get it from app.mur.run via `mur official install`"
         );
     };
     let item = format!("fleets/{}", manifest.fleet_name);

--- a/mur-core/src/cmd/official.rs
+++ b/mur-core/src/cmd/official.rs
@@ -19,7 +19,9 @@ pub(crate) async fn cmd_official_list() -> Result<()> {
         );
     }
     if crate::auth::load_tokens().is_none() {
-        println!("\nLog in with `mur login` to install (pro items need a MUR Pro subscription).");
+        println!(
+            "\nLog in with `mur auth login` to install (pro items need a MUR Pro subscription)."
+        );
     }
     Ok(())
 }

--- a/mur-core/src/official/client.rs
+++ b/mur-core/src/official/client.rs
@@ -84,7 +84,7 @@ pub async fn download_item(
         .context("download item")?;
     match resp.status().as_u16() {
         200 => {}
-        401 => bail!("not authorized — log in again (`mur login`)"),
+        401 => bail!("not authorized — log in again (`mur auth login`)"),
         402 | 403 => {
             bail!("'{id}' requires an active MUR Pro subscription — manage at app.mur.run")
         }

--- a/mur-core/src/official/install.rs
+++ b/mur-core/src/official/install.rs
@@ -17,11 +17,12 @@ use crate::official::store::save_license;
 /// Download and install `id` (`agents/<name>` or `fleets/<name>`).
 pub async fn install_item(id: &str) -> Result<()> {
     // 1. Identity first — everything downstream binds to it.
-    let tokens = crate::auth::load_tokens().context("not logged in — run `mur login` first")?;
+    let tokens =
+        crate::auth::load_tokens().context("not logged in — run `mur auth login` first")?;
     let user_id = tokens
         .user_id
         .clone()
-        .context("stored login has no account id — run `mur auth logout` then `mur login`")?;
+        .context("stored login has no account id — run `mur auth logout` then `mur auth login`")?;
 
     // 2. Download bundle + license.
     let base = crate::auth::server_url();

--- a/mur-core/src/skills/mur_official.yaml
+++ b/mur-core/src/skills/mur_official.yaml
@@ -8,7 +8,7 @@ content:
   abstract: |
     `mur official list` browses the app.mur.run catalog;
     `mur official install <id>` downloads, verifies, and installs an
-    official agent or fleet. Install requires `mur login`; pro-tier
+    official agent or fleet. Install requires `mur auth login`; pro-tier
     items need an active subscription.
   context: |
     # mur-official — the official catalog


### PR DESCRIPTION
## What

`mur login` has not existed since the 2026-05-31 CLI reorganization moved it to
`mur auth login` ([mapping table](https://github.com/mur-run/mur/blob/main/docs/superpowers/specs/2026-05-31-cli-reorganization-design.md#L71)).
Eight call sites kept the old name, and every one of them is a string the user reads:

| Site | What the user sees it as |
| --- | --- |
| `official/client.rs:87` | the 401 recovery hint |
| `official/install.rs:20,24` | not-logged-in / missing-account-id contexts |
| `cmd/official.rs:22` | the footer under `mur official list` |
| `cmd/agent/install.rs:127` | official-content import refusal |
| `cmd/fleet/import.rs:150` | official-content import refusal |
| `cli/actions.rs:1260` | `--help` for `mur official install` |
| `skills/mur_official.yaml:11` | the built-in skill — teaches the wrong command to every agent |

The failure mode is a closed loop: the download 401s, MUR tells you to run
`mur login`, and you get

```
error: unrecognized subcommand 'login'
```

with no hint that `auth` is the missing word. The skill entry is the worse half —
it ships the dead command into agent context on every sync.

## Also

`mur verify --file CLAUDE.md` flagged two stale claims; both are fixed here:

- the same `mur login`
- `Plans live in \`plans/\` and \`docs/superpowers/plans/\`` — `plans/` does not
  exist in the tree

CLAUDE.md now verifies clean: `Total: 73  Valid: 65  Invalid: 0  Skipped: 8`.

## Test

Text-only; no behavior change. `every_builtin_skill_yaml_parses` (added in #913)
covers the edited skill manifest:

```
PASS [0.037s] mur-core cmd::sync_cmd::builtin_skill_tests::every_builtin_skill_yaml_parses
```

plus the 25 `builtin_skill` / `official` tests, all green, and `cargo fmt --check` clean.

Out of scope: `docs/superpowers/specs/**` still says `mur login` in places, but
those are dated design records and should keep saying what was true when written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)