### PR TITLE
fix(release): checksum the macOS installers, and match the entries we publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,11 +507,27 @@ jobs:
           merge-multiple: true
 
       - name: Create checksums
-        # No `|| true`: a release page with an empty checksums.txt is a
-        # silent failure — if the artifact globs come up empty, fail here.
+        # Hash every published *binary* artifact, `.pkg`/`.dmg` included: they
+        # were uploaded but never listed, so the two macOS installers were the
+        # only downloads a user could not verify. `.sig`/`latest.json` stay out
+        # — they are the Tauri updater's own signed chain, checked against its
+        # embedded pubkey rather than against this file.
+        #
+        # nullglob because this job publishes even when `package-macos` /
+        # `hub-macos` fail (see `if:` above), so the macOS globs may legitimately
+        # match nothing. An entirely empty set still fails: a release page with
+        # an empty checksums.txt is a silent failure.
+        shell: bash
         run: |
-          sha256sum ./*.tar.gz ./*.zip > checksums.txt
+          shopt -s nullglob
+          artifacts=( ./*.tar.gz ./*.zip ./*.pkg ./*.dmg )
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "::error::no release artifacts to checksum"
+            exit 1
+          fi
+          sha256sum "${artifacts[@]}" > checksums.txt
           test -s checksums.txt
+          cat checksums.txt
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2

--- a/mur-core/src/update/release.rs
+++ b/mur-core/src/update/release.rs
@@ -245,7 +245,13 @@ pub fn checksum_for(checksums_txt: &str, filename: &str) -> Option<String> {
         }
         let mut parts = line.splitn(2, char::is_whitespace);
         let hex = parts.next()?.trim();
-        let rest = parts.next()?.trim_start_matches('*').trim();
+        // Two markers to shed: `sha256sum -b` writes `*<file>`, and the release
+        // job hashes `./*.tar.gz` so every published entry carries a `./` while
+        // callers pass a bare asset name (#906 fixed the same skew in the shell
+        // installers, but not here). Strip the prefix only — a suffix match
+        // would let `./evil/mur.zip` answer for `mur.zip`.
+        let rest = parts.next()?.trim().trim_start_matches('*');
+        let rest = rest.strip_prefix("./").unwrap_or(rest);
         if rest == filename {
             return Some(hex.to_string());
         }
@@ -285,6 +291,40 @@ mod checksum_tests {
     fn returns_none_when_missing() {
         let txt = "deadbeef *mur.zip\n";
         assert!(checksum_for(txt, "other.tar.gz").is_none());
+    }
+
+    /// The release job runs `sha256sum ./*.tar.gz ...`, so every published
+    /// entry carries a `./` prefix while `asset_name_for_host` yields a bare
+    /// name. Verbatim from the v2.68.2 release; an exact-match lookup misses
+    /// it and `mur update` aborts with "no checksum entry".
+    #[test]
+    fn matches_dot_slash_prefixed_entries_from_the_real_release() {
+        let txt = "\
+cddbd2918f3cde9e14f8e3977250d33563ea6e4f554babfa184f71b50b8f0d19  ./MUR-Hub.app.tar.gz
+df1570333a6df897ce074112c2185f0bc2d1d5e588ffc975fc0b09e2191b28f9  ./mur-aarch64-apple-darwin.tar.gz
+5641a2c0b21e93380ddbd3f33709d9ef0c0eb06b478b7a7ccb5dc1f89fceb473  ./mur-x86_64-unknown-linux-gnu.tar.gz
+6df9822b5e91e8d6794b6982ac5039640270058b70b6eb87d551691814518784  ./mur-x86_64-pc-windows-msvc.zip
+";
+        for (name, want) in [
+            (
+                "mur-aarch64-apple-darwin.tar.gz",
+                "df1570333a6df897ce074112c2185f0bc2d1d5e588ffc975fc0b09e2191b28f9",
+            ),
+            (
+                "mur-x86_64-pc-windows-msvc.zip",
+                "6df9822b5e91e8d6794b6982ac5039640270058b70b6eb87d551691814518784",
+            ),
+        ] {
+            assert_eq!(checksum_for(txt, name).as_deref(), Some(want), "{name}");
+        }
+    }
+
+    /// Normalization strips a leading `./`, not a directory: a suffix match
+    /// would let `./evil/mur.zip` answer for `mur.zip`.
+    #[test]
+    fn does_not_match_a_same_named_file_in_a_subdirectory() {
+        let txt = "deadbeef  ./nested/mur.zip\n";
+        assert!(checksum_for(txt, "mur.zip").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Two halves of the same skew between what `checksums.txt` says and what it should.

## 1. The `.pkg` and `.dmg` were never in it

The release job uploads `*.tar.gz`, `*.zip`, `*.pkg`, `*.dmg` — and hashed only
the first two. The published v2.68.2 manifest, verbatim:

```
cddbd291…  ./MUR-Hub.app.tar.gz
df157033…  ./mur-aarch64-apple-darwin.tar.gz
5641a2c0…  ./mur-x86_64-unknown-linux-gnu.tar.gz
6df9822b…  ./mur-x86_64-pc-windows-msvc.zip
```

`mur-aarch64-apple-darwin.dmg`, `mur-aarch64-apple-darwin.pkg` and
`MUR-Hub-aarch64-apple-darwin.dmg` are all absent — the downloads a user is most
likely to double-click were the ones they could not verify.

`.sig` / `latest.json` stay out on purpose: they are the Tauri updater's own
signed chain, checked against its embedded pubkey rather than against this file.

**`nullglob` is load-bearing.** This job publishes even when `package-macos` /
`hub-macos` fail (`if: always() && contains(needs.build.result, 'success')`).
Without it, a failed Hub build leaves `./*.dmg` unexpanded, `sha256sum` errors,
and a Hub-only failure takes the whole CLI release down with it. An entirely
empty set still fails, same as the old `test -s`.

Ran the actual step script against three artifact sets:

| scenario | entries | exit |
| --- | --- | --- |
| full release (+ `.sig`, `latest.json` present) | 7 — both DMGs and the PKG in, sig/json out | 0 |
| `package-macos` + `hub-macos` failed | 3 | 0 |
| nothing built | 0 | 1, `::error::no release artifacts to checksum` |

## 2. `mur update` could not read the entries either

`checksum_for` compared `rest == filename`. The job hashes `./*.tar.gz`, so
lines read `<hex>  ./mur-aarch64-apple-darwin.tar.gz` while
`asset_name_for_host()` returns the bare name. Every lookup missed:

```
no checksum entry for mur-aarch64-apple-darwin.tar.gz
```

This went unnoticed because Homebrew and cargo installs never reach it — `run()`
shells out to the package manager and returns. It fails only for
`InstallSource::Other`: the `curl -fsSL https://mur.run/install.sh | sh` users.
#906 fixed this exact skew in `scripts/install.sh` / `install.ps1` and stopped
at the shell.

Strips the `./` prefix, not a directory. A suffix match would let
`./evil/mur.zip` answer for `mur.zip`; there is a test pinning that.

## Test

The new parse test uses the four verbatim lines above. Negative control — before
the fix:

```
FAIL update::release::checksum_tests::matches_dot_slash_prefixed_entries_from_the_real_release
assertion `left == right` failed: mur-aarch64-apple-darwin.tar.gz
  left: None
 right: Some("df1570333a6df897ce074112c2185f0bc2d1d5e588ffc975fc0b09e2191b28f9")
```

After: `39 tests run: 39 passed` across `update::`.

## Note

The producer keeps emitting `./`-prefixed names. Changing that would be cosmetic
here but the installer served to users is maintained in the website repo, which
I can't see from this one — it may well match on the prefix. Fixing the consumer
covers both old and new releases either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)