### PR TITLE
fix(hub): show agents the Hub did not start itself

### DIFF
--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -110,7 +110,13 @@ async fn os_actor(
     // Agents this Hub spawned and supervises directly. The Hub owns each
     // child's lifetime, so there is exactly one runtime per agent.
     let mut children: HashMap<String, Child> = HashMap::new();
-    let mut known: HashSet<String> = HashSet::new();
+    // Runtimes already alive when this Hub session started — from the CLI, from
+    // `mur agent install-service`, or from a previous Hub — belong in the
+    // tracked set too. Without this seed the set only ever holds agents *this*
+    // session started, so `emit_status`'s lock check (which exists precisely to
+    // recognise foreign runtimes) is never asked about them and the Agents page
+    // renders every one of them idle while they are plainly running.
+    let mut known: HashSet<String> = adopt_live_runtimes(&mur_home);
     let mut poll_interval = tokio::time::interval(Duration::from_secs(5));
     poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -157,6 +163,10 @@ async fn os_actor(
             }
 
             _ = poll_interval.tick() => {
+                // Re-adopt on every tick, not just at startup: an agent can be
+                // started from the CLI while the Hub is open, and it would
+                // otherwise stay invisible until the next Hub restart.
+                known.extend(adopt_live_runtimes(&mur_home));
                 if !known.is_empty() {
                     emit_status(&known, &mur_home, &mut children, &status_tx);
                 }
@@ -282,6 +292,21 @@ fn lock_owner_pid(mur_home: &Path, slug: &str) -> Option<u32> {
         Ok(Some(l)) if mur_common::lock_file::pid_alive(l.pid) => Some(l.pid),
         _ => None,
     }
+}
+
+/// Every agent holding a live `running.lock` right now, including runtimes this
+/// Hub never spawned. Cheap enough for the 5-second poll: one `read_dir` plus a
+/// small JSON read and a `kill(0)` per agent directory.
+fn adopt_live_runtimes(mur_home: &Path) -> HashSet<String> {
+    let Ok(entries) = std::fs::read_dir(mur_home.join("agents")) else {
+        return HashSet::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|slug| lock_is_live(mur_home, slug))
+        .collect()
 }
 
 /// Stop whatever process owns `slug`'s lock, when it is not one of our own
@@ -446,6 +471,30 @@ mod tests {
         let pid = c.id();
         let _ = c.wait();
         pid
+    }
+
+    /// A runtime the Hub did not spawn (CLI, launchd, an earlier Hub) has to
+    /// land in the tracked set, or the Agents page reports it idle while it is
+    /// plainly running — which is what every agent looked like after a Hub
+    /// restart, because the set started empty and only `Start` ever filled it.
+    #[test]
+    fn adopt_live_runtimes_finds_foreign_runtimes_and_ignores_the_rest() {
+        let tmp = tempfile::tempdir().unwrap();
+        seed_runtime_state(tmp.path(), "alive", std::process::id());
+        seed_runtime_state(tmp.path(), "exited", dead_pid());
+        std::fs::create_dir_all(tmp.path().join("agents").join("never-started")).unwrap();
+
+        assert_eq!(
+            adopt_live_runtimes(tmp.path()),
+            HashSet::from(["alive".to_string()])
+        );
+    }
+
+    /// No `~/.mur/agents` yet (fresh install) must not panic the supervisor.
+    #[test]
+    fn adopt_live_runtimes_on_a_missing_agents_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(adopt_live_runtimes(tmp.path()).is_empty());
     }
 
     /// Deleting `running.sentinel` under a live owner destroys the flock that

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -66,6 +66,18 @@ fn list_agents(state: State<'_, AgentState>) -> Vec<AgentEntry> {
     state.0.lock().unwrap().clone()
 }
 
+/// The runtime snapshot as it stands right now.
+///
+/// `runtime-status-changed` only fires when the value *changes*, so a UI that
+/// mounts after the supervisor has settled sees nothing and renders every agent
+/// idle. `list_agents` above has always had this invoke-once-then-listen pair;
+/// runtime status was listen-only, which is what left the Agents page showing a
+/// resting flock while the agents were up.
+#[tauri::command]
+fn list_runtime_statuses(supervisor: State<'_, SupervisorState>) -> Vec<AgentRuntimeStatus> {
+    supervisor.0.status_receiver().borrow().clone()
+}
+
 #[tauri::command]
 async fn start_agent(name: String, supervisor: State<'_, SupervisorState>) -> Result<(), String> {
     supervisor.0.start(&name).await
@@ -588,6 +600,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             list_agents,
+            list_runtime_statuses,
             panel::panel_sessions,
             panel::panel_insert,
             panel::open_panel_window,

--- a/mur-hub-gui/ui/src/context/AgentContext.tsx
+++ b/mur-hub-gui/ui/src/context/AgentContext.tsx
@@ -61,6 +61,14 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
       .then((agents) => dispatch({ type: "set_agents", agents }))
       .catch(console.error);
 
+    // Pair the listener below with a one-shot read, the same way `list_agents`
+    // does. `runtime-status-changed` only fires on change, so without this the
+    // map stays empty until an agent starts or stops and every already-running
+    // agent renders idle.
+    invoke<AgentRuntimeStatus[]>("list_runtime_statuses")
+      .then((statuses) => dispatch({ type: "set_runtime", statuses }))
+      .catch(console.error);
+
     const unAgents = listen<AgentEntry[]>("agents-updated", (e) =>
       dispatch({ type: "set_agents", agents: e.payload }),
     );


### PR DESCRIPTION
## Symptom

The Agents page reported **1 flying, 26 resting** with 27 agents up and answering `message/send`. Every card showed `idle` behind a ▶ button. The one agent shown running was the concierge — the one agent the Hub starts for itself.

The ▶ buttons were the practical hazard: pressing one targets a runtime that is already up, which collides on the agent socket.

## Cause

`emit_status` builds its snapshot by iterating `known`, and `known`:

- starts empty every session (`sidecar.rs:113`)
- is only ever filled by `Msg::Start` (`:131`)

So the lock check inside it — `child_alive || lock_is_live(...)` (`:181`) — was never asked about any agent the Hub did not start. That check exists *precisely* to recognise foreign runtimes; its own doc comment names "one started from the CLI". The intent was there, the domain never reached it.

The 5-second poll could not rescue it either: gated on `!known.is_empty()` and iterating the same set.

The UI half is a matching asymmetry. `list_agents` has always been invoke-once-then-listen; runtime status was **listen-only**, against an event that fires on *change*. There was no command to read the current value, so a UI mounting after the supervisor settled kept an empty map.

## Fix

- **`adopt_live_runtimes()`** — the agents holding a live `running.lock` right now. Seeds `known` at startup, and re-adopts on **every poll tick**: an agent started from the CLI while the Hub is open was just as invisible as one started before launch, and seeding alone would only have fixed the second case.
- **`list_runtime_statuses`** command + a one-shot read on mount, pairing the listener the way `list_agents` already does.

## Verification

Built the `.app` and looked at it, because the symptom is visual:

| | before | after |
|---|---|---|
| counter | 1 FLYING / 26 RESTING | **27 FLYING / 0 RESTING** |
| cards | all `idle`, ▶ | all `running`, ■ |
| Home "Now running" | MUR only | all 27, green |

- `cargo test -p mur-gui-core sidecar` → 9/9, two new: a live foreign lock, a dead one, an agent dir with no lock, and a missing `agents/` dir
- `cargo clippy --all-targets -D warnings` on `mur-gui-core` and on the Hub lib; `cargo fmt --check`; `tsc -b`; `eslint`

## Not in this PR

`RuntimeState::Running { pid: 0 }` — the Hub never carries a real pid on this path. `lock_owner_pid` already computes one; surfacing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)