### PR TITLE
fix(agent): stop/remove respect the service supervisor; name a corrupted skill ref for what it is

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -663,6 +663,12 @@ pub(crate) async fn prepare_runtime(
                 "profile.yaml references a skill whose file exists but no longer parses \
                  as a valid skill; re-install or remove it"
             ),
+            SkillRefStatus::CorruptRef { reason } => tracing::warn!(
+                skill_ref = %r,
+                reason = %reason,
+                "profile.yaml holds a corrupted skill ref; the skills it names may well be \
+                 installed — installing anything will not help"
+            ),
         }
     }
     let loaded: Vec<_> = loaded

--- a/mur-common/src/skill/loader.rs
+++ b/mur-common/src/skill/loader.rs
@@ -48,6 +48,17 @@ pub enum SkillRefStatus {
         path: std::path::PathBuf,
         error: String,
     },
+    /// The ref itself cannot name a file — it holds whitespace, which a skill
+    /// id never does. Seen in the wild as several refs concatenated into one
+    /// `profile.yaml` list item (`skills/a - skills/b - skills/b`), growing by
+    /// a segment each time something appended to the string instead of pushing
+    /// a new item.
+    ///
+    /// Separate from `Missing` for the same reason `Missing` is separate from
+    /// `Malformed`: the advice differs. Nothing is missing here — the backing
+    /// skills are installed — so "install it" sends people to run a command
+    /// that cannot help. The entry has to be split or removed.
+    CorruptRef { reason: String },
 }
 
 /// Resolve a `profile.yaml` skill ref to its backing manifest file and report
@@ -74,6 +85,16 @@ pub fn skill_ref_status(agent_home: &Path, rel_ref: &str) -> SkillRefStatus {
         joined
     };
     if !file.is_file() {
+        // Only reclassify once resolution has already failed, and only when the
+        // ref holds whitespace. Anything that resolves today keeps resolving —
+        // this can never turn a working ref into an error.
+        if rel_ref.split_whitespace().count() > 1 {
+            return SkillRefStatus::CorruptRef {
+                reason: "a skill ref cannot contain whitespace; this entry looks like several \
+                         refs concatenated — split it into separate list items, or remove it"
+                    .to_string(),
+            };
+        }
         return SkillRefStatus::Missing { path: file };
     }
     let text = match std::fs::read_to_string(&file) {
@@ -473,6 +494,33 @@ content:
             }
             other => panic!("expected Missing, got {other:?}"),
         }
+    }
+
+    /// Observed on a live concierge: one `profile.yaml` item holding ten refs
+    /// run together, growing by a segment every time something appended to the
+    /// string instead of pushing a new item. Reported as `missing`, which sent
+    /// the user to install skills that were already installed.
+    #[test]
+    fn skill_ref_status_concatenated_refs_are_corrupt_not_missing() {
+        let home = tempdir().unwrap();
+        let ref_ = "skills/pm-spec-handoff - skills/brainstorming - skills/brainstorming";
+        match skill_ref_status(home.path(), ref_) {
+            SkillRefStatus::CorruptRef { reason } => {
+                assert!(reason.contains("whitespace"), "unhelpful reason: {reason}");
+            }
+            other => panic!("expected CorruptRef, got {other:?}"),
+        }
+    }
+
+    /// The regression that matters most: a plain uninstalled ref must keep
+    /// reporting `Missing`, because there "install it" is the right advice.
+    #[test]
+    fn skill_ref_status_plain_absent_ref_stays_missing() {
+        let home = tempdir().unwrap();
+        assert!(matches!(
+            skill_ref_status(home.path(), "skills/never-installed"),
+            SkillRefStatus::Missing { .. }
+        ));
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -752,6 +752,12 @@ pub fn cmd_stop(name: &str) -> Result<()> {
             .unwrap_or(15)
     };
 
+    // Take the agent out of its supervisor's hands before signalling it.
+    // launchd/systemd restart the runtime the instant it dies (every service
+    // `mur agent install-service` writes sets KeepAlive), so signalling alone
+    // cannot stop a service-managed agent — it only swaps the pid.
+    let had_service = super::service::stop_service(name);
+
     #[cfg(unix)]
     unsafe {
         libc::kill(lock.pid as libc::pid_t, libc::SIGTERM);
@@ -775,8 +781,52 @@ pub fn cmd_stop(name: &str) -> Result<()> {
     // Supervisor normally removes the lock, but after SIGKILL nothing will —
     // or our sleep-fixture has no lock cleanup — so best-effort remove here.
     let _ = fs::remove_file(&lock_path);
-    println!("Stopped agent '{name}'");
+
+    // Confirm, don't assert. Signalling the pid is not the same as the agent
+    // being down: a launchd job with KeepAlive (every service `mur agent
+    // install-service` writes) hands back a fresh pid within a second, and the
+    // old code printed "Stopped agent" regardless — so the arrow read
+    // 17402 → 17597 while the message said success.
+    //
+    // `stop_service` above removes that race for our own services. This loop
+    // catches whatever else might be respawning it, and says so instead of
+    // lying.
+    if let Some(pid) = wait_for_no_live_lock(&lock_path) {
+        bail!(
+            "signalled '{name}' but it is running again as pid {pid} — something is respawning it.{}",
+            if had_service {
+                ""
+            } else {
+                " No mur service is installed for it; check for another supervisor."
+            }
+        );
+    }
+    if had_service {
+        println!("Stopped agent '{name}' and unloaded its service");
+    } else {
+        println!("Stopped agent '{name}'");
+    }
     Ok(())
+}
+
+/// Poll briefly for a *live* `running.lock` to reappear, returning the pid that
+/// holds it. A supervisor that restarts the runtime needs a moment to do it, so
+/// checking once immediately after the kill would always look clean.
+fn wait_for_no_live_lock(lock_path: &Path) -> Option<u32> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let mut seen = None;
+    while std::time::Instant::now() < deadline {
+        seen = fs::read(lock_path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<LockFile>(&b).ok())
+            .filter(|l| pid_alive(l.pid))
+            .map(|l| l.pid);
+        if seen.is_some() {
+            return seen;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+    seen
 }
 
 pub fn cmd_remove(name: &str, purge: bool, force: bool) -> Result<()> {
@@ -800,6 +850,13 @@ pub fn cmd_remove(name: &str, purge: bool, force: bool) -> Result<()> {
     let symlink = bin_dir.join(format!("mur_agent_{name}"));
     if symlink.symlink_metadata().is_ok() {
         fs::remove_file(&symlink).ok();
+    }
+
+    // The symlink above is what the service execs, so leaving the descriptor
+    // behind leaves the supervisor retrying a path that no longer exists — and
+    // loading it again at the next login. Remove goes with it.
+    if let Some(path) = super::service::remove_service(name) {
+        println!("Removed service {}", path.display());
     }
 
     if purge {

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -1,11 +1,109 @@
-//! `mur agent install-service` — generate launchd / systemd unit files.
+//! `mur agent install-service` — generate launchd / systemd unit files, and
+//! the stop/remove half that keeps the supervisor in step with the CLI.
+//!
+//! Everything that locates a descriptor goes through [`service_file_in`]. When
+//! install wrote one path and stop looked at another, stop silently did
+//! nothing and still reported success — so the path has exactly one source.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow, bail};
 
 use super::{resolve_bin_dir, resolve_mur_home, write_atomic};
+
+/// The service descriptor's path for `name`, under `base`.
+///
+/// `base` is the home dir on macOS (`~/Library/LaunchAgents/...`) and the
+/// config dir on Linux (`$XDG_CONFIG_HOME/systemd/user/...`), matching what
+/// [`cmd_install_service`] writes.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub(super) fn service_file_in(base: &Path, name: &str) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        base.join(format!("Library/LaunchAgents/run.mur.agent.{name}.plist"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        base.join(format!("systemd/user/mur-agent-{name}.service"))
+    }
+}
+
+/// The installed service descriptor for `name`, if this platform has services
+/// and one is actually on disk.
+pub(super) fn installed_service(name: &str) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    let base = dirs::home_dir()?;
+    #[cfg(target_os = "linux")]
+    let base = dirs::config_dir()?;
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = name;
+        return None;
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let path = service_file_in(&base, name);
+        path.exists().then_some(path)
+    }
+}
+
+/// Tell the service manager to stop supervising `name`, so it stops respawning
+/// the runtime the moment we signal it. Returns whether a service existed.
+///
+/// Nothing here trusts the exit status: `launchctl bootout` reports failure
+/// when the job simply is not loaded, which is the state we want anyway. The
+/// caller confirms the outcome by looking for a live lock afterwards.
+pub(super) fn stop_service(name: &str) -> bool {
+    let Some(path) = installed_service(name) else {
+        return false;
+    };
+    let _ = path;
+    #[cfg(target_os = "macos")]
+    {
+        let uid = unsafe { libc::getuid() };
+        let _ = std::process::Command::new("launchctl")
+            .args(["bootout", &format!("gui/{uid}/run.mur.agent.{name}")])
+            .output();
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "stop", &format!("mur-agent-{name}.service")])
+            .output();
+    }
+    true
+}
+
+/// Stop the service and delete its descriptor. Returns the path removed.
+///
+/// Without this, `mur agent remove` left the descriptor on disk and loaded:
+/// the supervisor kept trying to exec the `mur_agent_<name>` symlink that
+/// remove had just deleted, and reloaded it again at the next login.
+pub(super) fn remove_service(name: &str) -> Option<PathBuf> {
+    let path = installed_service(name)?;
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "disable", "--now"])
+            .arg(format!("mur-agent-{name}.service"))
+            .output();
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        stop_service(name);
+    }
+    if fs::remove_file(&path).is_err() {
+        return None;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .status();
+    }
+    Some(path)
+}
 
 pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
     // Confirm the agent exists so we fail fast on typos.
@@ -23,9 +121,10 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
             print!("{plist}");
             return Ok(());
         }
-        let dest = dirs::home_dir()
-            .ok_or_else(|| anyhow!("no home dir"))?
-            .join(format!("Library/LaunchAgents/run.mur.agent.{name}.plist"));
+        let dest = service_file_in(
+            &dirs::home_dir().ok_or_else(|| anyhow!("no home dir"))?,
+            name,
+        );
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -51,9 +150,10 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
             print!("{unit}");
             return Ok(());
         }
-        let dest = dirs::config_dir()
-            .ok_or_else(|| anyhow!("no config dir"))?
-            .join(format!("systemd/user/mur-agent-{name}.service"));
+        let dest = service_file_in(
+            &dirs::config_dir().ok_or_else(|| anyhow!("no config dir"))?,
+            name,
+        );
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -194,5 +294,34 @@ mod tests {
         for dir in LAUNCHD_DEFAULT_PATH_DIRS {
             assert!(path.contains(dir), "missing {dir} in {path}");
         }
+    }
+
+    /// The label `stop_service` boots out is derived separately from the path
+    /// the descriptor lives at, so this pins the pair against the plist that
+    /// `darwin_plist` actually writes. If they ever drift, stop would boot out
+    /// a label nothing runs under and still report success — the exact shape of
+    /// the bug this whole change exists to fix.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn stop_boots_out_the_label_the_installed_plist_declares() {
+        let path = service_file_in(Path::new("/Users/x"), "kelp");
+        assert_eq!(
+            path,
+            Path::new("/Users/x/Library/LaunchAgents/run.mur.agent.kelp.plist")
+        );
+
+        let plist = darwin_plist("kelp", Path::new("/bin/mur_agent_kelp"), "/usr/bin");
+        assert!(
+            plist.contains("<string>run.mur.agent.kelp</string>"),
+            "stop_service boots out gui/<uid>/run.mur.agent.kelp; the plist must declare that label"
+        );
+    }
+
+    /// An agent that never had a service must not turn `remove` into an error,
+    /// and must not make `stop` claim it unloaded something.
+    #[test]
+    fn no_installed_service_is_not_an_error() {
+        assert!(!stop_service("definitely-not-an-agent-abc123"));
+        assert!(remove_service("definitely-not-an-agent-abc123").is_none());
     }
 }

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -57,6 +57,7 @@ pub fn validate_skill_refs(agent_home: &Path, refs: &[String]) -> Result<()> {
                 "{r}: {} exists but does not load as a skill ({error})",
                 path.display()
             )),
+            SkillRefStatus::CorruptRef { reason } => Some(format!("{r}: corrupted ref — {reason}")),
         })
         .collect();
     if bad.is_empty() {

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -98,13 +98,17 @@ pub struct SkillView {
 
 /// UI-facing skill-ref status. `Missing` = the resolved manifest file does
 /// not exist (profile.yaml references a skill that was never installed);
-/// `Malformed` = the file exists but no longer parses/validates.
+/// `Malformed` = the file exists but no longer parses/validates; `Corrupt` =
+/// the ref itself is not a usable path (several refs concatenated into one
+/// entry), so the skills it names may be installed and "install it" is the
+/// wrong advice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SkillRefStatusView {
     Ok,
     Missing,
     Malformed,
+    Corrupt,
 }
 
 /// Classify a legacy per-agent skill path via the shared resolver the runtime
@@ -117,6 +121,7 @@ fn skill_ref_view(agent_home: &std::path::Path, rel_path: &str) -> SkillRefStatu
         SkillRefStatus::Loadable => SkillRefStatusView::Ok,
         SkillRefStatus::Missing { .. } => SkillRefStatusView::Missing,
         SkillRefStatus::Malformed { .. } => SkillRefStatusView::Malformed,
+        SkillRefStatus::CorruptRef { .. } => SkillRefStatusView::Corrupt,
     }
 }
 

--- a/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
@@ -244,9 +244,11 @@ export function SkillsTab({
                   <span className={s.loadable ? "badge-loadable" : "badge-dead"}>
                     {s.loadable
                       ? t("detail.skillLoadable")
-                      : s.status === "missing"
-                        ? t("detail.skillMissing")
-                        : t("detail.skillDead")}
+                      : s.status === "corrupt"
+                        ? t("detail.skillCorrupt")
+                        : s.status === "missing"
+                          ? t("detail.skillMissing")
+                          : t("detail.skillDead")}
                   </span>
                   {s.loadable && (
                     <button
@@ -262,9 +264,11 @@ export function SkillsTab({
                 </div>
                 {!s.loadable && (
                   <div className="item-card-desc field-muted" style={{ fontSize: 11 }}>
-                    {s.status === "missing"
-                      ? t("detail.skillMissingHint", { path: s.path })
-                      : t("detail.skillDeadHint")}
+                    {s.status === "corrupt"
+                      ? t("detail.skillCorruptHint")
+                      : s.status === "missing"
+                        ? t("detail.skillMissingHint", { path: s.path })
+                        : t("detail.skillDeadHint")}
                   </div>
                 )}
               </li>

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -213,6 +213,8 @@ export const en = {
   "detail.skillDeadHint": "This legacy file no longer parses as a valid skill — remove and re-install it.",
   "detail.skillMissing": "missing",
   "detail.skillMissingHint": "File not found: {path} — profile.yaml references this skill but it was never installed. Install it (mur agent skill add) or remove the entry.",
+  "detail.skillCorrupt": "corrupt entry",
+  "detail.skillCorruptHint": "This is one profile.yaml entry holding several refs run together, not a skill id — so no file matches it. The skills it names are probably installed; installing again will not help. Split it into separate list items in profile.yaml, or remove it and re-add them.",
   "detail.remove": "Remove",
   "detail.addMcp": "Add MCP server",
   "detail.discoverMcp": "Discover from other tools",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -215,6 +215,8 @@ export const zhTW: Table = {
   "detail.skillDeadHint": "這個舊版檔案已無法解析為有效技能——請移除後重新安裝。",
   "detail.skillMissing": "檔案不存在",
   "detail.skillMissingHint": "找不到檔案:{path} — profile.yaml 引用了這個技能,但從未安裝。請安裝(mur agent skill add)或移除此項目。",
+  "detail.skillCorrupt": "項目損毀",
+  "detail.skillCorruptHint": "這是 profile.yaml 裡的單一項目,內含多個被串在一起的引用,並不是一個技能 id,所以沒有檔案對得上。它列出的技能多半已經安裝,再安裝一次沒有用。請在 profile.yaml 裡把它拆成各自獨立的項目,或移除後重新加入。",
   "detail.remove": "移除",
   "detail.addMcp": "新增 MCP 伺服器",
   "detail.discoverMcp": "從其他工具探索",

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -55,9 +55,11 @@ export interface SkillView {
   loadable: boolean;
   /**
    * Why: "missing" = the file was never installed (dangling profile.yaml ref),
-   * "malformed" = the file exists but no longer parses (#717).
+   * "malformed" = the file exists but no longer parses (#717), "corrupt" = the
+   * ref itself is not a usable path (several refs concatenated into one entry),
+   * so the skills it names may be installed and installing is not the fix.
    */
-  status: "ok" | "missing" | "malformed";
+  status: "ok" | "missing" | "malformed" | "corrupt";
 }
 
 export interface InstalledAddonView {


### PR DESCRIPTION
Two reports from one day of use. Separate commits — they are unrelated beyond both being lifecycle blind spots.

---

## 1. `mur agent stop` could not stop a service-managed agent (`f9d44e0`)

```
$ mur agent stop kelp
Stopped agent 'kelp'
$ mur agent list
kelp   running   2s   17597        # was pid 17402
```

Reproduced here on a launchd-managed agent: 50285 → 54132, and `launchctl list` showed the new pid under `run.mur.agent.drs-ux`.

The kill was real. Every service `install-service` writes sets `KeepAlive`, so launchd respawns the runtime the instant it dies — signalling the pid can only swap it. The success line printed unconditionally, so the output claimed one thing while the pid said another.

**The blind spot is only in these two commands.** `start` resolves the service (`kickstart`, then `load -w`), `restart` deliberately waits for the launchd respawn, `install-service` loads it. `start` even documents the missing half — *"Not loaded (e.g. after a manual bootout)"* — and nothing in the tree ever booted out.

Composed, they left a dead end: `remove` refuses while an agent is running, and stop could not stop it, so **a service-managed agent could not be removed at all**. The error told you to do the one thing that did not work.

- `stop`: boot out / `systemctl --user stop` first, signal, then **confirm no live lock came back** before claiming success
- `remove`: delete the descriptor too — it execs the `mur_agent_<name>` symlink `remove` just deleted, and reloads at the next login
- both, plus `install-service`, now derive the path from one function, so install cannot write where stop does not look

**Verified against a real launchd-managed agent:** stop prints "and unloaded its service", the agent is still stopped 8s later, `launchctl` no longer lists it, and `start` brings it back through the `load -w` branch written for exactly this state.

---

## 2. A corrupted skill ref was reported as "never installed" (`cf8bc4e`)

The Hub showed this on a live concierge, flagged `missing`:

```
skills/pm-spec-handoff - skills/brainstorming - skills/brainstorming - …
```

One `profile.yaml` list item, not nine. Every skill it names **is** installed. No file matches the whole string, so it resolved to `Missing` and the hint said *"references this skill but it was never installed. Install it (mur agent skill add)"*. Installing cannot help — and the user ran it anyway, because the tool asked.

The archived profiles date it and show it growing: 26 Jul a clean `- skills/pm-spec-handoff`; 27 Jul `- skills/brainstorming` **appended to that line** instead of pushed as a new item; 3 Aug three segments; today ten. Whatever writes it bypasses `save_profile` — `validate_skill_refs` there would reject it — so this cannot be prevented at our write path. It can only be reported honestly.

So classify it: a ref that fails to resolve **and** contains whitespace is a corrupted entry, not a missing skill. A skill id never holds whitespace. The check runs only *after* resolution has already failed, so no ref that works today can be reclassified.

This is the argument the enum's own doc comment already makes for splitting `Missing` from `Malformed` — *"telling the user it 'no longer parses' points them at the wrong root cause"* — applied one level further.

---

## Verification

| | |
|---|---|
| `cargo test -p mur-common --lib skill_ref_status` | 6/6, incl. the regression guard that a plain uninstalled ref **stays** `Missing` — there "install it" is right |
| `cargo test -p mur-core --lib agent::service` | 4/4, incl. one pinning that `stop_service` boots out the label `darwin_plist` declares |
| `cargo check --workspace --all-targets`, `clippy -D warnings`, `cargo fmt --check` | clean |
| `tsc -b`, `eslint`, i18n tests | clean (`tsc` caught the missing zh-TW keys) |
| stop/remove | driven against a real launchd agent, above |
| skill classification | confirmed on the real corrupt profile: with this change the Hub badge stops saying `missing` |

**One step not visually confirmed.** The new `corrupt entry` hint string is type-checked, present in the built bundle, and reached by a one-line ternary on a status the backend demonstrably emits — but I could not drive the Hub UI to the Skills tab to photograph it. Worth a glance before merging.

Also learned while verifying: this repo has no `beforeBuildCommand`, so `tauri build` ships whatever is in `ui/dist`. A local Hub build must run `npm run build` in `ui/` first or it silently packages a stale frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)