### PR TITLE
chore(release): bump workspace version to 2.68.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.68.4"
+version = "2.68.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.4"
+version = "2.68.5"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Cuts v2.68.5. Merging this **is** the release: `tag.yml` fires on a `Cargo.toml` push to `main`, tags `v2.68.5`, and dispatches `release.yml` at that tag.

## What ships

| PR | |
|---|---|
| #919 | `fix(update)`: the compress stale-writer notice fired after every release and meant nothing — the gateway's exact pin is one patch behind by construction, and the CLI's own same-day buckets were reported as "a long-lived service" |
| #920 | `fix(agent)`: `stop`/`remove` never told launchd/systemd anything, so KeepAlive respawned the agent and a service-managed agent could not be removed at all; and a corrupted skill ref is now named as such instead of "never installed" |

## Changed

- `Cargo.toml` — 2.68.4 → 2.68.5
- `Cargo.lock` and `mur-hub-gui/src-tauri/Cargo.lock` — the Hub keeps its own copy of every workspace crate version, and a disagreement breaks the Hub's release build

## Verification

- Bumped with an occurrence assertion rather than `sed -i ''`, a GNU-ism that exits 0 and changes nothing on macOS
- `version = "2.68.4"` now appears **0** times in either lock file; `2.68.5` appears 12 and 6 times
- `validate-version` in `release.yml` re-checks the tag against `Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)