### PR TITLE
fix(agent): let the seeded concierge author MUR objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,16 @@ Agent** wizard offers the same catalog as a source.
   construction: `/`, `/usr`, `/opt`, your home directory and a bare mount point
   are refused, and filesystem and network entitlements still bound whatever
   runs.
+- **A grant that never reached the kernel** — a filesystem entitlement only
+  takes effect if its path exists when the agent starts, so granting a
+  directory you hadn't created yet used to succeed at the CLI, survive a
+  restart, and still fail with a bare `Operation not permitted`. `mur agent
+  perm allow-read` / `allow-write` now refuse a path that doesn't exist and
+  print the `mkdir -p` to run; `mur agent runtime-doctor` reports grants that
+  were dropped, and tells the concierge which of its own authoring dirs it
+  still can't write. A freshly seeded MUR owns
+  `~/.mur/{skills,workflows,fleets,artifacts}`, so it can build the skill,
+  workflow or fleet it just designed instead of handing you a list of commands.
 - **Loop settings that can't quietly mean something else** — a fleet loop ends
   when its job queue drains, when a member emits an agreed marker on a line of
   its own, or when the router judges it done. `mur fleet set-loop` refuses a

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -22,6 +22,23 @@ pub const RESTRICTED_GENERAL_PORTS: [u16; 4] = [80, 443, 8080, 8443];
 /// profile and the file tools deny the same set.
 pub const SELF_PROTECTED_AGENT_FILES: [&str; 2] = ["profile.yaml", "identity.key"];
 
+/// Expand a `~`-relative entitlement path the way the sandbox builder does.
+///
+/// Public because a grant only takes effect if the path exists when the
+/// profile is sealed (see the dead-grant drop below). `mur agent perm ...` and
+/// `mur agent doctor` must test the *same* path the kernel will, or they end
+/// up confidently reporting on a path the sandbox never saw.
+pub fn expand_entitlement_path(s: &str) -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    if let Some(rest) = s.strip_prefix("~/") {
+        home.join(rest)
+    } else if s == "~" {
+        home
+    } else {
+        PathBuf::from(s)
+    }
+}
+
 /// Resolved, OS-ready sandbox policy derived from agent entitlements.
 /// All paths are absolute (tilde expanded). All fields are ready to
 /// feed directly to Landlock / SBPL / Job Object APIs.
@@ -106,16 +123,7 @@ impl Default for SandboxPolicy {
 impl SandboxPolicy {
     pub fn from_entitlements(ent: &Entitlements, agent_home: &Path) -> Self {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-
-        let expand = |s: &str| -> PathBuf {
-            if let Some(rest) = s.strip_prefix("~/") {
-                home.join(rest)
-            } else if s == "~" {
-                home.clone()
-            } else {
-                PathBuf::from(s)
-            }
-        };
+        let expand = expand_entitlement_path;
 
         // USER-DECLARED read/write entitlement paths are existence-checked at
         // profile-build time and dropped (fail-closed, warned) if missing.

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -753,6 +753,18 @@ fn default_dns_mode() -> String {
     "system".to_string()
 }
 
+/// Dirs under `<mur_home>` where MUR objects are authored.
+///
+/// The seeded concierge gets read+write on these; without them the one agent a
+/// fresh host has can describe a skill, workflow or fleet but cannot create
+/// one, and every answer ends in "run this command yourself".
+///
+/// Deliberately excludes `agents/`: `self_protected()` only covers an agent's
+/// OWN `profile.yaml` + `identity.key`, so write access there would let an
+/// agent author a sibling with unrestricted entitlements and start it, and
+/// read access would expose every other agent's Ed25519 signing key.
+pub const AUTHORING_DIRS: [&str; 4] = ["skills", "workflows", "fleets", "artifacts"];
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct FilesystemEntitlement {
     #[serde(default)]

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context as _, Result};
 use mur_common::LockFile;
+use std::path::PathBuf;
 
 use super::{resolve_mur_home, stale};
 
@@ -20,6 +21,51 @@ pub struct AgentRow {
     /// at edit time, and then the discrepancy is invisible — which is how a
     /// grant that "was definitely added" silently fails to apply.
     pub profile_drift: bool,
+}
+
+/// Entitlement paths that do not exist on disk.
+///
+/// The sandbox builder drops a grant whose path is missing when the profile is
+/// sealed (Issue 16), so `profile.yaml` can list a path the kernel never
+/// honored. The runtime says so only at `tracing::warn!` — invisible from the
+/// CLI and the TUI — which leaves the agent hitting a bare EPERM with no way
+/// to tell "not granted" from "granted but dropped". This is the other half of
+/// `profile_drift`: that one catches edits after start, this one catches
+/// grants that never took.
+pub fn dead_grants(fs: &mur_common::agent::FilesystemEntitlement) -> Vec<(&'static str, PathBuf)> {
+    [("read", &fs.read), ("write", &fs.write)]
+        .into_iter()
+        .flat_map(|(kind, list)| {
+            list.iter().filter_map(move |raw| {
+                let p = mur_agent_runtime::sandbox::policy::expand_entitlement_path(raw);
+                std::fs::metadata(&p).is_err().then_some((kind, p))
+            })
+        })
+        .collect()
+}
+
+/// `<mur_home>` authoring dirs the concierge has no write grant covering.
+///
+/// An upgrade deliberately does not widen an existing agent's sandbox, so an
+/// install seeded before those grants existed still has none — and nothing
+/// else tells the user why their concierge can describe a skill but never
+/// create one. Grants are subpath allows in SBPL/Landlock, so a grant on an
+/// ancestor counts.
+pub fn missing_authoring_grants(
+    fs: &mur_common::agent::FilesystemEntitlement,
+    mur_home: &std::path::Path,
+) -> Vec<PathBuf> {
+    mur_common::agent::AUTHORING_DIRS
+        .iter()
+        .map(|d| mur_home.join(d))
+        .filter(|want| {
+            !fs.write.iter().any(|raw| {
+                want.starts_with(mur_agent_runtime::sandbox::policy::expand_entitlement_path(
+                    raw,
+                ))
+            })
+        })
+        .collect()
 }
 
 /// Build a doctor row for a single agent from its parsed lock file.
@@ -110,6 +156,22 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
     // ── Output ──────────────────────────────────────────────────────────────
     let any_stale = rows.iter().any(|r| r.stale);
 
+    // Best effort: a profile that will not load is simply not reported on here,
+    // the row's other checks still stand.
+    let dead = |name: &str| -> Vec<(&'static str, PathBuf)> {
+        super::load_profile_for_edit(name)
+            .map(|(_p, prof)| dead_grants(&prof.entitlements.filesystem))
+            .unwrap_or_default()
+    };
+
+    // Checked outside the rows loop on purpose: `rows` only holds agents with a
+    // running.lock, and "my concierge cannot author anything" is exactly the
+    // question you ask about an agent that is not up.
+    let concierge_gaps: Vec<PathBuf> =
+        super::load_profile_for_edit(mur_common::fleet::CONCIERGE_AGENT)
+            .map(|(_p, prof)| missing_authoring_grants(&prof.entitlements.filesystem, &mur_home))
+            .unwrap_or_default();
+
     if json {
         let arr: Vec<serde_json::Value> = rows
             .iter()
@@ -121,6 +183,13 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                     "profile_drift": r.profile_drift,
                     "lock_sha": r.lock_sha,
                     "disk_sha": r.disk_sha,
+                    "dead_grants": dead(&r.name)
+                        .iter()
+                        .map(|(kind, p)| serde_json::json!({
+                            "kind": kind,
+                            "path": p.display().to_string(),
+                        }))
+                        .collect::<Vec<_>>(),
                 })
             })
             .collect();
@@ -128,6 +197,28 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
     } else {
         if rows.is_empty() {
             println!("No running agents found.");
+        }
+        // Text only: `--json` is a running-agents array that build.sh greps for
+        // stale counts, and this is a host-level fact about an agent that may
+        // not be running at all. Reshaping the array to carry it would break
+        // that consumer for no gain.
+        if !concierge_gaps.is_empty() {
+            println!(
+                "{}: cannot author MUR objects — no write grant covers:",
+                mur_common::fleet::CONCIERGE_AGENT
+            );
+            for p in &concierge_gaps {
+                println!(
+                    "  {} \u{2192} mur agent perm allow-write {} {}",
+                    p.display(),
+                    mur_common::fleet::CONCIERGE_AGENT,
+                    p.display()
+                );
+            }
+            println!(
+                "  (then: mur agent restart {})",
+                mur_common::fleet::CONCIERGE_AGENT
+            );
         }
         for r in &rows {
             if r.stale {
@@ -144,6 +235,15 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                 );
             } else {
                 println!("{}: running, current", r.name);
+            }
+            for (kind, p) in dead(&r.name) {
+                println!(
+                    "  {} grant has NO EFFECT: {} does not exist \u{2192} mkdir -p {} && mur agent restart {}",
+                    kind,
+                    p.display(),
+                    p.display(),
+                    r.name
+                );
             }
 
             // Best-effort program-deps preflight — never blocks or fails the
@@ -180,6 +280,65 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
 mod tests {
     use super::*;
     use mur_common::LockFile;
+
+    #[test]
+    fn dead_grants_flags_only_the_missing_paths() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let live = dir.path().join("skills");
+        std::fs::create_dir_all(&live).unwrap();
+        let gone = dir.path().join("artifacts");
+
+        let fs = mur_common::agent::FilesystemEntitlement {
+            read: vec![live.to_string_lossy().into_owned()],
+            write: vec![
+                live.to_string_lossy().into_owned(),
+                gone.to_string_lossy().into_owned(),
+            ],
+            deny: vec![],
+        };
+
+        // Negative control: without the missing entry nothing is reported, so a
+        // green result means "checked and clean", not "check never ran".
+        let clean = mur_common::agent::FilesystemEntitlement {
+            write: vec![live.to_string_lossy().into_owned()],
+            ..fs.clone()
+        };
+        assert!(dead_grants(&clean).is_empty());
+
+        let found = dead_grants(&fs);
+        assert_eq!(found.len(), 1, "got {found:?}");
+        assert_eq!(found[0].0, "write");
+        assert_eq!(found[0].1, gone);
+    }
+
+    #[test]
+    fn missing_authoring_grants_respects_subpath_semantics() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let home = dir.path();
+
+        // Nothing granted: every authoring dir is missing.
+        let none = mur_common::agent::FilesystemEntitlement::default();
+        assert_eq!(
+            missing_authoring_grants(&none, home).len(),
+            mur_common::agent::AUTHORING_DIRS.len()
+        );
+
+        // One exact grant covers exactly one dir.
+        let one = mur_common::agent::FilesystemEntitlement {
+            write: vec![home.join("skills").to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+        let gaps = missing_authoring_grants(&one, home);
+        assert_eq!(gaps.len(), mur_common::agent::AUTHORING_DIRS.len() - 1);
+        assert!(!gaps.contains(&home.join("skills")));
+
+        // Grants are subpath allows, so an ancestor covers all of them.
+        let ancestor = mur_common::agent::FilesystemEntitlement {
+            write: vec![home.to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+        assert!(missing_authoring_grants(&ancestor, home).is_empty());
+    }
 
     fn make_lock(build_sha: &str) -> LockFile {
         LockFile {

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -139,7 +139,30 @@ pub fn cmd_perm_list_hosts(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Refuse a filesystem grant the sandbox would silently discard.
+///
+/// `SandboxPolicy::from_entitlements` drops entitlement paths that do not exist
+/// when the profile is sealed (Issue 16 — a dead grant destabilizes unrelated
+/// write checks). Accepting one here is the worst outcome: the CLI reports
+/// success, the profile lists the path, `restart` says it applied, and the
+/// kernel still returns EPERM with nothing in between explaining why.
+fn reject_dead_grant(path_arg: &str) -> Result<()> {
+    let p = mur_agent_runtime::sandbox::policy::expand_entitlement_path(path_arg);
+    if std::fs::metadata(&p).is_ok() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{} does not exist.\n\
+         The sandbox drops grants for paths that are missing when the agent \
+         starts, so this one would be accepted here and still denied by the \
+         kernel. Create it first, then re-run this command:\n    mkdir -p {}",
+        p.display(),
+        p.display()
+    )
+}
+
 pub fn cmd_perm_allow_read(name: &str, path_arg: &str) -> Result<()> {
+    reject_dead_grant(path_arg)?;
     let (path, mut profile) = load_profile_for_edit(name)?;
     if !profile
         .entitlements
@@ -160,6 +183,7 @@ pub fn cmd_perm_allow_read(name: &str, path_arg: &str) -> Result<()> {
 }
 
 pub fn cmd_perm_allow_write(name: &str, path_arg: &str) -> Result<()> {
+    reject_dead_grant(path_arg)?;
     let (path, mut profile) = load_profile_for_edit(name)?;
     if !profile
         .entitlements

--- a/mur-core/tests/agent_perm.rs
+++ b/mur-core/tests/agent_perm.rs
@@ -98,9 +98,14 @@ fn perm_filesystem_and_spawn_mutators() {
         mur_home.path(),
         &["agent", "perm", "allow-read", "agent_x", "/var/log"],
     );
+    // A grant only takes effect if the path exists when the sandbox profile is
+    // sealed, so `perm` refuses paths that are missing. Use a real dir — that
+    // is the contract now, not test scaffolding.
+    let out_dir = TempDir::new().unwrap();
+    let out = out_dir.path().to_string_lossy().into_owned();
     let _ = run(
         mur_home.path(),
-        &["agent", "perm", "allow-write", "agent_x", "/tmp/out"],
+        &["agent", "perm", "allow-write", "agent_x", &out],
     );
     let _ = run(
         mur_home.path(),
@@ -118,12 +123,7 @@ fn perm_filesystem_and_spawn_mutators() {
             .read
             .contains(&"/var/log".to_string())
     );
-    assert!(
-        p.entitlements
-            .filesystem
-            .write
-            .contains(&"/tmp/out".to_string())
-    );
+    assert!(p.entitlements.filesystem.write.contains(&out));
     assert!(
         p.entitlements
             .filesystem
@@ -192,4 +192,62 @@ fn perm_show_prints_entitlements() {
         "show should print network section: {body}"
     );
     assert!(body.contains("filesystem"));
+}
+
+/// A grant on a path that does not exist is dropped when the sandbox profile is
+/// sealed, so accepting it here produces the worst possible failure: `perm` says
+/// OK, `restart` says applied, and the kernel still returns EPERM with nothing
+/// in between explaining why. Refuse at the door instead.
+#[test]
+fn allow_write_refuses_a_path_that_does_not_exist() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    mur_create(mur_home.path(), bin_dir.path(), "agent_x");
+
+    let missing = mur_home.path().join("artifacts");
+    let missing_s = missing.to_string_lossy().into_owned();
+
+    let out = run(
+        mur_home.path(),
+        &["agent", "perm", "allow-write", "agent_x", &missing_s],
+    );
+    assert!(
+        !out.status.success(),
+        "should have refused; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let err = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        err.contains("does not exist") && err.contains("mkdir -p"),
+        "error must say what to do, got: {err}"
+    );
+    assert!(
+        !read_profile(mur_home.path(), "agent_x")
+            .entitlements
+            .filesystem
+            .write
+            .contains(&missing_s),
+        "refused grant must not be written to the profile"
+    );
+
+    // Negative control: the identical call succeeds once the dir exists, so the
+    // refusal above is about the missing path and not some unrelated failure.
+    std::fs::create_dir_all(&missing).unwrap();
+    let out = run(
+        mur_home.path(),
+        &["agent", "perm", "allow-write", "agent_x", &missing_s],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        read_profile(mur_home.path(), "agent_x")
+            .entitlements
+            .filesystem
+            .write
+            .contains(&missing_s)
+    );
 }

--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/profile.yaml
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/profile.yaml
@@ -48,8 +48,26 @@ entitlements:
         - "localhost"
         - "127.0.0.1"
   filesystem:
-    read: []
-    write: []
+    # MUR's own authoring dirs. Without these the concierge can talk about
+    # skills/workflows/fleets but cannot create one — every road ends in
+    # "run this command yourself". Listed one by one on purpose: a blanket
+    # `~/.mur` read would expose `agents/*/identity.key` (every other agent's
+    # Ed25519 signing key), and `~/.mur/agents` write would let this agent
+    # author a sibling profile with unrestricted entitlements and start it.
+    # `self_protected()` only covers the agent's OWN profile.yaml + key.
+    # `~/.mur/config.yaml` is deliberately absent: `Config::load_or_default`
+    # never creates it, so on a fresh host the grant would be dropped at seal
+    # time — the exact dead-grant trap this set exists to avoid.
+    read:
+      - "~/.mur/skills"
+      - "~/.mur/workflows"
+      - "~/.mur/fleets"
+      - "~/.mur/artifacts"
+    write:
+      - "~/.mur/skills"
+      - "~/.mur/workflows"
+      - "~/.mur/fleets"
+      - "~/.mur/artifacts"
     deny: []
   processes:
     spawn:

--- a/mur-hub-gui/src-tauri/src/seed_mur.rs
+++ b/mur-hub-gui/src-tauri/src/seed_mur.rs
@@ -7,6 +7,8 @@
 
 use std::path::Path;
 
+use mur_common::agent::AUTHORING_DIRS;
+
 /// True if Mur is already seeded, i.e. `<mur_home>/agents/mur/profile.yaml` exists.
 /// We key off the profile file (not just the directory) so a previously broken
 /// half-seeded `agents/mur` directory is treated as "not seeded" and gets healed.
@@ -291,6 +293,15 @@ pub fn seed_mur_if_missing(template_dir: &Path, mur_home: &Path) -> std::io::Res
 
     let agents = mur_home.join("agents");
     std::fs::create_dir_all(&agents)?;
+
+    // The template grants write on these, but the sandbox drops a grant whose
+    // path does not exist at seal time (policy.rs, Issue 16) — so on a fresh
+    // host the concierge would boot with every authoring grant silently gone.
+    // Create them here, next to the seed that grants them.
+    for d in AUTHORING_DIRS {
+        std::fs::create_dir_all(mur_home.join(d))?;
+    }
+
     let staging = agents.join(".mur.seeding");
     let dst = agents.join("mur");
 
@@ -438,6 +449,68 @@ mod tests {
                 .join("agents/mur/skills/concierge.yaml")
                 .exists()
         );
+    }
+
+    #[test]
+    fn seeds_authoring_dirs_so_the_template_grants_are_not_dead() {
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_template(tpl.path());
+        assert!(seed_mur_if_missing(tpl.path(), home.path()).unwrap());
+        for d in AUTHORING_DIRS {
+            assert!(
+                home.path().join(d).is_dir(),
+                "<mur_home>/{d} must exist at seed time or the sandbox drops the \
+                 template's write grant for it and the concierge boots unable to author"
+            );
+        }
+    }
+
+    /// The template is YAML and `AUTHORING_DIRS` is Rust; nothing but this test
+    /// stops them drifting into "granted but never created" (the original bug).
+    #[test]
+    fn template_write_grants_match_authoring_dirs() {
+        let tpl = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("resources/mur-agent-template/profile.yaml");
+        let yaml = std::fs::read_to_string(&tpl).unwrap();
+        let v: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let writes: Vec<String> = v["entitlements"]["filesystem"]["write"]
+            .as_sequence()
+            .expect("template must declare filesystem.write")
+            .iter()
+            .map(|s| s.as_str().unwrap().to_string())
+            .collect();
+        let reads: Vec<String> = v["entitlements"]["filesystem"]["read"]
+            .as_sequence()
+            .expect("template must declare filesystem.read")
+            .iter()
+            .map(|s| s.as_str().unwrap().to_string())
+            .collect();
+
+        let expected: Vec<String> = AUTHORING_DIRS
+            .iter()
+            .map(|d| format!("~/.mur/{d}"))
+            .collect();
+        assert_eq!(writes, expected, "template write grants drifted");
+        assert_eq!(
+            reads, expected,
+            "template read grants drifted — every granted path must be one the \
+             seed creates, or the sandbox drops it at seal time"
+        );
+
+        // A blanket `~/.mur` read hands over every other agent's identity.key
+        // (Ed25519 signing key); `~/.mur/agents` write lets this agent author a
+        // sibling profile with unrestricted entitlements and start it.
+        for bad in ["~/.mur", "~/.mur/agents", "~/.mur/"] {
+            assert!(
+                !reads.contains(&bad.to_string()),
+                "read grant {bad} escapes"
+            );
+            assert!(
+                !writes.contains(&bad.to_string()),
+                "write grant {bad} escapes"
+            );
+        }
     }
 
     fn make_dir_skill_template(dir: &Path) {


### PR DESCRIPTION
## The problem

On a fresh MUR host the only agent you have is the seeded concierge, and its template grants it nothing:

```yaml
filesystem: { read: [], write: [], deny: [] }
processes:  { spawn: { mode: "none", allowed: [] } }
```

Every MUR building block lives under `~/.mur/` — `skills/`, `workflows/`, `fleets/`. So the agent whose job is to help you set MUR up cannot create a single MUR object. It designs what you asked for and then hands you a list of commands to run yourself.

Trying to fix that by hand hits the second wall:

```
$ mur agent perm allow-write mur ~/.mur/artifacts
warning: 'mur' is running; restart required for changes to take effect
$ mur agent restart mur
✓ 'mur' restarted
→ write_file: Operation not permitted
```

`SandboxPolicy::from_entitlements` drops an entitlement path that does not exist when the profile is sealed (Issue 16 — a dead SBPL `subpath` grant was observed to destabilize unrelated `file-write*` checks). `cmd_perm_allow_write` never checked. So the CLI reported success, the profile listed the path, `restart` reported applied, and the kernel still refused — and the only record was a `tracing::warn!` nobody sees.

## The change

Three walls, one class of bug: a grant that exists in the profile but never reached the kernel.

| | |
|---|---|
| **template** | concierge gets read+write on `<mur_home>/{skills,workflows,fleets,artifacts}` |
| **seed** | creates those dirs, so the grants are live when the runtime seals |
| **perm** | `allow-read`/`allow-write` refuse a missing path instead of recording a dead grant |
| **doctor** | reports dropped grants, and separately the authoring dirs the concierge has no grant covering |

`expand_entitlement_path` is now public so `perm`, `doctor` and the sandbox builder test the same path rather than three lookalikes that can disagree. `AUTHORING_DIRS` lives in `mur-common` so the hub seed and the core doctor cannot drift; a test pins the template YAML to it.

### Scope held deliberately narrow

- **`~/.mur` is not granted wholesale.** `self_protected()` appends only the agent's **own** `profile.yaml` + `identity.key` to the deny list, so a blanket read would expose every *other* agent's Ed25519 signing key and defeat v3d channel signature verification.
- **`~/.mur/agents` is not granted.** Write access there lets an agent author a sibling profile with unrestricted entitlements and start it — a full sandbox escape.
- **`~/.mur/config.yaml` is not granted.** `Config::load_or_default` never creates it, so on a fresh host that grant would itself be dropped at seal time.
- **Existing installs are not auto-widened.** An upgrade does not silently expand a sandbox; `doctor` reports the gap and the exact command instead.
- **`spawn` stays `none`.** Authoring a skill/workflow/fleet needs no `exec`.
- Runtime drop behavior is unchanged.

## Why the chain holds

Template grants → seed creates the dirs → `policy.rs` keeps grants whose paths exist (pinned by the existing Issue 16 regression test `from_entitlements_drops_dead_read_write_but_keeps_dead_deny`) → `macos.rs` emits `(allow file-write* (subpath …))`, so a grant on `~/.mur/fleets` covers `fleets/<name>/fleet.yaml`.

## Verification

```
cargo nextest -p mur-agent-runtime -p mur-core          847 passed, 0 failed
cargo test --lib seed_mur (mur-hub-gui)                  18 passed, 0 failed
cargo fmt --check  × 3 manifests                         clean
cargo clippy -p {mur-common,mur-agent-runtime,mur-core}
             --all-targets -- -D warnings                clean
```

New tests:

- `allow_write_refuses_a_path_that_does_not_exist` — exec test against the real `mur` binary, with a negative control asserting the identical call succeeds once the dir exists (so the refusal is about the missing path, not an unrelated failure).
- `seeds_authoring_dirs_so_the_template_grants_are_not_dead`
- `template_write_grants_match_authoring_dirs` — pins the YAML to `AUTHORING_DIRS` and asserts the escape paths never appear.
- `dead_grants_flags_only_the_missing_paths` — includes a negative control.
- `missing_authoring_grants_respects_subpath_semantics`

`perm_filesystem_and_spawn_mutators` was granting `/tmp/out`, a path that does not exist — the bug in miniature. Updated to a real dir.

## Not covered

In-session permission requests (agent hits a wall → human approves in the TUI → applied) are a follow-on. A sealed macOS sandbox cannot be widened in-process, so that needs either restart-and-replay or a broker; the existing risk-tiered HITL gate is the natural fit. This PR only removes the case where the concierge cannot write its own home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
