### PR TITLE
docs(agent): document the lifecycle commands, and fix the two help texts that lie

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ mur agent cli coach                           # streaming TUI chat with tool app
 mur agent cli dev qa ops                      # three agents, tiled panes (tmux/zellij/WezTerm/kitty)
                                               #   --resume continues the last conversation
 murmur coach                                  # quick form (murmur symlink), identical to mur agent cli coach
+
+mur agent stop coach                          # stops it for real: unloads the service first, so
+                                              #   the supervisor cannot respawn it a second later
+mur agent remove coach                        # unregisters it — add --purge to delete its data too
 ```
 
 <p align="center"><img src="assets/demo.gif" alt="mur agent cli — streaming TUI chat with a local agent" width="92%" /></p>
@@ -490,8 +494,9 @@ mur dashboard        # terminal TUI dashboard
 ```
 mur
 ├── init / doctor / update / stats / verify
-├── agent        create · cli · send · card · who · export · install · addon · companion ·
-│                voice · pair · schedule · perm · secret · trash · rollback … (40+)
+├── agent        create · start · stop · restart · remove · cli · send · card · who · export ·
+│                install · install-service · addon · companion · voice · pair · schedule ·
+│                perm · secret · trash · rollback … (40+)
 ├── capability   install · list · show · remove   (MCP + skills + programs bundled → an agent)
 ├── fleet        create · list · show · run · set-loop · send · jobs   (squads of agents over a shared channel)
 ├── official     list · install   (official agents/fleets from the app.mur.run catalog)

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -42,7 +42,10 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
-    /// Stop a running agent (SIGTERM, then SIGKILL after timeout)
+    /// Stop a running agent and keep it stopped: unloads its launchd/systemd
+    /// service first when one is installed (otherwise KeepAlive respawns it a
+    /// second later), then SIGTERM, then SIGKILL after the timeout. `start`
+    /// loads the service again.
     Stop {
         /// Agent name
         name: String,
@@ -64,7 +67,9 @@ pub enum AgentAction {
         #[arg(long = "dry-run")]
         dry_run: bool,
     },
-    /// Remove an agent (symlink + optionally data)
+    /// Remove an agent: deletes its runtime symlink and its launchd/systemd
+    /// service, and leaves `~/.mur/agents/<name>/` in place unless --purge.
+    /// Stop the agent first — removal refuses while it is running.
     Remove {
         /// Agent name
         name: String,


### PR DESCRIPTION
## Why

`mur agent stop` and `mur agent remove` appear **nowhere** in the README or the docs site. The only description of their semantics was `--help` — and after #920 both of those lines were wrong:

| | said | omitted |
|---|---|---|
| `stop` | "SIGTERM, then SIGKILL after timeout" | that it now unloads the service — the whole reason it works on a service-managed agent |
| `remove` | "symlink + optionally data" | the service descriptor it now deletes, and the part users actually get wrong: **the data directory survives unless you pass `--purge`** |

That gap has a cost. A user asked why `mur agent remove` had not deleted `~/.mur/agents/<name>/`. The answer existed only in `--help`, so the question was reasonable.

## Changes

- **README quickstart** — the two commands where someone meets them, each with the surprising half stated inline
- **README command tree** — the `agent` row gains the lifecycle verbs it was missing: `start · stop · restart · remove · install-service`. Top-level count unchanged (28).
- **`cli/agent.rs`** — both doc comments rewritten to match what the code does after #920

Command surface verified against `mur-core/src/cli/agent.rs`, not from memory, per the `update-docs` skill.

## Not here

The docs-site page (`agent-lifecycle`) is a separate PR in `mur-server` — different repo, and merging it publishes to app.mur.run.

The product page gets nothing: this is reference material about existing commands, not a new capability, and a "stop actually stops" card would read oddly on a marketing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)