### PR TITLE
feat(sandbox): protect MUR's launch chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,11 @@ Agent** wizard offers the same catalog as a source.
   perm allow-read` / `allow-write` now refuse a path that doesn't exist and
   print the `mkdir -p` to run; `mur agent runtime-doctor` reports grants that
   were dropped, and tells the concierge which of its own authoring dirs it
-  still can't write. A freshly seeded MUR owns
+  still can't write. Some paths can never be granted at all — another agent's
+  directory, the runtime binary, an autostart directory — because they decide
+  what starts next; `allow-read` / `allow-write` refuse them, and
+  `runtime-doctor` names any such grant that was already sitting in a profile.
+  A freshly seeded MUR owns
   `~/.mur/{skills,workflows,fleets,artifacts}`, so it can build the skill,
   workflow or fleet it just designed instead of handing you a list of commands.
 - **Loop settings that can't quietly mean something else** — a fleet loop ends

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -1,0 +1,276 @@
+//! MUR's own launch chain: the files that decide what starts next and with
+//! what authority.
+//!
+//! A sandbox that can be edited from inside it is not a boundary, it is a
+//! delay. The set guarded here is deliberately NOT "dangerous paths" — that
+//! set is open-ended (`.zshenv`, autostart, git hooks, cron) and unwinnable.
+//! It is the closed set MUR owns: what triggers a start, what gets exec'd,
+//! what entitlements the started process carries, and what identity it signs
+//! with. Every member is derivable from `mur_home`, `bin_dir` and `$HOME`.
+//!
+//! This is a predicate, not a path list, on purpose: a list built at seal
+//! time cannot cover `<mur_home>/agents/<name>` for a name that did not exist
+//! yet, and creating that directory is exactly the escape.
+
+use std::path::{Path, PathBuf};
+
+/// Written by MUR itself under `bin_dir`; exec'd before any sandbox applies.
+const RUNTIME_BINARY: &str = "mur-agent-runtime";
+/// BusyBox-style per-agent symlinks to `RUNTIME_BINARY`.
+const AGENT_SYMLINK_PREFIX: &str = "mur_agent_";
+
+#[derive(Clone, Debug)]
+pub struct LaunchChain {
+    mur_home: PathBuf,
+    agent_home: PathBuf,
+    bin_dir: PathBuf,
+    autostart: Vec<PathBuf>,
+}
+
+impl LaunchChain {
+    /// Derive the protected set for the agent rooted at `agent_home`.
+    pub fn new(agent_home: &Path) -> Self {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+        let bin_dir = std::env::var_os("MUR_AGENT_BIN_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/bin"));
+        Self::build(agent_home, &bin_dir, &home)
+    }
+
+    /// Construct with explicit roots. Tests use this; `new` is the real path.
+    pub fn for_test(agent_home: &Path, bin_dir: &Path, home: &Path) -> Self {
+        Self::build(agent_home, bin_dir, home)
+    }
+
+    fn build(agent_home: &Path, bin_dir: &Path, home: &Path) -> Self {
+        // `<mur_home>/agents/<name>` — the same derivation policy.rs uses for
+        // the channels and open-items force-grants.
+        let mur_home = agent_home
+            .parent()
+            .and_then(|p| p.parent())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| agent_home.to_path_buf());
+        Self {
+            mur_home,
+            agent_home: agent_home.to_path_buf(),
+            bin_dir: bin_dir.to_path_buf(),
+            autostart: autostart_dirs(home),
+        }
+    }
+
+    pub fn agent_self_home(&self) -> &Path {
+        &self.agent_home
+    }
+
+    /// Why `path` may never be written, or `None` if it is not in the set.
+    ///
+    /// Returns the reason rather than a bare `bool` because the tool gate is
+    /// the only layer that can explain itself — the kernel returns an EPERM
+    /// that reads identically to "not granted".
+    pub fn protects_write(&self, path: &Path) -> Option<&'static str> {
+        if self.is_other_agent(path) {
+            return Some(
+                "another agent's directory — its profile.yaml is that agent's \
+                 entitlements and its identity.key is that agent's signing authority",
+            );
+        }
+        if self.is_launch_artifact(path) {
+            return Some(
+                "MUR's runtime binary or a per-agent symlink — exec'd before \
+                 the sandbox applies, so replacing it escapes every sandbox",
+            );
+        }
+        if self.autostart.iter().any(|d| path.starts_with(d)) {
+            return Some("an OS autostart directory — entries here run outside any sandbox");
+        }
+        None
+    }
+
+    /// Why `path` may never be read. Only sibling signing keys: whoever reads
+    /// one can forge that agent's channel events with no write at all, and
+    /// verify-on-fold accepts them because the key on disk is untouched.
+    pub fn protects_read(&self, path: &Path) -> Option<&'static str> {
+        if self.is_other_agent(path) && path.file_name().is_some_and(|n| n == "identity.key") {
+            return Some(
+                "another agent's signing key — reading it is enough to forge \
+                 that agent's signed channel events",
+            );
+        }
+        None
+    }
+
+    /// Concrete paths for backends that need a list rather than a predicate
+    /// (SBPL). `<mur_home>/agents` is included as a whole; the caller is
+    /// responsible for re-allowing `agent_self_home()` after it.
+    pub fn deny_paths(&self) -> Vec<PathBuf> {
+        let mut out = vec![self.mur_home.join("agents")];
+        out.push(self.bin_dir.join(RUNTIME_BINARY));
+        out.extend(self.existing_agent_symlinks());
+        out.extend(self.autostart.iter().cloned());
+        out
+    }
+
+    /// Under `<mur_home>/agents` but not under this agent's own home.
+    fn is_other_agent(&self, path: &Path) -> bool {
+        path.starts_with(self.mur_home.join("agents")) && !path.starts_with(&self.agent_home)
+    }
+
+    fn is_launch_artifact(&self, path: &Path) -> bool {
+        if path.parent() != Some(self.bin_dir.as_path()) {
+            return false;
+        }
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n == RUNTIME_BINARY || n.starts_with(AGENT_SYMLINK_PREFIX))
+    }
+
+    /// Symlinks present now. One created later is not listed, which is
+    /// acceptable: a new symlink only matters if something starts it, and
+    /// that needs a profile (denied) or an autostart entry (denied) or a human.
+    fn existing_agent_symlinks(&self) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(&self.bin_dir) else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with(AGENT_SYMLINK_PREFIX))
+            })
+            .map(|e| e.path())
+            .collect()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn autostart_dirs(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join("Library/LaunchAgents"),
+        home.join("Library/LaunchDaemons"),
+    ]
+}
+
+#[cfg(target_os = "linux")]
+fn autostart_dirs(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(".config/systemd/user"),
+        home.join(".config/autostart"),
+    ]
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn autostart_dirs(_home: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+/// A grant root so broad that granting it is equivalent to no sandbox.
+///
+/// Unifies the judgement previously duplicated in `access.rs::is_overbroad_root`
+/// (cwd consent) and `policy.rs::is_guarded_prefix` (spawn prefixes). Those two
+/// disagreed: one knew about `/usr` and `/opt`, the other about depth. This is
+/// the union.
+pub fn is_overbroad_grant_root(path: &Path, home: &Path) -> bool {
+    if path == Path::new("/")
+        || path == home
+        || path == Path::new("/usr")
+        || path == Path::new("/opt")
+        || path == Path::new("/opt/homebrew")
+    {
+        return true;
+    }
+    if let Ok(rest) = path.strip_prefix("/Volumes") {
+        return rest.components().count() <= 1;
+    }
+    path.components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count()
+        < 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `<tmp>/agents/mur` as agent_home, so mur_home is `<tmp>`.
+    fn chain(tmp: &Path) -> LaunchChain {
+        LaunchChain::for_test(
+            &tmp.join("agents").join("mur"),
+            &tmp.join("bin"),
+            &tmp.join("home"),
+        )
+    }
+
+    #[test]
+    fn sibling_agent_files_are_write_protected_but_own_are_left_to_self_protect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let c = chain(tmp.path());
+        let agents = tmp.path().join("agents");
+
+        assert!(c.protects_write(&agents.join("pm/profile.yaml")).is_some());
+        assert!(c.protects_write(&agents.join("pm/identity.key")).is_some());
+        assert!(c.protects_write(&agents.join("pm/anything/else")).is_some());
+
+        // Negative control: the agent's own home stays writable. Without this,
+        // a predicate that returned Some() for everything would still pass.
+        assert!(c.protects_write(&agents.join("mur/running.lock")).is_none());
+        assert!(c.protects_write(&agents.join("mur/skills/x.yaml")).is_none());
+    }
+
+    #[test]
+    fn protects_agents_created_after_the_policy_was_built() {
+        // The regression a path list cannot catch: this directory does not
+        // exist, and never existed when any list would have been built.
+        let tmp = tempfile::tempdir().unwrap();
+        let c = chain(tmp.path());
+        let unborn = tmp.path().join("agents/not-created-yet/profile.yaml");
+        assert!(!unborn.exists());
+        assert!(c.protects_write(&unborn).is_some());
+    }
+
+    #[test]
+    fn only_murs_own_launch_artifacts_in_bin_dir_are_protected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let c = chain(tmp.path());
+        let bin = tmp.path().join("bin");
+
+        assert!(c.protects_write(&bin.join("mur-agent-runtime")).is_some());
+        assert!(c.protects_write(&bin.join("mur_agent_pm")).is_some());
+
+        // Negative control: an agent installing a tool for itself still works.
+        assert!(c.protects_write(&bin.join("ripgrep")).is_none());
+        assert!(c.protects_write(&bin.join("murmur-notes")).is_none());
+    }
+
+    #[test]
+    fn sibling_identity_key_is_read_protected_and_nothing_else_is() {
+        let tmp = tempfile::tempdir().unwrap();
+        let c = chain(tmp.path());
+        let agents = tmp.path().join("agents");
+
+        assert!(c.protects_read(&agents.join("pm/identity.key")).is_some());
+
+        // Negative controls: reads are otherwise untouched by this module.
+        assert!(c.protects_read(&agents.join("pm/profile.yaml")).is_none());
+        assert!(c.protects_read(&agents.join("mur/identity.key")).is_none());
+        assert!(c.protects_read(&tmp.path().join("skills/x.yaml")).is_none());
+    }
+
+    #[test]
+    fn overbroad_roots_are_rejected_and_normal_project_dirs_are_not() {
+        let home = PathBuf::from("/Users/someone");
+        assert!(is_overbroad_grant_root(Path::new("/"), &home));
+        assert!(is_overbroad_grant_root(&home, &home));
+        assert!(is_overbroad_grant_root(Path::new("/Users"), &home));
+        assert!(is_overbroad_grant_root(Path::new("/usr"), &home));
+        assert!(is_overbroad_grant_root(Path::new("/opt/homebrew"), &home));
+        assert!(is_overbroad_grant_root(Path::new("/Volumes/Disk"), &home));
+
+        // Negative controls: real grants people legitimately make.
+        assert!(!is_overbroad_grant_root(&home.join("Projects/app"), &home));
+        assert!(!is_overbroad_grant_root(
+            Path::new("/Volumes/Disk/Projects/app"),
+            &home
+        ));
+    }
+}

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -234,7 +234,10 @@ mod tests {
         // Negative control: the agent's own home stays writable. Without this,
         // a predicate that returned Some() for everything would still pass.
         assert!(c.protects_write(&agents.join("mur/running.lock")).is_none());
-        assert!(c.protects_write(&agents.join("mur/skills/x.yaml")).is_none());
+        assert!(
+            c.protects_write(&agents.join("mur/skills/x.yaml"))
+                .is_none()
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -42,6 +42,15 @@ impl LaunchChain {
         Self::build(agent_home, bin_dir, home)
     }
 
+    /// A chain rooted outside any real path, so it never fires.
+    ///
+    /// For tests that exercise something else and just need to construct a
+    /// tool. Tests that exercise the chain build their own with `for_test`.
+    #[cfg(test)]
+    pub fn inert() -> Self {
+        Self::default()
+    }
+
     fn build(agent_home: &Path, bin_dir: &Path, home: &Path) -> Self {
         // `<mur_home>/agents/<name>` — the same derivation policy.rs uses for
         // the channels and open-items force-grants.
@@ -140,6 +149,17 @@ impl LaunchChain {
             })
             .map(|e| e.path())
             .collect()
+    }
+}
+
+impl Default for LaunchChain {
+    /// Rooted outside any real path, so it never fires. Only reachable via
+    /// `SandboxPolicy::default()` (tests and policy-less contexts); every
+    /// real policy is built by `from_entitlements`, which constructs the
+    /// actual chain from `agent_home`.
+    fn default() -> Self {
+        let root = Path::new("/nonexistent-launch-chain-root");
+        Self::build(&root.join("agents/none"), &root.join("bin"), root)
     }
 }
 

--- a/mur-agent-runtime/src/sandbox/linux.rs
+++ b/mur-agent-runtime/src/sandbox/linux.rs
@@ -1,10 +1,20 @@
+use crate::sandbox::launch_chain::LaunchChain;
+use std::path::PathBuf;
+
+// The Landlock/seccomp application path is Linux-only; the module compiles
+// everywhere so `partition_write_grants` (shared with policy.rs, and tested on
+// macOS) is not cfg-gated.
+#[cfg(target_os = "linux")]
 use super::{SandboxPolicy, SandboxStatus};
+#[cfg(target_os = "linux")]
 use anyhow::Context;
+#[cfg(target_os = "linux")]
 use landlock::{
     ABI, Access, AccessFs, AccessNet, NetPort, Ruleset, RulesetAttr, RulesetCreatedAttr,
     RulesetStatus, make_bitflags, path_beneath_rules,
 };
 
+#[cfg(target_os = "linux")]
 pub fn apply_linux(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
     let abi = ABI::V4;
 
@@ -30,9 +40,16 @@ pub fn apply_linux(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
         created = created.add_rules(read_rules).context("add fs_read rules")?;
     }
 
-    // FS read+write paths (superset of read).
-    if !policy.fs_write.is_empty() {
-        let write_rules = path_beneath_rules(policy.fs_write.iter(), AccessFs::from_all(abi));
+    // FS read+write paths (superset of read). Landlock is a pure allow-list,
+    // so a grant that contains a protected launch-chain path cannot be carved
+    // (no deny rule exists to re-close it) — it is dropped whole, fail-closed.
+    // `policy.dropped_grants` already recorded the same computation at profile
+    // build time; this local recomputation also covers paths added after that
+    // (e.g. the media-state extra grants) and keeps the kernel and the report
+    // reading from the same code path.
+    let (writable, _dropped) = partition_write_grants(&policy.fs_write, &policy.launch_chain);
+    if !writable.is_empty() {
+        let write_rules = path_beneath_rules(writable.iter(), AccessFs::from_all(abi));
         created = created
             .add_rules(write_rules)
             .context("add fs_write rules")?;
@@ -78,6 +95,7 @@ pub fn apply_linux(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
 /// To deny a syscall unconditionally (no condition matching), map it to an EMPTY
 /// `Vec<SeccompRule>`. Mapping to a non-empty vec means "deny when a rule matches";
 /// mapping to `vec![]` means "always deny" (matches regardless of arguments).
+#[cfg(target_os = "linux")]
 fn apply_seccomp_denylist() -> anyhow::Result<()> {
     use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, TargetArch};
     use std::collections::BTreeMap;
@@ -122,4 +140,89 @@ fn apply_seccomp_denylist() -> anyhow::Result<()> {
     seccompiler::apply_filter(&prog).context("apply seccomp filter")?;
 
     Ok(())
+}
+
+/// Split write grants into those Landlock can safely install and those it
+/// cannot. Landlock has no deny rule, so a grant that contains a protected
+/// path cannot be carved — it is dropped whole. Fail-closed on purpose: the
+/// alternative is installing a rule that hands over the launch chain.
+///
+/// The agent's own home is exempt: on macOS the SBPL deny of the agents tree
+/// is followed by a re-allow of exactly this directory, and Landlock installs
+/// it as-is (it contains nothing protected — the own profile/identity
+/// self-protection is macOS tier 3 only). Without the exemption the symmetric
+/// overlap test below would also catch the `<mur_home>/agents/<self>`
+/// force-grant and Linux agents would lose their own home.
+pub(crate) fn partition_write_grants(
+    grants: &[PathBuf],
+    chain: &LaunchChain,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let protected = chain.deny_paths();
+    grants.iter().cloned().partition(|g| {
+        if g.starts_with(chain.agent_self_home()) {
+            return true;
+        }
+        !protected
+            .iter()
+            .any(|p| p.starts_with(g) || g.starts_with(p))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain(tmp: &std::path::Path) -> LaunchChain {
+        LaunchChain::for_test(
+            &tmp.join("agents").join("mur"),
+            &tmp.join("bin"),
+            &tmp.join("home"),
+        )
+    }
+
+    #[test]
+    fn a_write_grant_containing_a_protected_path_is_dropped_not_carved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents/mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let skills = mur_home.join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+
+        let (kept, dropped) = partition_write_grants(
+            &[mur_home.to_path_buf(), skills.clone()],
+            &chain(tmp.path()),
+        );
+
+        // `<mur_home>` contains `<mur_home>/agents`, and Landlock cannot carve it out.
+        assert_eq!(dropped, vec![mur_home.to_path_buf()]);
+        // Negative control: a grant that contains nothing protected survives intact.
+        assert_eq!(kept, vec![skills]);
+    }
+
+    #[test]
+    fn a_write_grant_on_a_sibling_agent_dir_is_dropped_but_own_home_survives() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents/mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let skills = mur_home.join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+
+        let (kept, dropped) = partition_write_grants(
+            &[
+                mur_home.join("agents/pm"),
+                agent_home.clone(),
+                skills.clone(),
+            ],
+            &chain(tmp.path()),
+        );
+
+        // A sibling's home is another agent's launch entry and cannot be
+        // carved — dropped whole.
+        assert_eq!(dropped, vec![mur_home.join("agents/pm")]);
+        // Negative controls: the own-home force-grant and an unrelated grant
+        // survive, so the drop is the launch chain and not a blanket prune.
+        assert_eq!(kept, vec![agent_home, skills]);
+    }
 }

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -190,6 +190,30 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
         lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
     }
 
+    // Launch chain, in three tiers (spec 2026-08-11). SBPL is last-match-wins,
+    // so ordering is the mechanism: deny the whole agents tree (siblings'
+    // profiles + signing keys, and names not created yet — the regression a
+    // path list cannot catch), re-allow this agent's own home, then re-assert
+    // the self-protection denies on profile.yaml/identity.key — the fs_deny
+    // emission above is overridden by the re-allow and must land last.
+    for path in policy.launch_chain.deny_paths() {
+        let p = sbpl_escape(&path.to_string_lossy());
+        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
+    }
+    let own = sbpl_escape(&policy.launch_chain.agent_self_home().to_string_lossy());
+    lines.push(format!("(allow file-write* (subpath \"{own}\"))"));
+    for f in crate::sandbox::policy::SELF_PROTECTED_AGENT_FILES {
+        let p = sbpl_escape(
+            &policy
+                .launch_chain
+                .agent_self_home()
+                .join(f)
+                .to_string_lossy(),
+        );
+        lines.push(format!("(deny file-read* (subpath \"{p}\"))"));
+        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
+    }
+
     // Process-exec restrictions. Under `(allow default)` any binary is
     // spawnable unless explicitly denied. When spawn_mode is not `Any`
     // (i.e. Allowlist, None, or Strict), deny all exec by default and
@@ -335,6 +359,23 @@ mod tests {
         }
     }
 
+    fn policy_with_launch_chain(agent_home: &str) -> SandboxPolicy {
+        let home = PathBuf::from(agent_home);
+        let mur_home = home
+            .parent()
+            .and_then(|p| p.parent())
+            .unwrap_or(&home)
+            .to_path_buf();
+        SandboxPolicy {
+            launch_chain: crate::sandbox::launch_chain::LaunchChain::for_test(
+                &home,
+                &mur_home.join("bin"),
+                &mur_home.join("home"),
+            ),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn writes_are_default_deny_with_baseline() {
         let sbpl = build_sbpl_profile(&policy_with(vec![], vec![]));
@@ -386,6 +427,40 @@ mod tests {
         assert!(
             deny > allow,
             "deny must follow the overlapping allow (last-match-wins):\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn agents_deny_precedes_the_self_reallow_which_precedes_the_self_file_denies() {
+        let policy = policy_with_launch_chain("/data/.mur/agents/mur");
+        let sbpl = build_sbpl_profile(&policy);
+
+        let agents_deny = sbpl
+            .find(r#"(deny file-write* (subpath "/data/.mur/agents"))"#)
+            .expect("agents deny missing");
+        let self_reallow = sbpl
+            .rfind(r#"(allow file-write* (subpath "/data/.mur/agents/mur"))"#)
+            .expect("self re-allow missing");
+        let self_profile_deny = sbpl
+            .find(r#"(deny file-write* (subpath "/data/.mur/agents/mur/profile.yaml"))"#)
+            .expect("self profile deny missing");
+
+        // SBPL is last-match-wins, so the ordering IS the mechanism. Asserting
+        // the lines merely exist would pass on a profile that grants everything.
+        assert!(
+            agents_deny < self_reallow,
+            "self re-allow must come after the agents deny or the agent cannot write its own home"
+        );
+        assert!(
+            self_reallow < self_profile_deny,
+            "self profile deny must come after the re-allow or self-protection is undone"
+        );
+
+        // Negative control: nothing re-denies the agent's own runtime files
+        // after the re-allow — running.lock stays writable.
+        assert!(
+            !sbpl.contains(r#"(subpath "/data/.mur/agents/mur/running.lock")"#),
+            "own-home runtime files must not be re-denied after the re-allow:\n{sbpl}"
         );
     }
 

--- a/mur-agent-runtime/src/sandbox/mod.rs
+++ b/mur-agent-runtime/src/sandbox/mod.rs
@@ -1,5 +1,6 @@
 pub mod child;
 pub mod egress_proxy;
+pub mod launch_chain;
 pub mod policy;
 pub mod reqwest_guard;
 

--- a/mur-agent-runtime/src/sandbox/mod.rs
+++ b/mur-agent-runtime/src/sandbox/mod.rs
@@ -4,7 +4,8 @@ pub mod launch_chain;
 pub mod policy;
 pub mod reqwest_guard;
 
-#[cfg(target_os = "linux")]
+// Unconditional: `partition_write_grants` is shared with policy.rs on every
+// platform; only the apply path inside is linux-gated.
 mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -104,6 +104,11 @@ pub struct SandboxPolicy {
     /// ordering tiers in SBPL; Linux drops any overlapping grant fail-closed.
     /// Set from `agent_home` in `from_entitlements`.
     pub launch_chain: crate::sandbox::launch_chain::LaunchChain,
+    /// Write grants that overlap the launch chain and were dropped whole,
+    /// fail-closed: Landlock cannot carve them (Linux), so they never reached
+    /// the kernel. Read by `mur agent runtime-doctor` to report what the
+    /// sandbox neutralised (spec 2026-08-11).
+    pub dropped_grants: Vec<PathBuf>,
 }
 
 impl Default for SandboxPolicy {
@@ -122,6 +127,7 @@ impl Default for SandboxPolicy {
             net_allow_hosts: None,
             memory_limit_mb: None,
             launch_chain: crate::sandbox::launch_chain::LaunchChain::default(),
+            dropped_grants: Vec::new(),
         }
     }
 }
@@ -528,6 +534,14 @@ impl SandboxPolicy {
                 NetworkOutboundMode::Off => (Some(vec![]), Some(vec![]), false),
             };
 
+        let launch_chain = crate::sandbox::launch_chain::LaunchChain::new(agent_home);
+        // Linux Landlock cannot carve a protected path out of a grant (pure
+        // allow-list), so any write grant overlapping the launch chain is
+        // dropped whole here, fail-closed — and recorded for the runtime-doctor
+        // (spec 2026-08-11). macOS carries the same field for symmetry; its
+        // SBPL deny/re-allow carve-out needs no drop.
+        let (_, dropped_grants) =
+            crate::sandbox::linux::partition_write_grants(&fs_write, &launch_chain);
         SandboxPolicy {
             fs_read,
             fs_write,
@@ -541,7 +555,8 @@ impl SandboxPolicy {
             net_loopback_allowed,
             net_allow_hosts,
             memory_limit_mb: Some(ent.limits.memory_mb),
-            launch_chain: crate::sandbox::launch_chain::LaunchChain::new(agent_home),
+            launch_chain,
+            dropped_grants,
         }
     }
 

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -99,6 +99,11 @@ pub struct SandboxPolicy {
     pub net_allow_hosts: Option<Vec<String>>,
     /// Memory limit in megabytes (for Windows Job Object).
     pub memory_limit_mb: Option<u64>,
+    /// MUR's own launch chain: the files that decide what starts next and
+    /// with what authority (spec 2026-08-11). macOS emits it as three
+    /// ordering tiers in SBPL; Linux drops any overlapping grant fail-closed.
+    /// Set from `agent_home` in `from_entitlements`.
+    pub launch_chain: crate::sandbox::launch_chain::LaunchChain,
 }
 
 impl Default for SandboxPolicy {
@@ -116,6 +121,7 @@ impl Default for SandboxPolicy {
             net_loopback_allowed: false,
             net_allow_hosts: None,
             memory_limit_mb: None,
+            launch_chain: crate::sandbox::launch_chain::LaunchChain::default(),
         }
     }
 }
@@ -535,6 +541,7 @@ impl SandboxPolicy {
             net_loopback_allowed,
             net_allow_hosts,
             memory_limit_mb: Some(ent.limits.memory_mb),
+            launch_chain: crate::sandbox::launch_chain::LaunchChain::new(agent_home),
         }
     }
 

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -276,16 +276,26 @@ pub async fn build_provider_runner(
         profile.inner.entitlements.filesystem.clone(),
         agent_home,
     );
-    let read_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::read_file::ReadFileTool::new(session_cwd.clone(), tool_fs.clone()),
-    );
+    // Issue #712 protects this agent's own profile/key. The launch chain
+    // protects every OTHER agent's, plus the binary and the autostart entries
+    // that start them — none of which any entitlement may authorise.
+    let launch_chain = crate::sandbox::launch_chain::LaunchChain::new(agent_home);
+    let read_file_exec: Arc<dyn crate::tools::ToolExecutor> =
+        Arc::new(crate::tools::read_file::ReadFileTool::new(
+            session_cwd.clone(),
+            tool_fs.clone(),
+            launch_chain.clone(),
+        ));
     let read_file_def = read_file_exec.def();
-    let write_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::write_file::WriteFileTool::new(session_cwd.clone(), tool_fs.clone()),
-    );
+    let write_file_exec: Arc<dyn crate::tools::ToolExecutor> =
+        Arc::new(crate::tools::write_file::WriteFileTool::new(
+            session_cwd.clone(),
+            tool_fs.clone(),
+            launch_chain.clone(),
+        ));
     let write_file_def = write_file_exec.def();
     let edit_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::edit_file::EditFileTool::new(session_cwd, tool_fs),
+        crate::tools::edit_file::EditFileTool::new(session_cwd, tool_fs, launch_chain),
     );
     let edit_file_def = edit_file_exec.def();
     let tools_policy = profile.inner.entitlements.tools.clone();

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -10,11 +10,32 @@ use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 pub struct EditFileTool {
     pub session_cwd: SessionCwd,
     pub fs: FilesystemEntitlement,
+    /// MUR's own launch chain. Checked before `fs`; no grant can satisfy it.
+    pub chain: crate::sandbox::launch_chain::LaunchChain,
 }
 
 impl EditFileTool {
-    pub fn new(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
-        Self { session_cwd, fs }
+    pub fn new(
+        session_cwd: SessionCwd,
+        fs: FilesystemEntitlement,
+        chain: crate::sandbox::launch_chain::LaunchChain,
+    ) -> Self {
+        Self {
+            session_cwd,
+            fs,
+            chain,
+        }
+    }
+
+    /// Test-only: construct with an inert launch chain. Production must go
+    /// through `new`, which cannot be called without a real chain.
+    #[cfg(test)]
+    pub fn new_for_test(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
+        Self::new(
+            session_cwd,
+            fs,
+            crate::sandbox::launch_chain::LaunchChain::inert(),
+        )
     }
 }
 
@@ -64,7 +85,7 @@ impl ToolExecutor for EditFileTool {
                 "edit", &joined, &base, &e,
             ))
         })?;
-        check_write_entitlement(&self.fs, &canonical)?;
+        check_write_entitlement(&self.fs, &canonical, &self.chain)?;
 
         let text = std::fs::read_to_string(&canonical).map_err(|e| {
             ToolError::Execution(crate::tools::fs_policy::format_io_error(
@@ -105,7 +126,7 @@ mod tests {
 
     fn tool(td: &tempfile::TempDir) -> EditFileTool {
         let root = td.path().to_str().unwrap();
-        EditFileTool::new(
+        EditFileTool::new_for_test(
             SessionCwd::new(td.path().into()),
             FilesystemEntitlement {
                 read: vec![],

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -174,7 +174,10 @@ mod tests {
         let err = check_write_entitlement(&fs, &agents.join("pm/profile.yaml"), &chain)
             .expect_err("a sibling profile must be refused even under a grant covering it");
         let msg = format!("{err:?}");
-        assert!(msg.contains("entitlements"), "error must explain why: {msg}");
+        assert!(
+            msg.contains("entitlements"),
+            "error must explain why: {msg}"
+        );
 
         // Negative control: the same grant still works for a path outside the
         // set, so the refusal above is the launch chain and not a broken check.

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -115,7 +115,17 @@ pub(crate) fn self_protected(
 pub(crate) fn check_write_entitlement(
     fs: &FilesystemEntitlement,
     canonical: &Path,
+    chain: &crate::sandbox::launch_chain::LaunchChain,
 ) -> Result<(), ToolError> {
+    // Checked first and unconditionally: no entitlement can satisfy this, and
+    // the kernel's bare EPERM reads the same as "not granted", so this is the
+    // only layer that can say which of the two happened.
+    if let Some(reason) = chain.protects_write(canonical) {
+        return Err(ToolError::Execution(format!(
+            "path is part of MUR's launch chain and can never be written: {} ({reason})",
+            canonical.display()
+        )));
+    }
     let under = |roots: &[String]| {
         roots.iter().any(|r| {
             let root = std::fs::canonicalize(r).unwrap_or_else(|_| PathBuf::from(r));
@@ -140,6 +150,37 @@ pub(crate) fn check_write_entitlement(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn launch_chain_beats_an_explicit_write_grant() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Canonical base: the gate compares canonicalized paths, and on macOS
+        // /var is a symlink to /private/var — raw tempdir paths would never
+        // match the canonicalized grant roots the check computes.
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        let agents = home.join("agents");
+        let chain = crate::sandbox::launch_chain::LaunchChain::for_test(
+            &agents.join("mur"),
+            &home.join("bin"),
+            &home.join("home"),
+        );
+
+        // The most permissive grant a user could write.
+        let fs = FilesystemEntitlement {
+            write: vec![home.to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+
+        let err = check_write_entitlement(&fs, &agents.join("pm/profile.yaml"), &chain)
+            .expect_err("a sibling profile must be refused even under a grant covering it");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("entitlements"), "error must explain why: {msg}");
+
+        // Negative control: the same grant still works for a path outside the
+        // set, so the refusal above is the launch chain and not a broken check.
+        check_write_entitlement(&fs, &home.join("skills/x.yaml"), &chain)
+            .expect("unprotected path under the same grant must still be allowed");
+    }
 
     fn eperm() -> std::io::Error {
         std::io::Error::from_raw_os_error(1) // EPERM, "Operation not permitted"
@@ -226,11 +267,23 @@ mod tests {
         let canonical_home = std::fs::canonicalize(&agent_home).unwrap();
         for f in ["profile.yaml", "identity.key"] {
             assert!(
-                check_write_entitlement(&fs, &canonical_home.join(f)).is_err(),
+                check_write_entitlement(
+                    &fs,
+                    &canonical_home.join(f),
+                    &crate::sandbox::launch_chain::LaunchChain::inert(),
+                )
+                .is_err(),
                 "{f} must be write-denied despite the agent-dir grant"
             );
         }
         // The rest of the agent dir stays writable (running.lock etc.).
-        assert!(check_write_entitlement(&fs, &canonical_home.join("running.lock")).is_ok());
+        assert!(
+            check_write_entitlement(
+                &fs,
+                &canonical_home.join("running.lock"),
+                &crate::sandbox::launch_chain::LaunchChain::inert(),
+            )
+            .is_ok()
+        );
     }
 }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -21,20 +21,50 @@ pub struct ReadFileTool {
     pub session_cwd: crate::tools::fs_policy::SessionCwd,
     /// Filesystem grants from the agent profile; checked before every read.
     pub fs: FilesystemEntitlement,
+    /// MUR's own launch chain. Checked before `fs`, and no grant can satisfy it.
+    pub chain: crate::sandbox::launch_chain::LaunchChain,
 }
 
 impl ReadFileTool {
     pub fn new(
         session_cwd: crate::tools::fs_policy::SessionCwd,
         fs: FilesystemEntitlement,
+        chain: crate::sandbox::launch_chain::LaunchChain,
     ) -> Self {
-        Self { session_cwd, fs }
+        Self {
+            session_cwd,
+            fs,
+            chain,
+        }
+    }
+
+    /// Test-only: construct with an inert launch chain. Production must go
+    /// through `new`, which cannot be called without a real chain.
+    #[cfg(test)]
+    pub fn new_for_test(
+        session_cwd: crate::tools::fs_policy::SessionCwd,
+        fs: FilesystemEntitlement,
+    ) -> Self {
+        Self::new(
+            session_cwd,
+            fs,
+            crate::sandbox::launch_chain::LaunchChain::inert(),
+        )
     }
 
     /// Prefix-match `path` against the entitlement lists after
     /// canonicalization. `deny` always wins; a read is allowed when the path
     /// falls under any `read` OR `write` grant (write implies read-back).
     fn check_entitlement(&self, canonical: &Path) -> Result<(), ToolError> {
+        // Before the lists, and unconditionally: reading another agent's
+        // signing key is enough to forge its signed events, and no entitlement
+        // may authorise that.
+        if let Some(reason) = self.chain.protects_read(canonical) {
+            return Err(ToolError::Execution(format!(
+                "path is part of MUR's launch chain and can never be read: {} ({reason})",
+                canonical.display()
+            )));
+        }
         let under = |roots: &[String]| {
             roots.iter().any(|r| {
                 let root = std::fs::canonicalize(r).unwrap_or_else(|_| PathBuf::from(r));
@@ -138,6 +168,41 @@ mod tests {
         }
     }
 
+    #[test]
+    fn sibling_identity_key_is_refused_even_under_a_read_grant() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Canonical base: the check compares canonicalized paths, and on macOS
+        // /var is a symlink to /private/var — raw tempdir paths would never
+        // match the canonicalized grant roots the check computes.
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        let agents = home.join("agents");
+        std::fs::create_dir_all(agents.join("pm")).unwrap();
+        std::fs::write(agents.join("pm/identity.key"), b"SECRET").unwrap();
+        std::fs::write(agents.join("pm/profile.yaml"), b"name: pm\n").unwrap();
+
+        let chain = crate::sandbox::launch_chain::LaunchChain::for_test(
+            &agents.join("mur"),
+            &home.join("bin"),
+            &home.join("home"),
+        );
+        let fs = fs_ent(&[&home.to_string_lossy()], &[], &[]);
+        let tool = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(home.clone()),
+            fs,
+            chain,
+        );
+
+        let err = tool
+            .check_entitlement(&agents.join("pm/identity.key"))
+            .expect_err("a sibling signing key must be refused under any read grant");
+        assert!(format!("{err:?}").contains("forge"), "error must say why");
+
+        // Negative control: the same grant still reads a neighbouring file, so
+        // the refusal is the key rule and not a broken read path.
+        tool.check_entitlement(&agents.join("pm/profile.yaml"))
+            .expect("sibling profile.yaml is not read-protected");
+    }
+
     fn write_tmp(dir: &Path, name: &str, content: &str) -> PathBuf {
         let p = dir.join(name);
         std::fs::write(&p, content).unwrap();
@@ -159,7 +224,7 @@ mod tests {
 
         let shared = SessionCwd::new(home.path().into());
         let bash = BashTool::new(home.path().into(), shared.clone());
-        let reader = ReadFileTool::new(
+        let reader = ReadFileTool::new_for_test(
             shared.clone(),
             fs_ent(
                 &[
@@ -203,7 +268,7 @@ mod tests {
     async fn missing_file_error_names_session_cwd() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[root], &[], &[]),
         );
@@ -217,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn missing_path_is_invalid_input() {
         let td = tempfile::tempdir().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[], &[], &[]),
         );
@@ -230,7 +295,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "l1\nl2\nl3\nl4");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[root], &[], &[]),
         );
@@ -246,7 +311,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "hi");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[], &[root], &[]),
         );
@@ -264,7 +329,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "secret");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[root], &[], &[root]),
         );
@@ -279,7 +344,7 @@ mod tests {
     async fn unentitled_path_is_rejected() {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "hi");
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&["/nonexistent-grant"], &[], &[]),
         );
@@ -294,7 +359,7 @@ mod tests {
     async fn nonexistent_file_is_execution_error() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(
+        let t = ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(td.path().into()),
             fs_ent(&[root], &[], &[]),
         );

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -203,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn read_file_tool_included_when_allowed() {
         use crate::tools::read_file::ReadFileTool;
-        let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new(
+        let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
@@ -227,7 +227,7 @@ mod tests {
     #[tokio::test]
     async fn read_file_tool_excluded_when_denied() {
         use crate::tools::read_file::ReadFileTool;
-        let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new(
+        let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
@@ -257,7 +257,7 @@ mod tests {
     #[tokio::test]
     async fn write_file_tool_included_when_allowed() {
         use crate::tools::write_file::WriteFileTool;
-        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
+        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
@@ -281,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn write_file_tool_excluded_when_denied() {
         use crate::tools::write_file::WriteFileTool;
-        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
+        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn edit_file_tool_included_when_allowed() {
         use crate::tools::edit_file::EditFileTool;
-        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
+        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
@@ -335,7 +335,7 @@ mod tests {
     #[tokio::test]
     async fn edit_file_tool_excluded_when_denied() {
         use crate::tools::edit_file::EditFileTool;
-        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
+        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new_for_test(
             crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -108,7 +108,8 @@ mod tests {
     async fn creates_and_overwrites() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
+        let t =
+            WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let r = t
             .execute(serde_json::json!({"path": "a.txt", "content": "one"}))
             .await
@@ -127,7 +128,8 @@ mod tests {
     async fn missing_parent_fails_loud() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
+        let t =
+            WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let err = t
             .execute(serde_json::json!({"path": "no/such/dir/a.txt", "content": "x"}))
             .await
@@ -147,8 +149,10 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("not write-entitled"));
-        let denied =
-            WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[root]));
+        let denied = WriteFileTool::new_for_test(
+            SessionCwd::new(td.path().into()),
+            fs_ent(&[root], &[root]),
+        );
         let err2 = denied
             .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
             .await

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -9,11 +9,31 @@ use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 pub struct WriteFileTool {
     pub session_cwd: SessionCwd,
     pub fs: FilesystemEntitlement,
+    /// MUR's own launch chain. Checked before `fs`; no grant can satisfy it.
+    pub chain: crate::sandbox::launch_chain::LaunchChain,
 }
 
 impl WriteFileTool {
-    pub fn new(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
-        Self { session_cwd, fs }
+    pub fn new(
+        session_cwd: SessionCwd,
+        fs: FilesystemEntitlement,
+        chain: crate::sandbox::launch_chain::LaunchChain,
+    ) -> Self {
+        Self {
+            session_cwd,
+            fs,
+            chain,
+        }
+    }
+    /// Test-only: construct with an inert launch chain. Production must go
+    /// through `new`, which cannot be called without a real chain.
+    #[cfg(test)]
+    pub fn new_for_test(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
+        Self::new(
+            session_cwd,
+            fs,
+            crate::sandbox::launch_chain::LaunchChain::inert(),
+        )
     }
 }
 
@@ -62,7 +82,7 @@ impl ToolExecutor for WriteFileTool {
             .file_name()
             .ok_or_else(|| ToolError::InvalidInput("path has no file name".into()))?;
         let target = canonical_parent.join(file_name);
-        check_write_entitlement(&self.fs, &target)?;
+        check_write_entitlement(&self.fs, &target, &self.chain)?;
         std::fs::write(&target, content).map_err(|e| {
             ToolError::Execution(crate::tools::fs_policy::format_io_error(
                 "write", &target, &base, &e,
@@ -88,7 +108,7 @@ mod tests {
     async fn creates_and_overwrites() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
+        let t = WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let r = t
             .execute(serde_json::json!({"path": "a.txt", "content": "one"}))
             .await
@@ -107,7 +127,7 @@ mod tests {
     async fn missing_parent_fails_loud() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
+        let t = WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let err = t
             .execute(serde_json::json!({"path": "no/such/dir/a.txt", "content": "x"}))
             .await
@@ -121,14 +141,14 @@ mod tests {
     async fn write_requires_write_grant_and_deny_wins() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let none = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[], &[]));
+        let none = WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[], &[]));
         let err = none
             .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("not write-entitled"));
         let denied =
-            WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[root]));
+            WriteFileTool::new_for_test(SessionCwd::new(td.path().into()), fs_ent(&[root], &[root]));
         let err2 = denied
             .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
             .await

--- a/mur-core/src/cmd/agent/cli/access.rs
+++ b/mur-core/src/cmd/agent/cli/access.rs
@@ -43,15 +43,12 @@ fn path_within_roots(target: &Path, roots: &[String], home: &Path) -> bool {
 
 /// Refuse to auto-grant an over-broad root: `/`, the user's whole home, or any
 /// path shallower than two normal components (e.g. `/Users`, `/Volumes`, `/tmp`).
+///
+/// One judgement, one home: `launch_chain.rs` holds the union (it also knows
+/// `/usr`, `/opt`, `/opt/homebrew` and volume roots), and the `perm` boundary
+/// refuses with the same helper. See `reject_ungrantable` in `perm.rs`.
 fn is_overbroad_root(p: &Path, home: &Path) -> bool {
-    if p == Path::new("/") || p == home {
-        return true;
-    }
-    let depth = p
-        .components()
-        .filter(|c| matches!(c, std::path::Component::Normal(_)))
-        .count();
-    depth < 2
+    mur_agent_runtime::sandbox::launch_chain::is_overbroad_grant_root(p, home)
 }
 
 /// The git toplevel containing `cwd`, if any.

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -362,7 +362,9 @@ mod tests {
         let bin = mur_home.join("bin");
         let home = mur_home.join("home");
         let chain = mur_agent_runtime::sandbox::launch_chain::LaunchChain::for_test(
-            &agent_home, &bin, &home,
+            &agent_home,
+            &bin,
+            &home,
         );
 
         let fs = mur_common::agent::FilesystemEntitlement {

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -44,6 +44,29 @@ pub fn dead_grants(fs: &mur_common::agent::FilesystemEntitlement) -> Vec<(&'stat
         .collect()
 }
 
+/// Grants the launch chain now makes inert. Reported, never removed: an
+/// upgrade that rewrites a user's entitlements is exactly the surprise this
+/// work exists to remove.
+pub fn neutralised_grants(
+    fs: &mur_common::agent::FilesystemEntitlement,
+    chain: &mur_agent_runtime::sandbox::launch_chain::LaunchChain,
+) -> Vec<(PathBuf, &'static str)> {
+    let mut out = Vec::new();
+    for raw in &fs.write {
+        let p = mur_agent_runtime::sandbox::policy::expand_entitlement_path(raw);
+        if let Some(reason) = chain.protects_write(&p) {
+            out.push((p, reason));
+        }
+    }
+    for raw in &fs.read {
+        let p = mur_agent_runtime::sandbox::policy::expand_entitlement_path(raw);
+        if let Some(reason) = chain.protects_read(&p) {
+            out.push((p, reason));
+        }
+    }
+    out
+}
+
 /// `<mur_home>` authoring dirs the concierge has no write grant covering.
 ///
 /// An upgrade deliberately does not widen an existing agent's sandbox, so an
@@ -164,6 +187,17 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
             .unwrap_or_default()
     };
 
+    // Grants the launch chain neutralised: profile says granted, sandbox says
+    // never. Same best-effort discipline as `dead` above.
+    let neutralised = |name: &str| -> Vec<(PathBuf, &'static str)> {
+        let chain = mur_agent_runtime::sandbox::launch_chain::LaunchChain::new(
+            &mur_home.join("agents").join(name),
+        );
+        super::load_profile_for_edit(name)
+            .map(|(_p, prof)| neutralised_grants(&prof.entitlements.filesystem, &chain))
+            .unwrap_or_default()
+    };
+
     // Checked outside the rows loop on purpose: `rows` only holds agents with a
     // running.lock, and "my concierge cannot author anything" is exactly the
     // question you ask about an agent that is not up.
@@ -245,6 +279,15 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                     r.name
                 );
             }
+            for (p, reason) in neutralised(&r.name) {
+                println!("  {}: grant has NO EFFECT: {}", r.name, p.display());
+                println!("    {reason}");
+                println!(
+                    "    remove with: mur agent perm deny-path {} {}",
+                    r.name,
+                    p.display()
+                );
+            }
 
             // Best-effort program-deps preflight — never blocks or fails the
             // doctor. A load/aggregate error is swallowed; the runtime-doctor
@@ -309,6 +352,33 @@ mod tests {
         assert_eq!(found.len(), 1, "got {found:?}");
         assert_eq!(found[0].0, "write");
         assert_eq!(found[0].1, gone);
+    }
+
+    #[test]
+    fn neutralised_grants_reports_all_three_real_world_escapes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents/mur");
+        let bin = mur_home.join("bin");
+        let home = mur_home.join("home");
+        let chain = mur_agent_runtime::sandbox::launch_chain::LaunchChain::for_test(
+            &agent_home, &bin, &home,
+        );
+
+        let fs = mur_common::agent::FilesystemEntitlement {
+            write: vec![
+                mur_home.join("agents").to_string_lossy().into_owned(),
+                bin.join("mur-agent-runtime").to_string_lossy().into_owned(),
+                mur_home.join("skills").to_string_lossy().into_owned(),
+            ],
+            ..Default::default()
+        };
+
+        let found = neutralised_grants(&fs, &chain);
+        assert_eq!(found.len(), 2, "got {found:?}");
+        // Negative control: the legitimate authoring grant is not reported, so the
+        // finding count reflects the rules rather than "everything is flagged".
+        assert!(!found.iter().any(|(p, _)| p.ends_with("skills")));
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -161,7 +161,42 @@ fn reject_dead_grant(path_arg: &str) -> Result<()> {
     )
 }
 
+/// Refuse a grant that no sandbox would honour, before it reaches the profile.
+///
+/// Distinct from `reject_dead_grant`, which refuses a path that does not exist
+/// yet. This one refuses paths that must never be granted at all.
+fn reject_ungrantable(name: &str, path_arg: &str, write: bool) -> Result<()> {
+    use mur_agent_runtime::sandbox::launch_chain::{LaunchChain, is_overbroad_grant_root};
+
+    let p = mur_agent_runtime::sandbox::policy::expand_entitlement_path(path_arg);
+    let agent_home = super::resolve_mur_home()?.join("agents").join(name);
+    let chain = LaunchChain::new(&agent_home);
+
+    let hit = if write {
+        chain.protects_write(&p)
+    } else {
+        chain.protects_read(&p)
+    };
+    if let Some(reason) = hit {
+        anyhow::bail!(
+            "{} is part of MUR's launch chain and can never be granted: {reason}",
+            p.display()
+        );
+    }
+
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"));
+    if is_overbroad_grant_root(&p, &home) {
+        anyhow::bail!(
+            "{} is too broad to grant — it covers the whole machine, the whole \
+             home directory, or a volume root. Grant the specific project dir instead.",
+            p.display()
+        );
+    }
+    Ok(())
+}
+
 pub fn cmd_perm_allow_read(name: &str, path_arg: &str) -> Result<()> {
+    reject_ungrantable(name, path_arg, false)?;
     reject_dead_grant(path_arg)?;
     let (path, mut profile) = load_profile_for_edit(name)?;
     if !profile
@@ -183,6 +218,7 @@ pub fn cmd_perm_allow_read(name: &str, path_arg: &str) -> Result<()> {
 }
 
 pub fn cmd_perm_allow_write(name: &str, path_arg: &str) -> Result<()> {
+    reject_ungrantable(name, path_arg, true)?;
     reject_dead_grant(path_arg)?;
     let (path, mut profile) = load_profile_for_edit(name)?;
     if !profile

--- a/mur-core/tests/agent_perm.rs
+++ b/mur-core/tests/agent_perm.rs
@@ -251,3 +251,41 @@ fn allow_write_refuses_a_path_that_does_not_exist() {
             .contains(&missing_s)
     );
 }
+
+#[test]
+fn allow_write_refuses_the_launch_chain_and_overbroad_roots() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    mur_create(mur_home.path(), bin_dir.path(), "agent_x");
+
+    let sibling = mur_home.path().join("agents/other");
+    std::fs::create_dir_all(&sibling).unwrap();
+    let sibling_s = sibling.to_string_lossy().into_owned();
+
+    let out = run(
+        mur_home.path(),
+        &["agent", "perm", "allow-write", "agent_x", &sibling_s],
+    );
+    assert!(!out.status.success(), "sibling agent dir must be refused");
+    let err = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(err.contains("launch chain"), "error must name the rule: {err}");
+
+    let out = run(mur_home.path(), &["agent", "perm", "allow-write", "agent_x", "/"]);
+    assert!(!out.status.success(), "root must be refused");
+
+    // Negative control: an ordinary existing dir under the same mur_home is
+    // still grantable, so the refusals above are the new rules and not a
+    // blanket failure.
+    let ok_dir = mur_home.path().join("artifacts");
+    std::fs::create_dir_all(&ok_dir).unwrap();
+    let ok_s = ok_dir.to_string_lossy().into_owned();
+    let out = run(
+        mur_home.path(),
+        &["agent", "perm", "allow-write", "agent_x", &ok_s],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/mur-core/tests/agent_perm.rs
+++ b/mur-core/tests/agent_perm.rs
@@ -268,9 +268,15 @@ fn allow_write_refuses_the_launch_chain_and_overbroad_roots() {
     );
     assert!(!out.status.success(), "sibling agent dir must be refused");
     let err = String::from_utf8_lossy(&out.stderr).into_owned();
-    assert!(err.contains("launch chain"), "error must name the rule: {err}");
+    assert!(
+        err.contains("launch chain"),
+        "error must name the rule: {err}"
+    );
 
-    let out = run(mur_home.path(), &["agent", "perm", "allow-write", "agent_x", "/"]);
+    let out = run(
+        mur_home.path(),
+        &["agent", "perm", "allow-write", "agent_x", "/"],
+    );
     assert!(!out.status.success(), "root must be refused");
 
     // Negative control: an ordinary existing dir under the same mur_home is


### PR DESCRIPTION
Implements #924 — the launch chain (what starts next, and with what authority) is now closed from inside the sandbox, in four enforcement layers plus a reporting layer.

- **Tool gate** (`fs_policy.rs`, read/write/edit tools): cross-OS predicate on the protected set — other agents' directories, the runtime binary + per-agent symlinks, OS autostart dirs. `identity.key` of sibling agents is read-protected too (reading it is enough to forge signed channel events). Predicate, not path list: closed under agents created after seal.
- **macOS SBPL** (`macos.rs`): three ordering tiers — deny the whole agents tree, re-allow this agent's own home, then re-assert the self-protection denies on its own profile/identity.key. Last-match-wins means the order is the mechanism.
- **Linux Landlock** (`linux.rs`): pure allow-list, so the carve-out has no equivalent — a write grant that contains a protected path is dropped whole, fail-closed, and recorded in `SandboxPolicy.dropped_grants`. Own home is exempt so the force-grant on `<mur_home>/agents/<self>` survives.
- **Grant time** (`mur agent perm allow-read/allow-write`): refuses launch-chain members and overbroad roots before they reach the profile; the duplicated overbroad-root judgement in `access.rs` folds onto one shared helper.
- **Reporting** (`mur agent runtime-doctor`): names grants the launch chain neutralised, with the reason and the `deny-path` to remove them. Reported, never removed.

Docs: README bullet on the protected set (in this PR). The mur-server troubleshooting page ("do not" → "cannot") goes in a **separate PR** — it deploys to the public app.mur.run and is not auto-merged.

Testing: full gate green — `cargo fmt` (3 manifests), 5941 nextest (mur-agent-runtime + mur-core), `cargo clippy --all-targets -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)