### PR TITLE
feat: binary attestation (launch-chain follow-on)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
+      - name: Create test signing identity (macOS)
+        if: runner.os == 'macOS'
+        run: bash scripts/test-signing-identity.sh
       # `cargo nextest run` builds + runs in one cargo invocation; `cargo
       # check --all` was a redundant pre-check whose .rmeta artifacts don't
       # help nextest's downstream test-binary build (different codegen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           codesign --force --options runtime --timestamp \
             --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
             target/aarch64-apple-darwin/release/mur-agent-runtime
-          codesign --verify --verbose target/aarch64-apple-darwin/release/mur-agent-runtime
+          codesign --verify --verbose -R "=anchor apple generic and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" target/aarch64-apple-darwin/release/mur-agent-runtime
         env:
           APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -469,7 +469,7 @@ jobs:
           codesign --force --options runtime --timestamp \
             --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
             mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
-          codesign --verify --verbose mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
+          codesign --verify --verbose -R "=anchor apple generic and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
         env:
           APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
             Add-MpPreference -ExclusionExtension $e -ErrorAction SilentlyContinue
           }
 
+      - name: Set release-marker env (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          echo "MUR_EMBED_RELEASE_MARKER=1" >> "$GITHUB_ENV"
+          echo "MUR_APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> "$GITHUB_ENV"
+
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-gnu'
         run: cargo build --release --locked --target ${{ matrix.target }}
@@ -140,6 +146,24 @@ jobs:
         run: cross build --release --locked --target ${{ matrix.target }}
         env:
           MUR_WEB_DIST: ${{ github.workspace }}/mur-web-src/dist
+
+      - name: Import Apple signing certs (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}
+          p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+
+      - name: Sign mur-agent-runtime (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
+            target/aarch64-apple-darwin/release/mur-agent-runtime
+          codesign --verify --verbose target/aarch64-apple-darwin/release/mur-agent-runtime
+        env:
+          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -380,6 +404,9 @@ jobs:
 
       # Build Hub UI and mur sidecars in parallel — both are independent at this point.
       - name: Build Hub UI + mur sidecars (parallel)
+        env:
+          MUR_EMBED_RELEASE_MARKER: '1'
+          MUR_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           (cd mur-hub-gui/ui && npm ci && npm run build) &
           UI_PID=$!
@@ -436,6 +463,16 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}
           p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+
+      - name: Sign agent-runtime sidecar
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
+            mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
+          codesign --verify --verbose mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
+        env:
+          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Build, sign, bundle .dmg
         env:

--- a/README.md
+++ b/README.md
@@ -403,7 +403,9 @@ Agent** wizard offers the same catalog as a source.
   still can't write. Some paths can never be granted at all — another agent's
   directory, the runtime binary, an autostart directory — because they decide
   what starts next; `allow-read` / `allow-write` refuse them, and
-  `runtime-doctor` names any such grant that was already sitting in a profile.
+  `runtime-doctor` names any such grant that was already sitting in a profile,
+  and the runtime binary itself is signed by MUR's Developer ID in release
+  builds — a swapped binary is refused at spawn, never run.
   A freshly seeded MUR owns
   `~/.mur/{skills,workflows,fleets,artifacts}`, so it can build the skill,
   workflow or fleet it just designed instead of handing you a list of commands.

--- a/docs/superpowers/plans/2026-08-12-binary-attestation.md
+++ b/docs/superpowers/plans/2026-08-12-binary-attestation.md
@@ -77,7 +77,7 @@ mod tests {
         let req = production_requirement();
         assert!(req.contains("anchor apple generic"), "req: {req}");
         assert!(req.contains("subject.OU"), "req: {req}");
-        assert!(req.starts_with("=designated =>"), "req: {req}");
+        assert!(req.starts_with("=anchor apple generic and"), "req: {req}");
     }
 
     // ── Behavioral matrix (macOS + test identity) ────────────────────────
@@ -177,10 +177,11 @@ pub const APPLE_TEAM_ID: &str = env!("MUR_APPLE_TEAM_ID");
 
 /// The designated requirement used in production: valid signature chaining to
 /// Apple plus a leaf certificate owned by MUR's team.
+/// Note: `=designated => ...` is NOT valid verification syntax (`designated`
+/// is a read-side token only); the plain inline form below is the verified
+/// canonical expression (wrong OU → exit 3, correct OU → exit 0).
 pub(crate) fn production_requirement() -> String {
-    format!(
-        "=designated => anchor apple generic and certificate leaf[subject.OU] = \"{APPLE_TEAM_ID}\""
-    )
+    format!("=anchor apple generic and certificate leaf[subject.OU] = \"{APPLE_TEAM_ID}\"")
 }
 
 /// Verify `path` is a legitimate runtime binary. No-op unless this is a

--- a/docs/superpowers/plans/2026-08-12-binary-attestation.md
+++ b/docs/superpowers/plans/2026-08-12-binary-attestation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Refuse to spawn `mur-agent-runtime` unless its signature is valid and belongs to MUR's team, gated to release builds.
 
-**Architecture:** A shared helper in `mur-common` (`binary_attestation.rs`) whose build-marker const is set by `build.rs` env, runs `codesign --verify --strict -R "=designated => anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\""` on macOS release builds and is a no-op otherwise. Mounted at all three spawn paths (CLI detached, launchd/systemd, Hub sidecar). The release pipeline signs the runtime in the matrix job (where the tar.gz is assembled) and in the Hub job, and sets the marker env.
+**Architecture:** A shared helper in `mur-common` (`binary_attestation.rs`) whose build-marker const is set by `build.rs` env, runs `codesign --verify --strict -R "=anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\""` on macOS release builds and is a no-op otherwise. Mounted at all three spawn paths (CLI detached, launchd/systemd, Hub sidecar). The release pipeline signs the runtime in the matrix job (where the tar.gz is assembled) and in the Hub job, and sets the marker env.
 
 **Tech Stack:** Rust (edition 2024), `codesign` subprocess, GitHub Actions (release.yml + ci.yml).
 
@@ -104,7 +104,7 @@ mod tests {
         let f = dir.join("runtime");
         std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
         std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let req = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        let req = format!("=certificate leaf[subject.OU] = \"{ou}\"");
         let err = verify_with_requirement(&f, &req).expect_err("unsigned must fail");
         assert!(matches!(err, AttestError::VerificationFailed { .. }));
         let _ = std::fs::remove_dir_all(&dir);
@@ -119,7 +119,7 @@ mod tests {
         std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
         let out = std::process::Command::new("codesign").args(["--force", "-s", "-"]).arg(&f).output().unwrap();
         assert!(out.status.success(), "ad-hoc sign failed: {}", String::from_utf8_lossy(&out.stderr));
-        let req = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        let req = format!("=certificate leaf[subject.OU] = \"{ou}\"");
         let err = verify_with_requirement(&f, &req).expect_err("ad-hoc (no OU) must fail");
         assert!(matches!(err, AttestError::VerificationFailed { .. }));
         let _ = std::fs::remove_dir_all(&dir);
@@ -138,11 +138,11 @@ mod tests {
             .output()
             .unwrap();
         assert!(out.status.success(), "sign failed: {}", String::from_utf8_lossy(&out.stderr));
-        let wrong = format!("=designated => certificate leaf[subject.OU] = \"WRONGTEAM000\"");
+        let wrong = format!("=certificate leaf[subject.OU] = \"WRONGTEAM000\"");
         let err = verify_with_requirement(&f, &wrong).expect_err("wrong OU must fail");
         assert!(matches!(err, AttestError::VerificationFailed { .. }));
         // Positive control: the same signed binary passes with the right OU.
-        let right = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        let right = format!("=certificate leaf[subject.OU] = \"{ou}\"");
         verify_with_requirement(&f, &right).expect("matching OU must pass");
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -177,7 +177,7 @@ pub const APPLE_TEAM_ID: &str = env!("MUR_APPLE_TEAM_ID");
 
 /// The designated requirement used in production: valid signature chaining to
 /// Apple plus a leaf certificate owned by MUR's team.
-/// Note: `=designated => ...` is NOT valid verification syntax (`designated`
+/// Note: `=...` is NOT valid verification syntax (`designated`
 /// is a read-side token only); the plain inline form below is the verified
 /// canonical expression (wrong OU → exit 3, correct OU → exit 0).
 pub(crate) fn production_requirement() -> String {

--- a/docs/superpowers/plans/2026-08-12-binary-attestation.md
+++ b/docs/superpowers/plans/2026-08-12-binary-attestation.md
@@ -1,0 +1,607 @@
+# Binary Attestation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refuse to spawn `mur-agent-runtime` unless its signature is valid and belongs to MUR's team, gated to release builds.
+
+**Architecture:** A shared helper in `mur-common` (`binary_attestation.rs`) whose build-marker const is set by `build.rs` env, runs `codesign --verify --strict -R "=designated => anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\""` on macOS release builds and is a no-op otherwise. Mounted at all three spawn paths (CLI detached, launchd/systemd, Hub sidecar). The release pipeline signs the runtime in the matrix job (where the tar.gz is assembled) and in the Hub job, and sets the marker env.
+
+**Tech Stack:** Rust (edition 2024), `codesign` subprocess, GitHub Actions (release.yml + ci.yml).
+
+## Global Constraints
+
+- Fail-closed on `Err` at every mount point — no warn-and-continue.
+- Negative controls are not optional in tests (launch-chain rule).
+- Verification runs only when the spawner binary was built with `MUR_EMBED_RELEASE_MARKER=1` (release pipeline only) — never gated on `debug_assertions`.
+- Build-time fail-closed: marker set but `MUR_APPLE_TEAM_ID` missing → build fails.
+- macOS-only verification; Linux/Windows are no-ops.
+- Canonicalize the target path before verifying (symlink + `/var`→`/private/var`).
+- The `=` prefix is required in the `-R` requirement string (full requirement, not named).
+
+---
+
+### Task 1: `mur-common` build marker + attestation helper
+
+**Files:**
+- Modify: `mur-common/build.rs`
+- Create: `mur-common/src/binary_attestation.rs`
+- Modify: `mur-common/src/lib.rs` (register module)
+- Create: `scripts/test-signing-identity.sh` (macOS test identity, reused by CI)
+- Modify: `.github/workflows/ci.yml` (macOS test job runs the identity script)
+
+**Interfaces:**
+- Produces: `mur_common::binary_attestation::{IS_EMBEDDED_RELEASE: bool, APPLE_TEAM_ID: &str, verify_runtime_signature(path: &Path) -> Result<(), AttestError>, verify_with_requirement(path: &Path, requirement: &str) -> Result<(), AttestError> /* #[doc(hidden)] */, AttestError: Debug + Display + Error}`. `AttestError::VerificationFailed { path: PathBuf, stderr: String }` and `AttestError::Io { path: PathBuf, source: std::io::Error }`.
+
+- [ ] **Step 1: Extend `mur-common/build.rs`**
+
+```rust
+use std::process::Command;
+
+fn main() {
+    // (existing MUR_GIT_SHA block, unchanged)
+
+    // Without rerun-if-env-changed, flipping the env vars later would keep
+    // the stale consts baked into the crate — a silent attestation gap.
+    println!("cargo:rerun-if-env-changed=MUR_EMBED_RELEASE_MARKER");
+    println!("cargo:rerun-if-env-changed=MUR_APPLE_TEAM_ID");
+    let marker = std::env::var("MUR_EMBED_RELEASE_MARKER").is_ok();
+    let team_id = std::env::var("MUR_APPLE_TEAM_ID").unwrap_or_default();
+    if marker && team_id.is_empty() {
+        panic!("MUR_EMBED_RELEASE_MARKER=1 requires MUR_APPLE_TEAM_ID to be set");
+    }
+    println!("cargo:rustc-env=MUR_EMBEDDED_RELEASE={}", if marker { "1" } else { "0" });
+    println!("cargo:rustc-env=MUR_APPLE_TEAM_ID={team_id}");
+}
+```
+
+- [ ] **Step 2: Write the failing tests in `mur-common/src/binary_attestation.rs`** (tests ship with the module; run them before the implementation below exists to see them fail on "module not found")
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // Compile-time gates: this binary is built without the release marker in
+    // CI, so IS_EMBEDDED_RELEASE is false here — the skip behavior is the
+    // negative control for every behavioral test below.
+    #[test]
+    fn dev_build_never_verifies() {
+        assert!(!IS_EMBEDDED_RELEASE);
+        // verify_runtime_signature on a garbage path must still be Ok in dev:
+        assert!(verify_runtime_signature(Path::new("/nonexistent/nope")).is_ok());
+    }
+
+    #[test]
+    fn production_requirement_binds_anchor_and_team() {
+        let req = production_requirement();
+        assert!(req.contains("anchor apple generic"), "req: {req}");
+        assert!(req.contains("subject.OU"), "req: {req}");
+        assert!(req.starts_with("=designated =>"), "req: {req}");
+    }
+
+    // ── Behavioral matrix (macOS + test identity) ────────────────────────
+    // These run only when MUR_TEST_SIGNING_OU is set (CI macOS job runs
+    // scripts/test-signing-identity.sh first). Negative controls included.
+    fn test_dir(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("mur-attest-{}-{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn test_ou() -> Option<String> {
+        std::env::var("MUR_TEST_SIGNING_OU").ok()
+    }
+
+    #[test]
+    fn unsigned_file_fails_test_requirement() {
+        let Some(ou) = test_ou() else {
+            eprintln!("skipping: MUR_TEST_SIGNING_OU not set");
+            return;
+        };
+        let dir = test_dir("unsigned");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let req = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        let err = verify_with_requirement(&f, &req).expect_err("unsigned must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn adhoc_signed_fails_test_requirement() {
+        let Some(ou) = test_ou() else { eprintln!("skipping"); return };
+        let dir = test_dir("adhoc");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let out = std::process::Command::new("codesign").args(["--force", "-s", "-"]).arg(&f).output().unwrap();
+        assert!(out.status.success(), "ad-hoc sign failed: {}", String::from_utf8_lossy(&out.stderr));
+        let req = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        let err = verify_with_requirement(&f, &req).expect_err("ad-hoc (no OU) must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wrong_ou_fails_test_requirement() {
+        let Some(ou) = test_ou() else { eprintln!("skipping"); return };
+        let dir = test_dir("wrongou");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let out = std::process::Command::new("codesign")
+            .args(["--force", "-s", &format!("Mur Test ({ou})")])
+            .arg(&f)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "sign failed: {}", String::from_utf8_lossy(&out.stderr));
+        let wrong = format!("=designated => certificate leaf[subject.OU] = \"WRONGTEAM000\"");
+        let err = verify_with_requirement(&f, &wrong).expect_err("wrong OU must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        // Positive control: the same signed binary passes with the right OU.
+        let right = format!("=designated => certificate leaf[subject.OU] = \"{ou}\"");
+        verify_with_requirement(&f, &right).expect("matching OU must pass");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail to compile** (module not registered)
+
+Run: `cargo test -p mur-common --lib binary_attestation`
+Expected: error `could not find binary_attestation in mur_common` (module not registered yet).
+
+- [ ] **Step 4: Implement `mur-common/src/binary_attestation.rs`**
+
+```rust
+//! Binary attestation: verify that a spawned `mur-agent-runtime` carries a
+//! valid signature from MUR's Developer ID team (launch-chain follow-on,
+//! spec 2026-08-12). Gated to release builds by the build marker.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// True when this binary was built with `MUR_EMBED_RELEASE_MARKER=1`
+/// (the release pipeline). Dev builds never verify.
+pub const IS_EMBEDDED_RELEASE: bool = env!("MUR_EMBEDDED_RELEASE") == "1";
+
+/// MUR's Apple Developer Team ID (empty in dev builds; build.rs panics if the
+/// marker is set without it).
+pub const APPLE_TEAM_ID: &str = env!("MUR_APPLE_TEAM_ID");
+
+/// The designated requirement used in production: valid signature chaining to
+/// Apple plus a leaf certificate owned by MUR's team.
+pub(crate) fn production_requirement() -> String {
+    format!(
+        "=designated => anchor apple generic and certificate leaf[subject.OU] = \"{APPLE_TEAM_ID}\""
+    )
+}
+
+/// Verify `path` is a legitimate runtime binary. No-op unless this is a
+/// macOS release build. Fail-closed: any verification error is returned.
+pub fn verify_runtime_signature(path: &Path) -> Result<(), AttestError> {
+    if !IS_EMBEDDED_RELEASE || !cfg!(target_os = "macos") {
+        return Ok(());
+    }
+    // Canonicalize so a symlink or /var → /private/var redirect is verified
+    // on the real file.
+    let real = path
+        .canonicalize()
+        .map_err(|e| AttestError::Io { path: path.to_path_buf(), source: e })?;
+    verify_with_requirement(&real, &production_requirement())
+}
+
+/// Testable core: run `codesign --verify --strict -R <requirement>` on `path`.
+#[doc(hidden)]
+pub fn verify_with_requirement(path: &Path, requirement: &str) -> Result<(), AttestError> {
+    let out = Command::new("codesign")
+        .args(["--verify", "--strict", "-R", requirement])
+        .arg(path)
+        .output()
+        .map_err(|e| AttestError::Io { path: path.to_path_buf(), source: e })?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(AttestError::VerificationFailed {
+            path: path.to_path_buf(),
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum AttestError {
+    /// The binary failed the designated requirement.
+    VerificationFailed { path: PathBuf, stderr: String },
+    /// Could not read/canonicalize the path or run codesign.
+    Io { path: PathBuf, source: std::io::Error },
+}
+
+impl fmt::Display for AttestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VerificationFailed { path, stderr } => write!(
+                f,
+                "runtime binary at {} failed signature verification: {stderr}",
+                path.display()
+            ),
+            Self::Io { path, source } => {
+                write!(f, "cannot verify runtime binary at {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for AttestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::VerificationFailed { .. } => None,
+        }
+    }
+}
+```
+
+Register the module in `mur-common/src/lib.rs` (alphabetical, near `bridge`): `pub mod binary_attestation;`
+
+- [ ] **Step 5: Run tests to verify they pass** (dev build: gate tests pass; behavioral tests print "skipping")
+
+Run: `cargo test -p mur-common --lib binary_attestation`
+Expected: 3 pass (`dev_build_never_verifies`, `production_requirement_binds_anchor_and_team`, and one behavioral test that skips). On macOS with `MUR_TEST_SIGNING_OU` set (Step 7), the behavioral matrix runs.
+
+- [ ] **Step 6: Write `scripts/test-signing-identity.sh`** (macOS-only; creates a throwaway self-signed identity with a fixed OU and installs it in a temp keychain)
+
+```bash
+#!/bin/bash
+# Create a throwaway self-signed code-signing identity for the attestation
+# behavioral tests. macOS only; exits 0 with a notice on other platforms.
+# Prints the OU (via MUR_TEST_SIGNING_OU in GITHUB_ENV when under CI).
+set -euo pipefail
+if [ "$(uname)" != "Darwin" ]; then
+  echo "test-signing-identity: not macOS, skipping"
+  exit 0
+fi
+OU="${MUR_TEST_TEAM_ID:-TESTTEAMID123}"
+CN="Mur Test ($OU)"
+KC_DIR="${TMPDIR:-/tmp}/mur-attest-keychain"
+rm -rf "$KC_DIR"; mkdir -p "$KC_DIR"
+KC="$KC_DIR/test.keychain"
+P12="$KC_DIR/test.p12"
+PASS="mur"
+openssl req -x509 -newkey rsa:2048 -keyout "$KC_DIR/key.pem" -out "$KC_DIR/cert.pem" \
+  -days 1 -nodes -subj "/OU=$OU/CN=$CN" >/dev/null 2>&1
+openssl pkcs12 -export -out "$P12" -inkey "$KC_DIR/key.pem" -in "$KC_DIR/cert.pem" \
+  -passout "pass:$PASS" >/dev/null 2>&1
+security create-keychain -p "$PASS" "$KC"
+security import "$P12" -k "$KC" -P "$PASS" -T /usr/bin/codesign >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$PASS" "$KC" >/dev/null 2>&1
+security default-keychain -s "$KC"
+security unlock-keychain -p "$PASS" "$KC"
+echo "test-signing-identity: identity '$CN' ready in $KC"
+echo "MUR_TEST_SIGNING_OU=$OU" >> "${GITHUB_ENV:-/dev/null}"
+```
+
+- [ ] **Step 7: CI hook — run the identity script on the macOS test job**
+
+In `.github/workflows/ci.yml`, in the `Test (${{ matrix.os }})` job, add a step before the cargo test step, gated to macOS:
+
+```yaml
+      - name: Create test signing identity (macOS)
+        if: runner.os == 'macOS'
+        run: bash scripts/test-signing-identity.sh
+```
+
+- [ ] **Step 8: Full gate + commit**
+
+Run: `cargo test -p mur-common && cargo fmt --check && cargo clippy -p mur-common --all-targets -- -D warnings`
+Then:
+```bash
+git add mur-common/build.rs mur-common/src/binary_attestation.rs mur-common/src/lib.rs scripts/test-signing-identity.sh .github/workflows/ci.yml
+git commit -m "feat(common): binary attestation helper with build-marker gating
+
+codesign requirement binds anchor apple generic + team OU; no-op in dev
+builds and off-macOS. Behavioral matrix runs on macOS CI with a throwaway
+self-signed identity; negative controls are mandatory.
+"
+```
+
+### Task 2: Mount at CLI start paths (`mur-core/src/cmd/agent/start.rs`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/start.rs`
+
+**Interfaces:**
+- Consumes: `mur_common::binary_attestation::verify_runtime_signature`
+- Produces: `fn verify_runtime_at(symlink: &Path) -> Result<()>` — canonicalizes then verifies; used by all three paths inside `cmd_start`.
+
+- [ ] **Step 1: Write the failing unit test** (`start.rs` has no test module today — append `#[cfg(test)] mod tests` at the end of the file)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn verify_runtime_at_surfaces_resolution_errors() {
+        // Even in a dev build (where verification is a no-op), a target that
+        // cannot be resolved must fail — the mount never spawns blind.
+        let err = verify_runtime_at(Path::new("/nonexistent/mur_agent_nope")).unwrap_err();
+        assert!(err.to_string().contains("/nonexistent/mur_agent_nope"), "{err}");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-core --lib cmd::agent::start`
+Expected: FAIL — `verify_runtime_at` not defined.
+
+- [ ] **Step 3: Implement** — add after `cmd_start`'s helper imports:
+
+```rust
+/// Resolve a runtime symlink (canonicalizing through symlinks and the
+/// /var → /private/var redirect) and verify its signature. Dev builds
+/// verify nothing but still resolve, so a broken target always errors.
+fn verify_runtime_at(symlink: &Path) -> Result<()> {
+    let real = symlink.canonicalize().with_context(|| format!("resolve {}", symlink.display()))?;
+    mur_common::binary_attestation::verify_runtime_signature(&real)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+```
+
+Then call it before each of the three spawn paths inside `cmd_start`:
+
+1. launchd block — before the `launchctl kickstart` command (after `plist.exists()`):
+```rust
+verify_runtime_at(&resolve_bin_dir()?.join(format!("mur_agent_{name}")))?;
+```
+2. systemd block — before `systemctl start` (no-op off-macOS; harmless on Linux):
+```rust
+verify_runtime_at(&resolve_bin_dir()?.join(format!("mur_agent_{name}")))?;
+```
+3. detached spawn — after the `symlink.exists()` check, before opening logs:
+```rust
+verify_runtime_at(&symlink)?;
+```
+
+- [ ] **Step 4: Run to verify it passes + full mur-core test**
+
+Run: `cargo test -p mur-core --lib cmd::agent::start && cargo test -p mur-core --lib`
+Expected: new test passes; existing start-path tests (if any) still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/start.rs
+git commit -m "feat(agent): attest the runtime before every CLI start path
+
+launchd kickstart, systemd start and the detached symlink spawn all go
+through verify_runtime_at; a broken or swapped binary refuses to start.
+"
+```
+
+### Task 3: Mount at the Hub sidecar spawn (`mur-gui-core`)
+
+**Files:**
+- Modify: `mur-gui-core/src/sidecar.rs`
+
+**Interfaces:**
+- Consumes: `mur_common::binary_attestation::verify_runtime_signature`
+
+- [ ] **Step 1: Write the failing test** (in the existing `#[cfg(test)]` module at the bottom of `sidecar.rs`; `find_runtime_binary` honors the `MUR_AGENT_RUNTIME_BIN` env override and rejects a directory via `is_real_binary`)
+
+```rust
+#[test]
+fn spawn_runtime_fails_cleanly_on_invalid_target() {
+    // A directory is not an executable runtime: the pre-spawn resolution
+    // (find → verify → spawn) must fail with the human-readable error, never
+    // panic and never spawn. The signature-verification mount lives in this
+    // same fail-before-spawn path; its behavior is covered in mur-common
+    // with a test requirement (Task 1) — this test pins the structural guard.
+    let dir = std::env::temp_dir().join(format!("mur-sidecar-dir-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    unsafe { std::env::set_var("MUR_AGENT_RUNTIME_BIN", &dir) };
+    let err = spawn_runtime("attest-test", std::path::Path::new("/tmp")).unwrap_err();
+    unsafe { std::env::remove_var("MUR_AGENT_RUNTIME_BIN") };
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(err.contains("agent runtime not found"), "unexpected error: {err}");
+}
+```
+
+- [ ] **Step 2: Run to verify the baseline**
+
+Run: `cargo test -p mur-gui-core --lib sidecar`
+Expected: the test passes against today's code (the guard already exists at find-time) — that is the point: the mount adds a second gate on the same fail-before-spawn path, which a dev build cannot toggle. The release-build path is covered by Task 1's behavioral matrix.
+
+- [ ] **Step 3: Implement** — in `spawn_runtime`, after `find_runtime_binary()`:
+
+```rust
+    let runtime_bin = find_runtime_binary().map_err(|e| {
+        format!(
+            "agent runtime not found ({e}). Reinstall MUR so mur-agent-runtime \
+             is available, or run build.sh to install it."
+        )
+    })?;
+    mur_common::binary_attestation::verify_runtime_signature(&runtime_bin).map_err(|e| {
+        format!(
+            "{e} — the runtime binary may have been swapped (launch-chain \
+             protection covers writes, attestation covers swaps). Fix: mur \
+             update --restart-agents, or reinstall MUR."
+        )
+    })?;
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p mur-gui-core --lib`
+```bash
+git add mur-gui-core/src/sidecar.rs
+git commit -m "feat(gui-core): attest the runtime before sidecar spawn
+
+Hub-spawned runtimes are verified identically to CLI spawns; a swapped
+binary surfaces as a human-readable error in the Hub UI.
+"
+```
+
+### Task 4: Release pipeline — sign the runtime and set the marker
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `docs/superpowers/specs/2026-08-12-binary-attestation-design.md` (correct the pipeline section: the tar.gz is assembled in the matrix job, so signing happens there, not in the PKG job)
+
+**Facts the task relies on (all verified 2026-08-12):**
+- The tar.gz (the brew release asset) is built in the `Build (aarch64-apple-darwin)` matrix row — the only macOS matrix row (x86_64-apple-darwin is commented out) — and packaged unsigned at `Package (Unix)` → `tar czf ... mur-agent-runtime` (line 152).
+- `Package macOS (DMG + PKG)` extracts that tar.gz but its `pkg-root` does **not** contain the runtime — signing there would not reach the shipped artifact.
+- The Hub job builds sidecars and copies the runtime to `mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin` (step `Build Hub UI + mur sidecars (parallel)`, lines 382-392) before the `Build, sign, bundle .dmg` step; certs are imported at `Import Apple signing certs` (lines 434-438).
+- Cert import action is `apple-actions/import-codesign-certs@v2` with `p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}` and `p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}` (both existing usages agree).
+- Codesign identity pattern: `codesign --force --options runtime --timestamp --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)"` with `APPLE_TEAM_NAME`/`APPLE_TEAM_ID` set in step env (existing usages at lines 221-233, 280-284).
+
+- [ ] **Step 1: Amend the spec's Pipeline section** — replace the three bullets with:
+
+```markdown
+### Pipeline changes (`.github/workflows/release.yml`)
+
+1. `Build (aarch64-apple-darwin)` matrix row: import the Apple certs, sign
+   `target/aarch64-apple-darwin/release/mur-agent-runtime` in place before the
+   tar.gz is assembled (the tar.gz is the brew release asset and carries the
+   signed runtime), and export `MUR_EMBED_RELEASE_MARKER=1` +
+   `MUR_APPLE_TEAM_ID` for the cargo build.
+2. Hub job: export the same two env vars for the sidecar build, and sign the
+   copied `mur-agent-runtime-aarch64-apple-darwin` sidecar before the tauri
+   bundling step.
+3. The PKG/DMG job is unchanged — its pkg-root does not contain the runtime.
+```
+
+- [ ] **Step 2: Matrix job — marker env (macOS row only)**
+
+Add a step before `Build (native)` (line 132):
+
+```yaml
+      - name: Set release-marker env (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          echo "MUR_EMBED_RELEASE_MARKER=1" >> "$GITHUB_ENV"
+          echo "MUR_APPLE_TEAM_ID=${{ secrets.APPLE_TEAM_ID }}" >> "$GITHUB_ENV"
+```
+
+(Do not set the marker on Linux/Windows rows — verification is a no-op there, but the Team ID secret should not reach those runners.)
+
+- [ ] **Step 3: Matrix job — import certs + sign the runtime (macOS row only)**
+
+Add after the `Build (native)` step (line 136) and before `Package (Unix)` (line 144). Use the exact input names from the existing usages:
+
+```yaml
+      - name: Import Apple signing certs (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}
+          p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+
+      - name: Sign mur-agent-runtime (macOS)
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
+            target/aarch64-apple-darwin/release/mur-agent-runtime
+          codesign --verify --verbose target/aarch64-apple-darwin/release/mur-agent-runtime
+        env:
+          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+```
+
+- [ ] **Step 4: Hub job — marker env + sign the sidecar**
+
+In the Hub job, add an env block to the `Build Hub UI + mur sidecars (parallel)` step (line 382, which currently has no env):
+
+```yaml
+        env:
+          MUR_EMBED_RELEASE_MARKER: '1'
+          MUR_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+```
+
+And a new step between `Import Apple signing certs` (line 434) and `Build, sign, bundle .dmg` (line 440) — the certs must be in the keychain first:
+
+```yaml
+      - name: Sign agent-runtime sidecar
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
+            mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
+          codesign --verify --verbose mur-hub-gui/src-tauri/binaries/mur-agent-runtime-aarch64-apple-darwin
+        env:
+          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+```
+
+- [ ] **Step 5: Validate the workflow YAML parses**
+
+Run: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"` (ruby + YAML ship on macOS; pyyaml is not reliably present)
+Expected: `yaml ok`. Then `cargo fmt --check` is unaffected (no Rust change) — skip it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/release.yml docs/superpowers/specs/2026-08-12-binary-attestation-design.md
+git commit -m "ci(release): sign mur-agent-runtime and set the attestation marker
+
+The tar.gz is assembled in the matrix job, so that is where the runtime is
+signed; the Hub sidecar is signed before bundling. Marker env is exported
+only for the macOS rows (Build matrix + Hub), keeping dev and non-macOS
+builds unverified per the spec.
+"
+```
+
+### Task 5: Docs — README mention
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add one sentence to the launch-chain grant bullet**
+
+Find the bullet added by #924 (mentions `runtime-doctor` and "decide what starts next") and extend it:
+
+```markdown
+and the runtime binary itself is signed by MUR's Developer ID in release
+builds — a swapped binary is refused at spawn, never run.
+```
+
+(Adjust wording to the bullet's existing voice; do not create a new bullet if the grant bullet already covers the launch chain.)
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `grep -n "attest\|swapped" README.md` (one hit expected)
+```bash
+git add README.md
+git commit -m "docs: mention runtime attestation next to the launch-chain grant bullet"
+```
+
+### Task 6: Full gate + PR
+
+- [ ] **Step 1: Full gate**
+
+```bash
+cargo fmt --check
+cargo test --workspace --all-targets   # ORT_STRATEGY=download on this machine; nextest for mur-core per repo convention
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: all green, no new warnings.
+
+- [ ] **Step 2: Verify the diff contains only intended files**
+
+```bash
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+```
+
+Expected: 6 commits (spec + 5 tasks), files: mur-common (build.rs, binary_attestation.rs, lib.rs), scripts/test-signing-identity.sh, .github/workflows/ci.yml, mur-core/src/cmd/agent/start.rs, mur-gui-core/src/sidecar.rs, .github/workflows/release.yml, spec, README.md.
+
+- [ ] **Step 3: Push + open the PR** (per repo convention: title `feat: binary attestation (launch-chain follow-on)`, body summarizing the six commits and noting the negative-control rule; do NOT auto-merge — supervised PRs merge after review)

--- a/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
+++ b/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
@@ -51,11 +51,16 @@ Decision tree (in order):
 2. `!cfg!(target_os = "macos")` → `Ok`. Developer ID is macOS-only. Linux and
    Windows attestation are out of scope (see below).
 3. macOS + embedded release: run
-   `codesign --verify --strict -R "=designated => anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\"" <path>`.
+   `codesign --verify --strict -R "=anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\"" <path>`.
    One call binds both properties that matter: the binary has a valid signature
    issued by Apple (Developer ID), and that signature belongs to MUR's team. The
-   `=` prefix makes `-R` a full requirement rather than a named requirement. No
-   unsafe FFI, no signature parsing; `codesign` is present on every macOS install.
+   `=` prefix makes `-R` parse the argument as inline requirement text rather
+   than a named requirement or a file path. (`=designated => ...` is NOT valid
+   verification syntax — `designated` is only a read-side token — and its
+   implication-reading would pass any binary without a designated requirement.
+   Verified empirically 2026-08-12: wrong OU exits 3, unsigned exits 1, correct
+   team OU exits 0.) No unsafe FFI, no signature parsing; `codesign` is present
+   on every macOS install.
 4. Any failure of the `codesign` invocation (nonzero exit, missing binary,
    malformed path) → `Err` (fail-closed).
 

--- a/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
+++ b/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
@@ -98,14 +98,15 @@ This is the same boundary the launch-chain design accepted for autostart units.
 
 ### Pipeline changes (`.github/workflows/release.yml`)
 
-1. macOS job: add `mur-agent-runtime` to the existing `codesign --force --options
-   runtime --timestamp` invocation that already signs `mur`, `mur-mcp-server`,
-   `murmurd`.
-2. Set `MUR_EMBED_RELEASE_MARKER=1` and `MUR_APPLE_TEAM_ID=$APPLE_TEAM_ID` for
-   the `mur` build in the macOS job and for the Hub `.app` build job (both are
-   spawners).
-3. Verify the Hub `.app`'s sidecar runtime (the copy of `mur-agent-runtime`
-   bundled in the app) is also signed; add it to the signing step if it is not.
+1. `Build (aarch64-apple-darwin)` matrix row: import the Apple certs, sign
+   `target/aarch64-apple-darwin/release/mur-agent-runtime` in place before the
+   tar.gz is assembled (the tar.gz is the brew release asset and carries the
+   signed runtime), and export `MUR_EMBED_RELEASE_MARKER=1` +
+   `MUR_APPLE_TEAM_ID` for the cargo build.
+2. Hub job: export the same two env vars for the sidecar build, and sign the
+   copied `mur-agent-runtime-aarch64-apple-darwin` sidecar before the tauri
+   bundling step.
+3. The PKG/DMG job is unchanged — its pkg-root does not contain the runtime.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
+++ b/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
@@ -74,6 +74,9 @@ Team ID is absent, the build **fails to compile** — fail-closed at build time.
 |---|---|---|
 | CLI detached spawn | `mur-core/src/cmd/agent/start.rs` path 3 | before `Command::new(&symlink).spawn()` |
 | launchd / systemd | `mur-core/src/cmd/agent/start.rs` paths 1-2 | before `launchctl kickstart` / `systemctl start` (restart flows through the same paths) |
+| CLI direct respawn | `mur-core/src/cmd/agent/restart.rs` `direct_respawn` | before `Command::new(&target).spawn()` (serviceless agents, `--stale` retry) |
+| Service kick restart | `mur-core/src/cmd/agent/restart.rs` `kickstart_service` | before `launchctl kickstart -k` / `systemctl --user restart` (fail-closed: attestation failure does not fall through to `direct_respawn`) |
+| Ephemeral dial spawn | `mur-core/src/a2a_dial.rs` `dial_ephemeral` | before `Command::new(&runtime).spawn()` (`mur agent send` / `card` on stopped agents) |
 | Hub sidecar supervisor | `mur-gui-core` sidecar spawn | before every spawn |
 
 A failure at any mount point refuses the spawn and returns the attestation error.

--- a/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
+++ b/docs/superpowers/specs/2026-08-12-binary-attestation-design.md
@@ -1,0 +1,141 @@
+# Binary Attestation Design
+
+**Status:** Draft
+**Date:** 2026-08-12
+**Scope:** Follow-on to launch-chain protection (#924, merged `7e7dbbac`).
+
+## Goal
+
+Verify `mur-agent-runtime`'s signature before MUR spawns it, so a swapped binary
+is refused regardless of how the swap happened. Launch-chain protection makes the
+binary's location unwritable by agents; attestation covers the case where the
+binary was replaced by something **outside MUR entirely** (the human, a package
+manager, a stray install script, another user).
+
+## Background
+
+The launch-chain spec's follow-on section names this exactly:
+
+> Verify `mur-agent-runtime`'s Developer ID signature before exec. That catches a
+> swapped binary regardless of how it was swapped, and so covers the case where
+> the protected set is bypassed by something outside MUR entirely.
+
+Current state (verified 2026-08-12):
+
+- Release pipeline signs `mur`, `mur-mcp-server`, `murmurd` with Developer ID +
+  hardened runtime + timestamp (`.github/workflows/release.yml`), but the
+  `mur-agent-runtime` shipped in the tar.gz is **not signed**. Signing the runtime
+  in the pipeline is a precondition for this design.
+- Spawn paths: CLI detached spawn (`mur-core/src/cmd/agent/start.rs` path 3),
+  launchd kickstart / systemd load (start.rs paths 1-2), Hub sidecar supervisor
+  (`mur-gui-core` sidecar module). Restart flows through the same paths.
+- Dependency direction: `mur-gui-core` depends on `mur-common` only — the shared
+  helper must live in `mur-common` (or below it), not in `mur-core` or
+  `mur-agent-runtime`.
+
+## Design
+
+### Verification helper — `mur-common/src/binary_attestation.rs`
+
+```rust
+pub const IS_EMBEDDED_RELEASE: bool;   // build.rs, from MUR_EMBED_RELEASE_MARKER
+pub fn verify_runtime_signature(path: &Path) -> Result<(), AttestError>;
+```
+
+Decision tree (in order):
+
+1. `!IS_EMBEDDED_RELEASE` → `Ok`. Dev builds (`cargo run`, `build.sh --install`)
+   are not Developer ID signed; requiring a signature there would break every
+   development workflow. The build marker is the gate, not `debug_assertions` —
+   a locally-built `--release` binary still runs unrestricted.
+2. `!cfg!(target_os = "macos")` → `Ok`. Developer ID is macOS-only. Linux and
+   Windows attestation are out of scope (see below).
+3. macOS + embedded release: run
+   `codesign --verify --strict -R "=designated => anchor apple generic and certificate leaf[subject.OU] = \"<TEAM_ID>\"" <path>`.
+   One call binds both properties that matter: the binary has a valid signature
+   issued by Apple (Developer ID), and that signature belongs to MUR's team. The
+   `=` prefix makes `-R` a full requirement rather than a named requirement. No
+   unsafe FFI, no signature parsing; `codesign` is present on every macOS install.
+4. Any failure of the `codesign` invocation (nonzero exit, missing binary,
+   malformed path) → `Err` (fail-closed).
+
+Team ID source: `build.rs` reads `MUR_APPLE_TEAM_ID` (injected by the release
+pipeline from the existing `APPLE_TEAM_ID` secret). If the marker is set but the
+Team ID is absent, the build **fails to compile** — fail-closed at build time.
+
+### Mount points (all spawn paths)
+
+| Path | Location | When |
+|---|---|---|
+| CLI detached spawn | `mur-core/src/cmd/agent/start.rs` path 3 | before `Command::new(&symlink).spawn()` |
+| launchd / systemd | `mur-core/src/cmd/agent/start.rs` paths 1-2 | before `launchctl kickstart` / `systemctl start` (restart flows through the same paths) |
+| Hub sidecar supervisor | `mur-gui-core` sidecar spawn | before every spawn |
+
+A failure at any mount point refuses the spawn and returns the attestation error.
+
+### Error handling
+
+Fail-closed with a message that names the risk and the fix:
+
+```
+runtime binary at <path> failed signature verification
+  <agent> not started: the binary may have been swapped — launch-chain protection
+  covers writes, attestation covers swaps. Fix: mur update --restart-agents, or
+  reinstall MUR.
+```
+
+### Known limitation (structural, stated honestly)
+
+launchd `KeepAlive` / systemd `Restart=on-failure` respawn the runtime without
+going through MUR code. Attestation covers every MUR-triggered spawn; the
+supervisor-driven respawn path has no verification point and none is claimed.
+This is the same boundary the launch-chain design accepted for autostart units.
+
+### Pipeline changes (`.github/workflows/release.yml`)
+
+1. macOS job: add `mur-agent-runtime` to the existing `codesign --force --options
+   runtime --timestamp` invocation that already signs `mur`, `mur-mcp-server`,
+   `murmurd`.
+2. Set `MUR_EMBED_RELEASE_MARKER=1` and `MUR_APPLE_TEAM_ID=$APPLE_TEAM_ID` for
+   the `mur` build in the macOS job and for the Hub `.app` build job (both are
+   spawners).
+3. Verify the Hub `.app`'s sidecar runtime (the copy of `mur-agent-runtime`
+   bundled in the app) is also signed; add it to the signing step if it is not.
+
+## Testing
+
+Every protection test ships its negative control — a test that passes because the
+verification never ran is indistinguishable from one that passes because the
+protection works (rule established in the launch-chain spec).
+
+The requirement string is parameterized: the public helper uses the production
+requirement (anchor apple generic + MUR team OU), and a test-only entry point
+accepts a requirement string. CI's macOS job has no Developer ID certificate, and
+a self-signed cert **cannot** satisfy `anchor apple generic` (its chain does not
+anchor at Apple), so behavioral tests run against the same code path with a test
+requirement.
+
+| Test | Positive | Negative control |
+|---|---|---|
+| production requirement shape | the requirement used by `verify_runtime_signature` contains both `anchor apple generic` and `subject.OU` bindings (string assertion) | — |
+| marker off → skip | unsigned binary, no marker → `Ok` | — |
+| marker on, non-macOS | (Linux CI) unsigned binary → `Ok` | — |
+| marker on, macOS, valid Team ID (test requirement) | CI macOS job: self-signed cert with `OU` = the test Team ID → `Ok` | same binary with a different `OU` → `Err` |
+| marker on, macOS, unsigned | ad-hoc / unsigned binary → `Err` | same binary with marker off → `Ok` |
+| mount integration | spawn path calls `verify_runtime_signature` before exec | verification failure → agent is not spawned (process list unchanged) |
+
+## Out of scope
+
+- **Linux / Windows attestation.** No Developer ID; Linux has no equivalent
+  code-signing mechanism MUR can rely on. Launch-chain write protection remains
+  the Linux story. A GPG-based scheme is possible but belongs in its own spec.
+- **Verifying `mur` itself or the Hub `.app`.** The spawner is trusted; the
+  threat model is a swapped *runtime*.
+- **Notarization checking.** `codesign --verify` checks the signature; checking
+  stapled notarization ticket state adds nothing to the swapped-binary story.
+
+## Constraints carried from launch-chain
+
+- Fail-closed on `Err` everywhere — no warn-and-continue at a mount point.
+- Negative controls are not optional in tests.
+- The protected-set write story (#924) is untouched; this layers on top.

--- a/mur-common/build.rs
+++ b/mur-common/build.rs
@@ -17,4 +17,19 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=MUR_GIT_SHA={sha}");
+
+    // Without rerun-if-env-changed, flipping the env vars later would keep
+    // the stale consts baked into the crate — a silent attestation gap.
+    println!("cargo:rerun-if-env-changed=MUR_EMBED_RELEASE_MARKER");
+    println!("cargo:rerun-if-env-changed=MUR_APPLE_TEAM_ID");
+    let marker = std::env::var("MUR_EMBED_RELEASE_MARKER").is_ok();
+    let team_id = std::env::var("MUR_APPLE_TEAM_ID").unwrap_or_default();
+    if marker && team_id.is_empty() {
+        panic!("MUR_EMBED_RELEASE_MARKER=1 requires MUR_APPLE_TEAM_ID to be set");
+    }
+    println!(
+        "cargo:rustc-env=MUR_EMBEDDED_RELEASE={}",
+        if marker { "1" } else { "0" }
+    );
+    println!("cargo:rustc-env=MUR_APPLE_TEAM_ID={team_id}");
 }

--- a/mur-common/src/binary_attestation.rs
+++ b/mur-common/src/binary_attestation.rs
@@ -1,0 +1,216 @@
+//! Binary attestation: verify that a spawned `mur-agent-runtime` carries a
+//! valid signature from MUR's Developer ID team (launch-chain follow-on,
+//! spec 2026-08-12). Gated to release builds by the build marker.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// True when this binary was built with `MUR_EMBED_RELEASE_MARKER=1`
+/// (the release pipeline). Dev builds never verify.
+pub const IS_EMBEDDED_RELEASE: bool = {
+    // `==`/`match` on `&str` is not const-stable on current rustc, so compare
+    // bytes (build.rs emits exactly "1" or "0").
+    let bytes = env!("MUR_EMBEDDED_RELEASE").as_bytes();
+    bytes.len() == 1 && bytes[0] == b'1'
+};
+
+/// MUR's Apple Developer Team ID (empty in dev builds; build.rs panics if the
+/// marker is set without it).
+pub const APPLE_TEAM_ID: &str = env!("MUR_APPLE_TEAM_ID");
+
+/// The designated requirement used in production: valid signature chaining to
+/// Apple plus a leaf certificate owned by MUR's team.
+pub(crate) fn production_requirement() -> String {
+    // Leading "=" marks the arg as literal requirement text to codesign (a
+    // plain arg would be read as a file path); "designated =>" is accepted
+    // only when *reading* a designated requirement, not as verification text.
+    format!("=anchor apple generic and certificate leaf[subject.OU] = \"{APPLE_TEAM_ID}\"")
+}
+
+/// Verify `path` is a legitimate runtime binary. No-op unless this is a
+/// macOS release build. Fail-closed: any verification error is returned.
+pub fn verify_runtime_signature(path: &Path) -> Result<(), AttestError> {
+    if !IS_EMBEDDED_RELEASE || !cfg!(target_os = "macos") {
+        return Ok(());
+    }
+    // Canonicalize so a symlink or /var → /private/var redirect is verified
+    // on the real file.
+    let real = path.canonicalize().map_err(|e| AttestError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    verify_with_requirement(&real, &production_requirement())
+}
+
+/// Testable core: run `codesign --verify --strict -R <requirement>` on `path`.
+#[doc(hidden)]
+pub fn verify_with_requirement(path: &Path, requirement: &str) -> Result<(), AttestError> {
+    let out = Command::new("codesign")
+        .args(["--verify", "--strict", "-R", requirement])
+        .arg(path)
+        .output()
+        .map_err(|e| AttestError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(AttestError::VerificationFailed {
+            path: path.to_path_buf(),
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum AttestError {
+    /// The binary failed the designated requirement.
+    VerificationFailed { path: PathBuf, stderr: String },
+    /// Could not read/canonicalize the path or run codesign.
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl fmt::Display for AttestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VerificationFailed { path, stderr } => write!(
+                f,
+                "runtime binary at {} failed signature verification: {stderr}",
+                path.display()
+            ),
+            Self::Io { path, source } => {
+                write!(
+                    f,
+                    "cannot verify runtime binary at {}: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AttestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::VerificationFailed { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // Compile-time gates: this binary is built without the release marker in
+    // CI, so IS_EMBEDDED_RELEASE is false here — the skip behavior is the
+    // negative control for every behavioral test below.
+    #[test]
+    #[allow(clippy::assertions_on_constants)] // runtime negative control on a compile-time const
+    fn dev_build_never_verifies() {
+        assert!(!IS_EMBEDDED_RELEASE);
+        // verify_runtime_signature on a garbage path must still be Ok in dev:
+        assert!(verify_runtime_signature(Path::new("/nonexistent/nope")).is_ok());
+    }
+
+    #[test]
+    fn production_requirement_binds_anchor_and_team() {
+        let req = production_requirement();
+        assert!(req.contains("anchor apple generic"), "req: {req}");
+        assert!(req.contains("subject.OU"), "req: {req}");
+        assert!(req.starts_with("=anchor apple generic and"), "req: {req}");
+    }
+
+    // ── Behavioral matrix (macOS + test identity) ────────────────────────
+    // These run only when MUR_TEST_SIGNING_OU is set (CI macOS job runs
+    // scripts/test-signing-identity.sh first). Negative controls included.
+    fn test_dir(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("mur-attest-{}-{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn test_ou() -> Option<String> {
+        std::env::var("MUR_TEST_SIGNING_OU").ok()
+    }
+
+    #[test]
+    fn unsigned_file_fails_test_requirement() {
+        let Some(ou) = test_ou() else {
+            eprintln!("skipping: MUR_TEST_SIGNING_OU not set");
+            return;
+        };
+        let dir = test_dir("unsigned");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let req = format!("=certificate leaf[subject.OU] = \"{ou}\"");
+        let err = verify_with_requirement(&f, &req).expect_err("unsigned must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn adhoc_signed_fails_test_requirement() {
+        let Some(ou) = test_ou() else {
+            eprintln!("skipping");
+            return;
+        };
+        let dir = test_dir("adhoc");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let out = std::process::Command::new("codesign")
+            .args(["--force", "-s", "-"])
+            .arg(&f)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "ad-hoc sign failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let req = format!("=certificate leaf[subject.OU] = \"{ou}\"");
+        let err = verify_with_requirement(&f, &req).expect_err("ad-hoc (no OU) must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wrong_ou_fails_test_requirement() {
+        let Some(ou) = test_ou() else {
+            eprintln!("skipping");
+            return;
+        };
+        let dir = test_dir("wrongou");
+        let f = dir.join("runtime");
+        std::fs::write(&f, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let out = std::process::Command::new("codesign")
+            .args(["--force", "-s", &format!("Mur Test ({ou})")])
+            .arg(&f)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "sign failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let wrong = "=certificate leaf[subject.OU] = \"WRONGTEAM000\"".to_string();
+        let err = verify_with_requirement(&f, &wrong).expect_err("wrong OU must fail");
+        assert!(matches!(err, AttestError::VerificationFailed { .. }));
+        // Positive control: the same signed binary passes with the right OU.
+        let right = format!("=certificate leaf[subject.OU] = \"{ou}\"");
+        verify_with_requirement(&f, &right).expect("matching OU must pass");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+}

--- a/mur-common/src/binary_attestation.rs
+++ b/mur-common/src/binary_attestation.rs
@@ -106,6 +106,7 @@ impl std::error::Error for AttestError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::path::PathBuf;
 
     // Compile-time gates: this binary is built without the release marker in
@@ -130,6 +131,7 @@ mod tests {
     // ── Behavioral matrix (macOS + test identity) ────────────────────────
     // These run only when MUR_TEST_SIGNING_OU is set (CI macOS job runs
     // scripts/test-signing-identity.sh first). Negative controls included.
+    #[cfg(unix)]
     fn test_dir(name: &str) -> PathBuf {
         let d = std::env::temp_dir().join(format!("mur-attest-{}-{}", name, std::process::id()));
         let _ = std::fs::remove_dir_all(&d);
@@ -137,6 +139,7 @@ mod tests {
         d
     }
 
+    #[cfg(unix)]
     fn test_ou() -> Option<String> {
         std::env::var("MUR_TEST_SIGNING_OU").ok()
     }

--- a/mur-common/src/binary_attestation.rs
+++ b/mur-common/src/binary_attestation.rs
@@ -142,6 +142,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)] // PermissionsExt::from_mode is unix-only (Windows CI compiles this module)
     fn unsigned_file_fails_test_requirement() {
         let Some(ou) = test_ou() else {
             eprintln!("skipping: MUR_TEST_SIGNING_OU not set");
@@ -158,6 +159,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)] // PermissionsExt::from_mode is unix-only (Windows CI compiles this module)
     fn adhoc_signed_fails_test_requirement() {
         let Some(ou) = test_ou() else {
             eprintln!("skipping");
@@ -184,6 +186,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)] // PermissionsExt::from_mode is unix-only (Windows CI compiles this module)
     fn wrong_ou_fails_test_requirement() {
         let Some(ou) = test_ou() else {
             eprintln!("skipping");
@@ -212,5 +215,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 }

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod actor;
 pub mod agent;
 pub mod agent_facts;
 pub mod agent_name;
+pub mod binary_attestation;
 pub mod bridge;
 pub mod build;
 pub mod bundle;

--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use mur_common::LockFile;
 use serde_json::{Value, json};
 
-use crate::cmd::agent::resolve_runtime_target;
+use crate::cmd::agent::{attest::verify_runtime_at, resolve_runtime_target};
 
 /// Strategy for reaching the target agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -462,6 +462,9 @@ fn dial_ephemeral(
             runtime.display()
         );
     }
+    verify_runtime_at(&runtime).with_context(|| {
+        format!("cannot reach agent '{agent_name}' — runtime attestation failed")
+    })?;
 
     let mut child = std::process::Command::new(&runtime)
         .env("MUR_HOME", home)
@@ -593,7 +596,9 @@ mod tests {
         unsafe { std::env::remove_var("MUR_AGENT_RUNTIME_BIN") };
         let msg = err.to_string();
         assert!(
-            msg.contains("runtime binary not found") || msg.contains("spawn"),
+            msg.contains("runtime binary not found")
+                || msg.contains("spawn")
+                || msg.contains("attestation"),
             "unexpected error: {msg}"
         );
     }

--- a/mur-core/src/cmd/agent/attest.rs
+++ b/mur-core/src/cmd/agent/attest.rs
@@ -1,0 +1,46 @@
+//! Binary attestation mount helper — shared across all CLI spawn sites.
+//!
+//! Every path that spawns the agent runtime must verify the binary's
+//! Developer ID signature first. Dev builds verify nothing but still
+//! resolve, so a broken target always errors.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Resolve a runtime path (canonicalizing through symlinks and the
+/// /var -> /private/var redirect) and verify its Developer ID signature.
+/// Dev builds verify nothing but still resolve, so a broken target always
+/// errors.
+///
+/// When verification fails, the error carries the spec's canonical guidance
+/// so every CLI-side mount site surfaces the same fix message.
+pub(crate) fn verify_runtime_at(path: &Path) -> Result<()> {
+    let real = path
+        .canonicalize()
+        .with_context(|| format!("resolve {}", path.display()))?;
+    mur_common::binary_attestation::verify_runtime_signature(&real).map_err(|e| {
+        anyhow::anyhow!(
+            "{e} — the runtime binary may have been swapped (launch-chain \
+             protection covers writes, attestation covers swaps). Fix: mur \
+             update --restart-agents, or reinstall MUR."
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn verify_runtime_at_surfaces_resolution_errors() {
+        // Even in a dev build (where verification is a no-op), a target that
+        // cannot be resolved must fail — the mount never spawns blind.
+        let err = verify_runtime_at(Path::new("/nonexistent/mur_agent_nope")).unwrap_err();
+        assert!(
+            err.to_string().contains("/nonexistent/mur_agent_nope"),
+            "{err}"
+        );
+    }
+}

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -26,6 +26,7 @@ use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
 pub mod addon;
 mod apply;
+pub(crate) mod attest;
 pub mod channel_import;
 pub mod cli;
 mod comm;

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -10,10 +10,13 @@ use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
-use super::{pid_alive, resolve_mur_home, resolve_runtime_target, restart_confirm, stale};
+use super::attest::verify_runtime_at;
+use super::{
+    pid_alive, resolve_bin_dir, resolve_mur_home, resolve_runtime_target, restart_confirm, stale,
+};
 
 /// Extra grace period added on top of the runtime's `stop_timeout_secs` before
 /// the SIGKILL fallback fires.  The SIGKILL wait MUST outlast the runtime's own
@@ -432,6 +435,8 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
 /// Spawn the runtime directly (detached) for an agent with no service unit.
 pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<()> {
     let target = resolve_runtime_target();
+    verify_runtime_at(&target)
+        .with_context(|| format!("cannot respawn agent '{name}' — runtime attestation failed"))?;
     let mur_home = resolve_mur_home()?;
     let stderr_log = agent_home.join("stderr.log");
     let stdout_file = OpenOptions::new()
@@ -479,13 +484,20 @@ pub(super) fn poll_new_lock(lock_path: &Path, old_pid: u32, secs: u64) -> Option
 
 /// Actively (re)start the agent's service unit, killing whatever instance the
 /// service manager currently tracks — including a zombie whose pid never
-/// matched the lock's. Returns false when there is no service manager, the
-/// unit isn't loaded, or the command failed; callers treat that as "nothing
-/// kicked" and let the poll decide.
+/// matched the lock's.
+///
+/// Verifies the runtime before the kick; on verification failure, returns
+/// `Err` (fail-closed — the caller must NOT fall through to a direct spawn).
+/// Returns `Ok(false)` when the service manager command itself fails, which
+/// callers may treat as "nothing kicked" and fall back to a direct respawn.
+/// Returns `Ok(true)` when the kick succeeded.
 #[cfg(target_os = "macos")]
-pub(super) fn kickstart_service(name: &str) -> bool {
+pub(super) fn kickstart_service(name: &str) -> Result<bool> {
+    let symlink = resolve_bin_dir()?.join(format!("mur_agent_{name}"));
+    verify_runtime_at(&symlink)
+        .with_context(|| format!("cannot kick agent '{name}' — runtime attestation failed"))?;
     let uid = unsafe { libc::getuid() };
-    Command::new("launchctl")
+    let ok = Command::new("launchctl")
         .args([
             "kickstart",
             "-k",
@@ -495,23 +507,28 @@ pub(super) fn kickstart_service(name: &str) -> bool {
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    Ok(ok)
 }
 
 #[cfg(target_os = "linux")]
-pub(super) fn kickstart_service(name: &str) -> bool {
-    Command::new("systemctl")
+pub(super) fn kickstart_service(name: &str) -> Result<bool> {
+    let symlink = resolve_bin_dir()?.join(format!("mur_agent_{name}"));
+    verify_runtime_at(&symlink)
+        .with_context(|| format!("cannot kick agent '{name}' — runtime attestation failed"))?;
+    let ok = Command::new("systemctl")
         .args(["--user", "restart", &format!("mur-agent-{name}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    Ok(ok)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub(super) fn kickstart_service(_name: &str) -> bool {
-    false
+pub(super) fn kickstart_service(_name: &str) -> Result<bool> {
+    Ok(false)
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────
@@ -787,6 +804,55 @@ mod tests {
         // Result always strictly exceeds the drain bound
         for t in [1u64, 15, 30, 60, 120] {
             assert!(kill_wait_secs(t) > t, "kill wait must exceed drain bound");
+        }
+    }
+
+    // ── Attestation mount tests ──────────────────────────────────────────
+
+    /// `direct_respawn` refuses to spawn when the runtime target cannot be
+    /// resolved (the attestation mount canonicalizes before verifying).
+    /// Negative control: the error comes from the attestation mount on the
+    /// spawn path, proving the verify call exists.
+    #[test]
+    fn direct_respawn_refuses_unresolvable_runtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agent_home = tmp.path().join("agents").join("test-agent");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        unsafe { std::env::set_var("MUR_AGENT_RUNTIME_BIN", "/nonexistent/mur_agent_nope") };
+        let err = direct_respawn("test-agent", &agent_home).unwrap_err();
+        unsafe { std::env::remove_var("MUR_AGENT_RUNTIME_BIN") };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("resolve") && msg.contains("mur_agent_nope"),
+            "expected resolution error from attestation mount, got: {msg}"
+        );
+    }
+
+    /// `kickstart_service` (macOS path) refuses to kick when the symlink
+    /// points at a non-resolvable target. This is a structural test: the
+    /// function now returns `Result<bool>` and the `Err` variant means
+    /// "attestation failed — never kick."
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn kickstart_service_refuses_unresolvable_symlink() {
+        // Redirect bin_dir to a tmp dir with a broken symlink.
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("MUR_AGENT_BIN_DIR", tmp.path()) };
+        // No mur_agent_test-kick symlink → canonicalize fails → Err.
+        let result = kickstart_service("test-kick");
+        unsafe { std::env::remove_var("MUR_AGENT_BIN_DIR") };
+        match result {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("resolve") || msg.contains("attestation"),
+                    "expected attestation error, got: {msg}"
+                );
+            }
+            Ok(false) => {} // No symlink, no service unit — the kick command just
+            // wasn't found. On macOS without a loaded unit, this is
+            // expected (the key assertion is that we didn't panic).
+            Ok(true) => panic!("kick should not succeed without a unit loaded"),
         }
     }
 }

--- a/mur-core/src/cmd/agent/restart_confirm.rs
+++ b/mur-core/src/cmd/agent/restart_confirm.rs
@@ -16,6 +16,8 @@
 use std::path::Path;
 use std::process::Command;
 
+use anyhow::bail;
+
 use super::restart::{direct_respawn, kickstart_service, poll_new_lock};
 
 /// Passive wait for launchd/systemd's natural respawn. Covers respawn latency
@@ -64,13 +66,23 @@ pub(super) fn wait_for_confirmed_lock(
         // kicked instead of being mistaken for a cold start.
         if new_pid.is_none() {
             if has_service {
-                if kickstart_service(name) {
-                    println!("agent '{name}': no respawn seen; kicked the service unit");
-                } else {
-                    println!(
-                        "agent '{name}': service kickstart failed; falling back to direct respawn"
-                    );
-                    direct_respawn(name, agent_home)?;
+                match kickstart_service(name) {
+                    Ok(true) => {
+                        println!("agent '{name}': no respawn seen; kicked the service unit");
+                    }
+                    Ok(false) => {
+                        println!(
+                            "agent '{name}': service kickstart failed; falling back to direct respawn"
+                        );
+                        direct_respawn(name, agent_home)?;
+                    }
+                    Err(e) => {
+                        // Attestation failed — fail-closed: do NOT kick the
+                        // service manager and do NOT fall through to a direct
+                        // spawn (which would also verify and fail). The runtime
+                        // binary needs repair before the agent can restart.
+                        bail!("{e:#}");
+                    }
                 }
             } else {
                 println!("agent '{name}': no respawn seen; retrying direct respawn");

--- a/mur-core/src/cmd/agent/start.rs
+++ b/mur-core/src/cmd/agent/start.rs
@@ -22,7 +22,9 @@ use super::{pid_alive, resolve_bin_dir, resolve_mur_home};
 /// /var → /private/var redirect) and verify its signature. Dev builds
 /// verify nothing but still resolve, so a broken target always errors.
 fn verify_runtime_at(symlink: &Path) -> Result<()> {
-    let real = symlink.canonicalize().with_context(|| format!("resolve {}", symlink.display()))?;
+    let real = symlink
+        .canonicalize()
+        .with_context(|| format!("resolve {}", symlink.display()))?;
     mur_common::binary_attestation::verify_runtime_signature(&real)
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
@@ -159,6 +161,9 @@ mod tests {
         // Even in a dev build (where verification is a no-op), a target that
         // cannot be resolved must fail — the mount never spawns blind.
         let err = verify_runtime_at(Path::new("/nonexistent/mur_agent_nope")).unwrap_err();
-        assert!(err.to_string().contains("/nonexistent/mur_agent_nope"), "{err}");
+        assert!(
+            err.to_string().contains("/nonexistent/mur_agent_nope"),
+            "{err}"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/start.rs
+++ b/mur-core/src/cmd/agent/start.rs
@@ -10,12 +10,22 @@
 //!    sidecar — the process runs UNSUPERVISED (no auto-restart).
 
 use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use mur_common::LockFile;
 
 use super::{pid_alive, resolve_bin_dir, resolve_mur_home};
+
+/// Resolve a runtime symlink (canonicalizing through symlinks and the
+/// /var → /private/var redirect) and verify its signature. Dev builds
+/// verify nothing but still resolve, so a broken target always errors.
+fn verify_runtime_at(symlink: &Path) -> Result<()> {
+    let real = symlink.canonicalize().with_context(|| format!("resolve {}", symlink.display()))?;
+    mur_common::binary_attestation::verify_runtime_signature(&real)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
 
 pub fn cmd_start(name: &str) -> Result<()> {
     let mur_home = resolve_mur_home()?;
@@ -54,6 +64,7 @@ pub fn cmd_start(name: &str) -> Result<()> {
             .context("no home dir")?
             .join(format!("Library/LaunchAgents/run.mur.agent.{name}.plist"));
         if plist.exists() {
+            verify_runtime_at(&resolve_bin_dir()?.join(format!("mur_agent_{name}")))?;
             let label = format!("run.mur.agent.{name}");
             let uid = unsafe { libc::getuid() };
             let kick = Command::new("launchctl")
@@ -86,6 +97,7 @@ pub fn cmd_start(name: &str) -> Result<()> {
             .context("no config dir")?
             .join(format!("systemd/user/mur-agent-{name}.service"));
         if unit.exists() {
+            verify_runtime_at(&resolve_bin_dir()?.join(format!("mur_agent_{name}")))?;
             let out = Command::new("systemctl")
                 .args(["--user", "start", &format!("mur-agent-{name}.service")])
                 .output()?;
@@ -108,6 +120,7 @@ pub fn cmd_start(name: &str) -> Result<()> {
             symlink.display()
         );
     }
+    verify_runtime_at(&symlink)?;
     let stdout = fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -134,4 +147,18 @@ pub fn cmd_start(name: &str) -> Result<()> {
         child.id()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn verify_runtime_at_surfaces_resolution_errors() {
+        // Even in a dev build (where verification is a no-op), a target that
+        // cannot be resolved must fail — the mount never spawns blind.
+        let err = verify_runtime_at(Path::new("/nonexistent/mur_agent_nope")).unwrap_err();
+        assert!(err.to_string().contains("/nonexistent/mur_agent_nope"), "{err}");
+    }
 }

--- a/mur-core/src/cmd/agent/start.rs
+++ b/mur-core/src/cmd/agent/start.rs
@@ -10,24 +10,13 @@
 //!    sidecar — the process runs UNSUPERVISED (no auto-restart).
 
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use mur_common::LockFile;
 
+use super::attest::verify_runtime_at;
 use super::{pid_alive, resolve_bin_dir, resolve_mur_home};
-
-/// Resolve a runtime symlink (canonicalizing through symlinks and the
-/// /var → /private/var redirect) and verify its signature. Dev builds
-/// verify nothing but still resolve, so a broken target always errors.
-fn verify_runtime_at(symlink: &Path) -> Result<()> {
-    let real = symlink
-        .canonicalize()
-        .with_context(|| format!("resolve {}", symlink.display()))?;
-    mur_common::binary_attestation::verify_runtime_signature(&real)
-        .map_err(|e| anyhow::anyhow!("{e}"))
-}
 
 pub fn cmd_start(name: &str) -> Result<()> {
     let mur_home = resolve_mur_home()?;
@@ -149,21 +138,4 @@ pub fn cmd_start(name: &str) -> Result<()> {
         child.id()
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn verify_runtime_at_surfaces_resolution_errors() {
-        // Even in a dev build (where verification is a no-op), a target that
-        // cannot be resolved must fail — the mount never spawns blind.
-        let err = verify_runtime_at(Path::new("/nonexistent/mur_agent_nope")).unwrap_err();
-        assert!(
-            err.to_string().contains("/nonexistent/mur_agent_nope"),
-            "{err}"
-        );
-    }
 }

--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -236,6 +236,13 @@ fn spawn_runtime(slug: &str, mur_home: &Path) -> Result<Child, String> {
              is available, or run build.sh to install it."
         )
     })?;
+    mur_common::binary_attestation::verify_runtime_signature(&runtime_bin).map_err(|e| {
+        format!(
+            "{e} — the runtime binary may have been swapped (launch-chain \
+             protection covers writes, attestation covers swaps). Fix: mur \
+             update --restart-agents, or reinstall MUR."
+        )
+    })?;
     // Clear any stale lock/socket a previously crashed runtime left behind so
     // the new one binds cleanly.
     clear_runtime_state(mur_home, slug);
@@ -582,5 +589,53 @@ mod tests {
         sup.stop("alpha").await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         sup.shutdown().await;
+    }
+
+    /// A directory is not an executable runtime: the pre-spawn resolution
+    /// (find → verify → spawn) must fail with the human-readable error, never
+    /// panic and never spawn. The signature-verification mount lives in this
+    /// same fail-before-spawn path; its behavior is covered in mur-common
+    /// with a test requirement (Task 1) — this test pins the structural guard.
+    ///
+    /// Env is saved/restored rather than clobbered (tests share one process
+    /// env). PATH keeps every entry except ones that resolve to a real runtime
+    /// binary, so the directory override cannot fall through to an installed
+    /// MUR on PATH — which would spawn a stray runtime instead of failing.
+    #[test]
+    fn spawn_runtime_fails_cleanly_on_invalid_target() {
+        let dir = std::env::temp_dir().join(format!("mur-sidecar-dir-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev_bin = std::env::var_os("MUR_AGENT_RUNTIME_BIN");
+        let prev_path = std::env::var_os("PATH");
+        #[cfg(target_os = "windows")]
+        let runtime_name = "mur-agent-runtime.exe";
+        #[cfg(not(target_os = "windows"))]
+        let runtime_name = "mur-agent-runtime";
+        let path_without_runtime = prev_path.as_ref().map(|p| {
+            std::env::join_paths(
+                std::env::split_paths(&p).filter(|d| !is_real_binary(&d.join(runtime_name))),
+            )
+            .expect("PATH entries join back together")
+        });
+        unsafe {
+            std::env::set_var("MUR_AGENT_RUNTIME_BIN", &dir);
+            if let Some(p) = &path_without_runtime {
+                std::env::set_var("PATH", p);
+            }
+        }
+        let err = spawn_runtime("attest-test", std::path::Path::new("/tmp")).unwrap_err();
+        match prev_bin {
+            Some(v) => unsafe { std::env::set_var("MUR_AGENT_RUNTIME_BIN", v) },
+            None => unsafe { std::env::remove_var("MUR_AGENT_RUNTIME_BIN") },
+        }
+        match prev_path {
+            Some(v) => unsafe { std::env::set_var("PATH", v) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            err.contains("agent runtime not found"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/scripts/test-signing-identity.sh
+++ b/scripts/test-signing-identity.sh
@@ -38,6 +38,15 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$PASS" "$
 # OU below if the identity is genuinely usable.
 perl -e 'alarm 20; exec @ARGV' security add-trusted-cert -d -r trustRoot -k "$KC" "$KC_DIR/cert.pem" >/dev/null 2>&1 || \
   echo "test-signing-identity: trust settings not installed; behavioral matrix will skip"
+# Save the prior default keychain so it can be restored on exit.
+# security default-keychain outputs "  \"/path/to/keychain\"" (quoted, indented).
+PRIOR_KC=$(security default-keychain 2>/dev/null | xargs 2>/dev/null || echo "")
+if [ -n "$PRIOR_KC" ]; then
+  trap 'security default-keychain -s "$PRIOR_KC" 2>/dev/null || true' EXIT
+fi
+# Keep the temp keychain in the search list so codesign finds the identity
+# mid-run, even when it is not the default.
+security list-keychains -d user -s "$KC" $(security list-keychains -d user 2>/dev/null | tr -d '"' | tr '\n' ' ') 2>/dev/null || true
 security default-keychain -s "$KC"
 security unlock-keychain -p "$PASS" "$KC"
 if security find-identity -v -p codesigning "$KC" | grep -q "Mur Test ($OU)"; then

--- a/scripts/test-signing-identity.sh
+++ b/scripts/test-signing-identity.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Create a throwaway self-signed code-signing identity for the attestation
+# behavioral tests. macOS only; exits 0 with a notice on other platforms.
+# Prints the OU (via MUR_TEST_SIGNING_OU in GITHUB_ENV when under CI).
+set -euo pipefail
+if [ "$(uname)" != "Darwin" ]; then
+  echo "test-signing-identity: not macOS, skipping"
+  exit 0
+fi
+OU="${MUR_TEST_TEAM_ID:-TESTTEAMID123}"
+CN="Mur Test ($OU)"
+KC_DIR="${TMPDIR:-/tmp}/mur-attest-keychain"
+rm -rf "$KC_DIR"; mkdir -p "$KC_DIR"
+KC="$KC_DIR/test.keychain"
+P12="$KC_DIR/test.p12"
+PASS="mur"
+# A plain self-signed cert (CA:TRUE, no EKU) is refused by codesign: the
+# Code Signing EKU, a digitalSignature key usage and CA:FALSE are required.
+openssl req -x509 -newkey rsa:2048 -keyout "$KC_DIR/key.pem" -out "$KC_DIR/cert.pem" \
+  -days 1 -nodes -subj "/OU=$OU/CN=$CN" \
+  -addext "basicConstraints=critical,CA:FALSE" \
+  -addext "extendedKeyUsage=codeSigning" \
+  -addext "keyUsage=critical,digitalSignature" >/dev/null 2>&1
+# OpenSSL 3's default PKCS12 MAC is unreadable by the Security framework
+# (import dies with "MAC verification failed"); LibreSSL has no -legacy and
+# its default output is already legacy-compatible. Try -legacy, else plain.
+if ! openssl pkcs12 -legacy -export -out "$P12" -inkey "$KC_DIR/key.pem" -in "$KC_DIR/cert.pem" \
+  -passout "pass:$PASS" >/dev/null 2>&1; then
+  openssl pkcs12 -export -out "$P12" -inkey "$KC_DIR/key.pem" -in "$KC_DIR/cert.pem" \
+    -passout "pass:$PASS" >/dev/null 2>&1
+fi
+security create-keychain -p "$PASS" "$KC"
+security import "$P12" -k "$KC" -P "$PASS" -T /usr/bin/codesign >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$PASS" "$KC" >/dev/null 2>&1
+# codesign refuses untrusted identities; trust the throwaway root in the user
+# domain. This can raise a GUI authorization dialog and hang headless (known
+# CI runner hazard), so bound it with a hard deadline and only advertise the
+# OU below if the identity is genuinely usable.
+perl -e 'alarm 20; exec @ARGV' security add-trusted-cert -d -r trustRoot -k "$KC" "$KC_DIR/cert.pem" >/dev/null 2>&1 || \
+  echo "test-signing-identity: trust settings not installed; behavioral matrix will skip"
+security default-keychain -s "$KC"
+security unlock-keychain -p "$PASS" "$KC"
+if security find-identity -v -p codesigning "$KC" | grep -q "Mur Test ($OU)"; then
+  echo "test-signing-identity: identity '$CN' ready in $KC"
+  echo "MUR_TEST_SIGNING_OU=$OU" >> "${GITHUB_ENV:-/dev/null}"
+else
+  echo "test-signing-identity: identity not usable; MUR_TEST_SIGNING_OU not exported"
+fi


### PR DESCRIPTION
## What

Verify `mur-agent-runtime`'s Developer ID signature before **every MUR-triggered spawn** — a swapped runtime binary is refused at exec regardless of how it was swapped (follow-on to launch-chain protection #924, which makes the binary's location unwritable by agents but not by something outside MUR).

Build-marker gated: release builds built with `MUR_EMBED_RELEASE_MARKER=1` + `MUR_APPLE_TEAM_ID` (injected by the release pipeline) carry the consts and verify on macOS (`codesign --verify --strict -R ...`, fail-closed). Dev builds skip verification; Linux/Windows no-op. `build.rs` panics if the marker is set without a Team ID (fail-closed at build time).

**Spawn sites mounted (6):**
- CLI: launchd kickstart, systemd start, detached spawn — `mur-core/src/cmd/agent/start.rs`
- CLI restart: `direct_respawn` + `kickstart_service` — `mur-core/src/cmd/agent/restart.rs`
- Ephemeral dial (send/cli on a stopped agent) — `mur-core/src/a2a_dial.rs`
- Hub sidecar supervisor — `mur-gui-core/src/sidecar.rs`

Known limitation (stated in spec): launchd `KeepAlive` / systemd `Restart` supervisor-driven respawns have no MUR verification point — same boundary the launch-chain design accepted for autostart units.

## Commits (16)

1. `docs(spec): binary attestation design (launch-chain follow-on)`
2. `docs(plans): binary attestation implementation plan`
3. `feat(common): binary attestation helper with build-marker gating`
4. `docs: correct codesign requirement syntax in spec + plan`
5. `fix(common): cfg-guard attestation tests for Windows`
6. `fix(common): cfg-guard attestation test helpers for Windows`
7. `feat(agent): attest the runtime before every CLI start path`
8. `feat(gui-core): attest the runtime before sidecar spawn`
9. `ci(release): sign mur-agent-runtime and set the attestation marker`
10. `docs: mention runtime attestation next to the launch-chain grant bullet`
11. `style: cargo fmt on start.rs attestation mount` (gate fix)
12. `fix(agent): attest restart + ephemeral-dial spawn paths` (final-review finding: three unverified spawn sites)
13. `docs(plans): correct remaining designated-requirement syntax`
14. `ci(release): bind sign self-checks to team OU`
15. `chore(scripts): restore default keychain after test identity`
16. `docs(spec): mount table covers restart and ephemeral dial`

## Codesign requirement

The original `=designated =>` syntax is **invalid** for verification (parse error — `designated` is a read-side token only), and its implication-reading would vacuous-pass binaries without a designated requirement. Empirically verified (wrong OU exit 3, unsigned exit 1, correct team OU exit 0):

```
=anchor apple generic and certificate leaf[subject.OU] = "TEAM"
```

## Testing (negative controls mandatory)

- mur-common behavioral matrix on the macOS CI row (`Test (macos-14)`): throwaway self-signed identity with a test OU (`scripts/test-signing-identity.sh`); unsigned / ad-hoc / wrong-OU binaries must fail verification, matching-OU must pass. Marker-off skip pinned by `dev_build_never_verifies`.
- Marker-build experiment (local): `MUR_EMBED_RELEASE_MARKER=1 MUR_APPLE_TEAM_ID=TEST` — the skip-gate negative control fires (test panics under marker), behavioral tests pass.
- Mount tests: verification failure surfaces a clean, context-rich error and no spawn; resolution errors carry the canonical fix guidance.

## Release pipeline

- Build matrix row (`aarch64-apple-darwin`): imports the Apple certs, signs `mur-agent-runtime` **before** the tar.gz (brew asset) is assembled, exports the marker env for the cargo build.
- Hub job: exports the same env for the sidecar build, signs the copied sidecar before bundling.
- Both `codesign --verify` self-checks bind the team OU via `-R`, so a misconfigured signing identity fails the pipeline, not users' machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
