### PR TITLE
fix(murmur): make TUI content visibility explicit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.68.6"
+version = "2.68.7"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.68.6"
+version = "2.68.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/docs/superpowers/plans/2026-08-12-murmur-tui-visibility-fixes-plan.md
+++ b/docs/superpowers/plans/2026-08-12-murmur-tui-visibility-fixes-plan.md
@@ -1,0 +1,1296 @@
+# murmur TUI visibility fixes — implementation plan
+
+Spec: `docs/superpowers/specs/2026-08-12-murmur-tui-visibility-fixes-design.md`
+Branch: `fix/murmur-tui-visibility`
+
+> **Execute with `mur-executing-plans`.** Tasks 1–4 are a chain and must run in
+> order. Tasks 5, 6, 7 are independent of the chain and of each other.
+
+## Goal
+
+Stop the murmur TUI from silently dropping content the operator must read: the
+approval modal's key row, the settlement's text, and the reply hidden behind the
+suggested-reply chooser.
+
+## Architecture
+
+`mur-agent-runtime` builds a per-turn settlement as fenced Markdown text and
+appends it to the reply; `mur-core`'s TUI (`cmd/agent/cli/`) renders replies with
+ratatui in an Inline viewport whose live band is drawn by `ui.rs::push_message`
+every frame. This plan keeps that split: the runtime stops truncating text it
+cannot measure, and the TUI — which knows the width via `App::width` — takes
+over presentation. The approval modal and the chooser band are pure `ui.rs`
+layout fixes.
+
+## Tech stack
+
+Rust edition 2024, ratatui, `unicode-width` (already a `mur-core` dependency at
+`mur-core/Cargo.toml:126`), `cargo nextest` for tests.
+
+## Global Constraints
+
+Every task implicitly includes all of these.
+
+- No hardcoded values — new tunables become named `const`s beside the existing
+  ones in the same file.
+- Single source file ≤ 800 lines; `ui.rs` is already 1636 lines, so new
+  rendering code goes in new sibling modules, never appended to `ui.rs`.
+- Run tests with `cargo nextest`, never plain `cargo test` — plain `cargo test`
+  reports ~7 false failures in `mur-core`.
+- `mur-core` tests need the environment prefix
+  `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432`.
+  The first run compiles LanceDB/Arrow and takes several minutes; that is
+  expected, not a hang.
+- Brand name in user-visible strings is uppercase `MUR`.
+- Every task ends with `cargo fmt` and a commit. CI runs
+  `cargo clippy --workspace --all-targets -- -D warnings`.
+- Do not touch `flush_finished` / `band_inner_rows` / `band_capacity`. Their
+  chooser-blind capacity rule is deliberate (`ui.rs:463-471`) and out of scope.
+
+## File structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `mur-agent-runtime/src/turn_ledger.rs` | modify | Stop truncating to widths it cannot know; emit a plain settlement marker |
+| `mur-core/src/cmd/agent/cli/settlement.rs` | **new** | Split the settlement fence out of a reply; parse its rows; render the card at a given width |
+| `mur-core/src/cmd/agent/cli/theme.rs` | modify | One new colour, `card_bg`, in each of the three skins |
+| `mur-core/src/cmd/agent/cli/app.rs` | modify | `ChatMsg.settlement` field, populated where an agent turn is finalized |
+| `mur-core/src/cmd/agent/cli/mod.rs` | modify | Declare `mod settlement;` |
+| `mur-core/src/cmd/agent/cli/ui.rs` | modify | Paint the settlement card; pin the HITL key row; chooser floor; transcript scroll marker |
+
+---
+
+## Task 1 — Runtime stops truncating settlement text
+
+The runtime cuts strings at 72 / 80 / 120 characters before any renderer sees
+them. It cannot know the terminal width, so every one of those numbers is wrong
+somewhere. Raise them all to a single backstop whose only job is to stop a
+runaway error dump, and let the renderer decide what fits.
+
+### Interfaces
+
+**Consumes:** nothing.
+
+**Produces:** the settlement text format that Task 2 parses —
+
+```
+\n\n```\n─ settlement ─\n<row>\n<row>\n…\n```
+```
+
+where each `<row>` is either `  <glyph> <text>` with `<glyph>` one of
+`✔ ~ ✘ ⚠`, or a detail line indented by exactly six spaces. There is no
+trailing rule line; the closing fence terminates the card. Row text may be of
+any length and contains no newlines.
+
+### Steps
+
+- [ ] **Write the failing test.** Append to the `mod tests` block in
+  `mur-agent-runtime/src/turn_ledger.rs`, just before its closing brace:
+
+  ```rust
+      #[test]
+      fn long_detail_survives_to_the_renderer() {
+          // The runtime cannot know the terminal width, so it must not decide
+          // what fits. Only a runaway-dump backstop remains.
+          let mut l = TurnLedger::default();
+          let long = "e".repeat(300);
+          l.record(act("bash", "cargo test", Outcome::Failed(long.clone())));
+          let card = render(&l);
+          assert!(card.contains(&long), "detail was truncated: {card}");
+          assert!(!card.contains('…'), "nothing should be elided here: {card}");
+      }
+
+      #[test]
+      fn the_settlement_header_carries_no_fixed_width_rule() {
+          let mut l = TurnLedger::default();
+          l.record(act("edit_file", "src/lib.rs", Outcome::Ok));
+          let card = render(&l);
+          assert!(card.contains("─ settlement ─\n"), "{card}");
+          // A hard-coded rule cannot match a pane it never measured.
+          assert!(!card.contains("──────────"), "{card}");
+      }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  cargo nextest run -p mur-agent-runtime turn_ledger
+  ```
+
+  Expect `FAIL … long_detail_survives_to_the_renderer` and
+  `FAIL … the_settlement_header_carries_no_fixed_width_rule`.
+
+- [ ] **Add the backstop constant.** In `mur-agent-runtime/src/turn_ledger.rs`,
+  immediately above `fn truncate`, insert:
+
+  ```rust
+  /// The only length limit the runtime still applies. Not a display width — it
+  /// exists so one runaway error dump cannot flood the reply. The renderer owns
+  /// what fits, because it is the only thing that knows the pane.
+  const RUNAWAY_BACKSTOP: usize = 400;
+  ```
+
+- [ ] **Raise every cap to the backstop.** Four edits in the same file, leaving
+  `truncate`'s newline flattening untouched — a newline really would break a row.
+
+  - In `describe_target`, replace `truncate(raw, 72)` with
+    `truncate(raw, RUNAWAY_BACKSTOP)`.
+  - In `clean_reason`, replace `truncate(s, 80)` with
+    `truncate(s, RUNAWAY_BACKSTOP)`.
+  - In `classify`, replace `truncate(detail, 120)` with
+    `truncate(detail, RUNAWAY_BACKSTOP)`.
+  - In `classify`, replace `truncate(content.trim(), 120)` with
+    `truncate(content.trim(), RUNAWAY_BACKSTOP)`.
+
+- [ ] **Drop the fixed-width rules.** In `pub fn render`:
+
+  - Replace the opening line
+
+    ```rust
+    let mut out = String::from("\n\n```\n─ settlement ─────────────────────────────\n");
+    ```
+
+    with
+
+    ```rust
+    let mut out = String::from("\n\n```\n─ settlement ─\n");
+    ```
+
+  - Replace the closing line
+
+    ```rust
+    out.push_str("──────────────────────────────────────────\n```");
+    ```
+
+    with
+
+    ```rust
+    out.push_str("```");
+    ```
+
+    Note the last row already ends in `\n`, so the fence still starts its own
+    line.
+
+- [ ] **Update the test that pinned the old 72-char cap.** In
+  `describe_target_picks_the_identifying_argument`, replace
+
+  ```rust
+          assert!(describe_target("bash", &long).chars().count() <= 72);
+  ```
+
+  with
+
+  ```rust
+          assert!(describe_target("bash", &long).chars().count() <= RUNAWAY_BACKSTOP);
+  ```
+
+  Leave the two lines below it alone — the `"a\nb"` → `"a b"` assertion is the
+  newline flattening, which must survive.
+
+- [ ] **Watch it pass.**
+
+  ```
+  cargo nextest run -p mur-agent-runtime turn_ledger
+  ```
+
+  Expect `16 tests run: 16 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "fix(runtime): stop truncating settlement text the runtime cannot measure"
+  ```
+
+---
+
+## Task 2 — Split the settlement out of the reply text
+
+The card needs the pane width, which is only known at paint time. Keep it out of
+the cached Markdown render by carrying it on the message as its own field.
+
+### Interfaces
+
+**Consumes:** Task 1's settlement text format.
+
+**Produces:**
+
+- `mur-core/src/cmd/agent/cli/settlement.rs`, declared as `mod settlement;` in
+  `mur-core/src/cmd/agent/cli/mod.rs`:
+
+  ```rust
+  /// Split a settlement card off the end of an agent reply.
+  /// Returns (reply_without_card, card_body). `card_body` lines exclude the
+  /// fences and the `─ settlement ─` marker.
+  pub fn split(text: &str) -> (String, Option<String>);
+  ```
+
+- `mur-core/src/cmd/agent/cli/app.rs`: `ChatMsg` gains
+  `pub settlement: Option<String>`, populated on the two paths that finalize an
+  agent turn.
+
+### Steps
+
+- [ ] **Create the module with a failing test.** Write
+  `mur-core/src/cmd/agent/cli/settlement.rs`:
+
+  ```rust
+  //! The per-turn settlement card: split off the reply, parsed, and rendered at
+  //! the pane's real width.
+  //!
+  //! The runtime emits it as fenced text so every non-TUI consumer (`mur agent
+  //! send`, `--plain`, logs, the Hub) can read it. The TUI upgrades that text to
+  //! a card, which is why the split happens here and not in the Markdown
+  //! renderer: the card needs a width, and `ChatMsg::rendered` is cached
+  //! width-free.
+
+  /// The marker the runtime writes as the fence's first line.
+  const MARKER: &str = "─ settlement ─";
+
+  /// Split a settlement card off the end of an agent reply.
+  ///
+  /// Returns the reply with the card removed, and the card's body — every line
+  /// between the marker and the closing fence. Returns `(text, None)` unchanged
+  /// when there is no card, which is the common case: most turns do not earn
+  /// one.
+  pub fn split(text: &str) -> (String, Option<String>) {
+      let Some(fence_at) = text.rfind("```\n") else {
+          return (text.to_string(), None);
+      };
+      let after_fence = &text[fence_at + 4..];
+      let Some(rest) = after_fence.strip_prefix(MARKER) else {
+          return (text.to_string(), None);
+      };
+      let rest = rest.strip_prefix('\n').unwrap_or(rest);
+      let Some(close_at) = rest.find("```") else {
+          return (text.to_string(), None);
+      };
+      let body = rest[..close_at].trim_end_matches('\n').to_string();
+      let head = text[..fence_at].trim_end_matches('\n').to_string();
+      (head, Some(body))
+  }
+
+  #[cfg(test)]
+  mod tests {
+      use super::split;
+
+      #[test]
+      fn splits_the_card_off_the_prose() {
+          let reply = "did the thing\n\n```\n─ settlement ─\n  ✔ bash · cargo test\n```";
+          let (head, card) = split(reply);
+          assert_eq!(head, "did the thing");
+          assert_eq!(card.as_deref(), Some("  ✔ bash · cargo test"));
+      }
+
+      #[test]
+      fn an_ordinary_code_fence_is_not_a_settlement() {
+          let reply = "look:\n\n```\nfn main() {}\n```";
+          let (head, card) = split(reply);
+          assert_eq!(head, reply);
+          assert!(card.is_none());
+      }
+
+      #[test]
+      fn a_reply_with_no_fence_is_returned_whole() {
+          let (head, card) = split("just prose");
+          assert_eq!(head, "just prose");
+          assert!(card.is_none());
+      }
+  }
+  ```
+
+- [ ] **Declare the module.** In `mur-core/src/cmd/agent/cli/mod.rs`, find the
+  block of `mod` declarations near the top and add, in alphabetical position:
+
+  ```rust
+  mod settlement;
+  ```
+
+- [ ] **Watch it fail to compile, then pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement::tests
+  ```
+
+  Expect `3 tests run: 3 passed`. (The module is new, so there is no red phase
+  for `split` itself; the red phase for the *behaviour* is the next step.)
+
+- [ ] **Write the failing test for the field.** In
+  `mur-core/src/cmd/agent/cli/app.rs`, in the existing `#[cfg(test)] mod tests`
+  block, append (it uses that module's own `fn app()` helper, the same way
+  `finished_agent_turn_caches_markdown` does):
+
+  ```rust
+      #[test]
+      fn finishing_a_turn_moves_the_settlement_off_the_body() {
+          let mut a = app();
+          a.begin_user_turn("hi");
+          a.finish_agent_turn(
+              "did it\n\n```\n─ settlement ─\n  ✔ bash · cargo test\n```".to_string(),
+              None,
+          );
+          let m = a.messages.last().expect("a message");
+          assert_eq!(m.text, "did it", "card must not stay in the body");
+          assert_eq!(
+              m.settlement.as_deref(),
+              Some("  ✔ bash · cargo test"),
+              "card must be carried separately so it can be drawn at the pane width"
+          );
+      }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core finishing_a_turn_moves_the_settlement
+  ```
+
+  Expect a compile error: no field `settlement` on `ChatMsg`.
+
+- [ ] **Add the field.** In `mur-core/src/cmd/agent/cli/app.rs`, in
+  `pub struct ChatMsg`, after the `step` field, add:
+
+  ```rust
+      /// The turn's settlement card, lifted out of `text` so it can be drawn at
+      /// the pane's real width every frame. `rendered` is cached width-free, so
+      /// a card baked into it would keep a stale width across a resize.
+      pub settlement: Option<String>,
+  ```
+
+  Then add `settlement: None,` to each of the three `Self { … }` literals in
+  `impl ChatMsg` — in `new`, in `agent_rendered`, and in `tool`.
+
+- [ ] **Populate it on the resume path.** In `impl ChatMsg`, replace the body of
+  `agent_rendered`:
+
+  ```rust
+      /// A finished agent message whose markdown is pre-rendered (resume path).
+      fn agent_rendered(text: String) -> Self {
+          let (text, settlement) = super::settlement::split(&text);
+          let rendered = Some(markdown::render(&text).lines);
+          Self {
+              role: Role::Agent,
+              severity: Severity::Info,
+              text,
+              thinking: String::new(),
+              streaming: false,
+              rendered,
+              step: None,
+              settlement,
+          }
+      }
+  ```
+
+- [ ] **Populate it on the live path.** In `pub fn finish_agent_turn`, replace
+
+  ```rust
+          if let Some(m) = self.streaming_agent_mut() {
+              if !reply.is_empty() {
+                  m.text = reply;
+              }
+              m.streaming = false;
+              m.rendered = Some(markdown::render(&m.text).lines);
+              body = Some(m.text.clone());
+  ```
+
+  with
+
+  ```rust
+          if let Some(m) = self.streaming_agent_mut() {
+              if !reply.is_empty() {
+                  m.text = reply;
+              }
+              let (text, settlement) = super::settlement::split(&m.text);
+              m.text = text;
+              m.settlement = settlement;
+              m.streaming = false;
+              m.rendered = Some(markdown::render(&m.text).lines);
+              body = Some(m.text.clone());
+  ```
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
+  ```
+
+  Expect `4 tests run: 4 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "feat(murmur): carry the settlement card beside the reply body"
+  ```
+
+---
+
+## Task 3 — Render the settlement as a card
+
+### Interfaces
+
+**Consumes:** `settlement::split` from Task 2; `Theme` from `theme.rs`.
+
+**Produces:**
+
+- `theme.rs`: `pub card_bg: Color` on `Theme`, set in `DARK`, `LIGHT`, `MUR`.
+- `settlement.rs`:
+
+  ```rust
+  pub fn card_lines(
+      body: &str,
+      theme: &'static super::theme::Theme,
+      width: u16,
+  ) -> Vec<ratatui::text::Line<'static>>;
+  ```
+
+  Every returned line is padded to exactly `width` display columns and carries
+  `theme.card_bg`, so the card reads as one block. Text wraps; nothing is cut.
+
+### Steps
+
+- [ ] **Add the theme colour.** In `mur-core/src/cmd/agent/cli/theme.rs`, in
+  `pub struct Theme`, after the `separator` field, add:
+
+  ```rust
+      pub card_bg: Color,      // settlement card background (one step off the pane)
+  ```
+
+  Then add one line to each of the three skins, after their `separator:` line:
+
+  - `DARK`: `card_bg: Color::Rgb(0x1e, 0x1e, 0x1e),`
+  - `LIGHT`: `card_bg: Color::Rgb(0xf1, 0xf1, 0xf7),`
+  - `MUR`: `card_bg: Color::Rgb(0x14, 0x14, 0x2c),`
+
+  These are the only three `Theme` struct literals in the workspace, so nothing
+  else needs updating.
+
+- [ ] **Write the failing test.** Append to the `mod tests` block in
+  `mur-core/src/cmd/agent/cli/settlement.rs`:
+
+  ```rust
+      use super::card_lines;
+      use super::super::theme::DARK;
+      use unicode_width::UnicodeWidthStr;
+
+      fn plain(lines: &[ratatui::text::Line<'static>]) -> Vec<String> {
+          lines
+              .iter()
+              .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+              .collect()
+      }
+
+      #[test]
+      fn every_row_is_padded_to_the_pane_width() {
+          let out = card_lines("  ✔ bash · cargo test", &DARK, 40);
+          assert!(!out.is_empty());
+          for row in plain(&out) {
+              assert_eq!(row.width(), 40, "ragged row: {row:?}");
+          }
+      }
+
+      #[test]
+      fn long_detail_wraps_instead_of_being_cut() {
+          let body = format!("  ✘ parallel_jobs · {}", "e".repeat(200));
+          let narrow = card_lines(&body, &DARK, 40);
+          let wide = card_lines(&body, &DARK, 100);
+          assert!(
+              narrow.len() > wide.len(),
+              "narrow={} wide={} — text must reflow, not truncate",
+              narrow.len(),
+              wide.len()
+          );
+          for row in plain(&narrow) {
+              assert!(!row.contains('…'), "nothing may be elided: {row:?}");
+          }
+      }
+
+      #[test]
+      fn the_card_names_itself() {
+          let out = plain(&card_lines("  ✔ bash", &DARK, 40));
+          assert!(out[0].contains("SETTLEMENT"), "{out:?}");
+      }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement::tests
+  ```
+
+  Expect a compile error: no function `card_lines`.
+
+- [ ] **Implement the renderer.** Append to
+  `mur-core/src/cmd/agent/cli/settlement.rs`, above its `mod tests`:
+
+  ```rust
+  use ratatui::style::{Modifier, Style};
+  use ratatui::text::{Line, Span};
+  use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+  /// Columns the glyph column occupies: two spaces, the glyph, one space.
+  const GLYPH_COL: usize = 4;
+
+  /// Narrower than this and the hanging indent costs more than it buys, so the
+  /// card falls back to flush-left rows.
+  const MIN_INDENT_WIDTH: u16 = 24;
+
+  /// Colour for a row, chosen by its lead glyph.
+  fn row_style(glyph: char, theme: &'static super::theme::Theme) -> Style {
+      let fg = match glyph {
+          '✔' => theme.success,
+          '✘' => theme.error,
+          '⚠' => theme.warn,
+          _ => theme.agent_text,
+      };
+      Style::default().fg(fg).bg(theme.card_bg)
+  }
+
+  /// Break `s` into chunks no wider than `width` display columns.
+  ///
+  /// Greedy on word boundaries, falling back to a hard break for a single token
+  /// longer than the line — a 200-character error string with no spaces still
+  /// has to land somewhere, and cutting it is the one thing this card must not
+  /// do.
+  fn wrap(s: &str, width: usize) -> Vec<String> {
+      if width == 0 {
+          return vec![s.to_string()];
+      }
+      let mut out: Vec<String> = Vec::new();
+      let mut line = String::new();
+      let mut line_w = 0usize;
+      for word in s.split(' ') {
+          let word_w = word.width();
+          if !line.is_empty() && line_w + 1 + word_w > width {
+              out.push(std::mem::take(&mut line));
+              line_w = 0;
+          }
+          if word_w > width {
+              // Hard-break an unbreakable token.
+              for c in word.chars() {
+                  let cw = c.width().unwrap_or(0);
+                  if line_w + cw > width {
+                      out.push(std::mem::take(&mut line));
+                      line_w = 0;
+                  }
+                  line.push(c);
+                  line_w += cw;
+              }
+              continue;
+          }
+          if !line.is_empty() {
+              line.push(' ');
+              line_w += 1;
+          }
+          line.push_str(word);
+          line_w += word_w;
+      }
+      if !line.is_empty() || out.is_empty() {
+          out.push(line);
+      }
+      out
+  }
+
+  /// Pad `s` to exactly `width` display columns.
+  fn pad(s: &str, width: usize) -> String {
+      let w = s.width();
+      if w >= width {
+          return s.to_string();
+      }
+      format!("{s}{}", " ".repeat(width - w))
+  }
+
+  /// Draw the settlement card for `body` at `width` columns.
+  ///
+  /// Every row is padded to the full width and carries `theme.card_bg`, so the
+  /// block reads as one surface rather than ragged text. Nothing is elided: the
+  /// runtime already stopped guessing what fits, and this is the layer that
+  /// actually knows.
+  pub fn card_lines(
+      body: &str,
+      theme: &'static super::theme::Theme,
+      width: u16,
+  ) -> Vec<Line<'static>> {
+      let w = width.max(1) as usize;
+      let indent = if width >= MIN_INDENT_WIDTH { GLYPH_COL } else { 0 };
+      let mut out = vec![
+          Line::from(Span::styled(
+              pad(" SETTLEMENT", w),
+              Style::default()
+                  .fg(theme.border_title)
+                  .bg(theme.card_bg)
+                  .add_modifier(Modifier::BOLD),
+          )),
+      ];
+      for raw in body.lines() {
+          let trimmed = raw.trim_start();
+          let glyph = trimmed.chars().next().unwrap_or(' ');
+          let style = row_style(glyph, theme);
+          let is_row = matches!(glyph, '✔' | '✘' | '⚠' | '~');
+          let (head, text) = if is_row {
+              let rest = trimmed.chars().skip(1).collect::<String>();
+              (format!("  {glyph} "), rest.trim_start().to_string())
+          } else {
+              (" ".repeat(indent.max(2)), trimmed.to_string())
+          };
+          let head_w = head.width();
+          let avail = w.saturating_sub(head_w).max(1);
+          for (i, chunk) in wrap(&text, avail).into_iter().enumerate() {
+              let prefix = if i == 0 {
+                  head.clone()
+              } else {
+                  " ".repeat(head_w)
+              };
+              out.push(Line::from(Span::styled(
+                  pad(&format!("{prefix}{chunk}"), w),
+                  style,
+              )));
+          }
+      }
+      out
+  }
+  ```
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
+  ```
+
+  Expect `7 tests run: 7 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "feat(murmur): draw the settlement as a width-aware card"
+  ```
+
+---
+
+## Task 4 — Paint the card in the transcript
+
+### Interfaces
+
+**Consumes:** `settlement::card_lines` (Task 3), `ChatMsg.settlement` (Task 2).
+
+**Produces:** nothing further; this closes the settlement chain.
+
+### Steps
+
+- [ ] **Write the failing test.** Append a new module at the end of
+  `mur-core/src/cmd/agent/cli/ui.rs`:
+
+  ```rust
+  #[cfg(test)]
+  mod settlement_paint_tests {
+      use super::push_message;
+      use super::super::app::{ChatMsg, Role};
+      use super::super::theme::DARK;
+
+      #[test]
+      fn a_carried_settlement_is_painted_after_the_body() {
+          let mut m = ChatMsg::for_test(Role::Agent, "did it");
+          m.settlement = Some("  ✔ bash · cargo test".into());
+          let mut lines = Vec::new();
+          push_message(&mut lines, &m, 0, &DARK, false, 60);
+          let text: Vec<String> = lines
+              .iter()
+              .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+              .collect();
+          assert!(
+              text.iter().any(|l| l.contains("SETTLEMENT")),
+              "card missing: {text:?}"
+          );
+          assert!(
+              text.iter().any(|l| l.contains("cargo test")),
+              "card body missing: {text:?}"
+          );
+      }
+
+      #[test]
+      fn a_message_without_one_paints_nothing_extra() {
+          let m = ChatMsg::for_test(Role::Agent, "did it");
+          let mut lines = Vec::new();
+          push_message(&mut lines, &m, 0, &DARK, false, 60);
+          let text: Vec<String> = lines
+              .iter()
+              .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+              .collect();
+          assert!(!text.iter().any(|l| l.contains("SETTLEMENT")), "{text:?}");
+      }
+  }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement_paint_tests
+  ```
+
+  Expect `FAIL … a_carried_settlement_is_painted_after_the_body`.
+
+- [ ] **Paint it.** In `mur-core/src/cmd/agent/cli/ui.rs`, in `fn push_message`,
+  in the `Role::Agent` arm, replace
+
+  ```rust
+          Role::Agent => {
+              // Animated bullet while streaming, solid bullet once done — so an
+              // in-progress turn reads as "live" at a glance vs. a finished one.
+              push_agent_header(lines, m, spinner, theme);
+              lines.extend(agent_body_lines(
+                  &m.text,
+                  m.streaming,
+                  spinner,
+                  theme,
+                  m.rendered.as_ref(),
+              ));
+          }
+  ```
+
+  with
+
+  ```rust
+          Role::Agent => {
+              // Animated bullet while streaming, solid bullet once done — so an
+              // in-progress turn reads as "live" at a glance vs. a finished one.
+              push_agent_header(lines, m, spinner, theme);
+              lines.extend(agent_body_lines(
+                  &m.text,
+                  m.streaming,
+                  spinner,
+                  theme,
+                  m.rendered.as_ref(),
+              ));
+              // Drawn here, not baked into `rendered`: this is the only place
+              // that knows the pane width, and it runs every frame, so the card
+              // reflows on resize for free.
+              if let Some(body) = &m.settlement {
+                  let inner = width.saturating_sub(u16::from(theme.inner_padding) * 2);
+                  lines.extend(super::settlement::card_lines(body, theme, inner));
+              }
+          }
+  ```
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
+  ```
+
+  Expect `9 tests run: 9 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "feat(murmur): paint the settlement card in the transcript"
+  ```
+
+---
+
+## Task 5 — Pin the approval modal's key row
+
+Independent of Tasks 1–4.
+
+### Interfaces
+
+**Consumes:** nothing. **Produces:** nothing consumed elsewhere.
+
+### Steps
+
+- [ ] **Write the failing test.** Append a new module at the end of
+  `mur-core/src/cmd/agent/cli/ui.rs`:
+
+  ```rust
+  #[cfg(test)]
+  mod hitl_modal_tests {
+      use super::render_hitl;
+      use super::super::stream::HitlRequest;
+      use ratatui::Terminal;
+      use ratatui::backend::TestBackend;
+
+      /// A tool input big enough that, wrapped, it fills the modal on its own.
+      fn fat_request() -> HitlRequest {
+          HitlRequest {
+              hitl_id: "h1".into(),
+              step_id: None,
+              tool_name: "bash".into(),
+              tool_input: serde_json::json!({
+                  "command": "x".repeat(400),
+                  "cwd": "/Volumes/Firecuda4tb/Projects/mur",
+              }),
+              prompt: "Run `bash`?".into(),
+              created_at: std::time::Instant::now(),
+          }
+      }
+
+      #[test]
+      fn the_key_row_survives_an_oversized_input() {
+          let mut term = Terminal::new(TestBackend::new(88, 24)).unwrap();
+          term.draw(|f| render_hitl(f, &fat_request(), None)).unwrap();
+          let dump = term.backend().to_string();
+          assert!(
+              dump.contains("approve"),
+              "the operator cannot answer a gate whose keys are off-screen:\n{dump}"
+          );
+          assert!(dump.contains("deny"), "{dump}");
+      }
+  }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core hitl_modal_tests
+  ```
+
+  Expect `FAIL … the_key_row_survives_an_oversized_input`.
+
+- [ ] **Split the modal.** In `mur-core/src/cmd/agent/cli/ui.rs`, in
+  `fn render_hitl`:
+
+  1. Change the `lines` builder so the key row is no longer pushed into it.
+     Replace the two `lines.push(Line::from(vec![…]))` calls in the
+     `if let Some(c) = grant_confirm { … } else { … }` block with assignments to
+     a new `keys` binding:
+
+     ```rust
+     let keys = if let Some(c) = grant_confirm {
+         let what = if c == 'a' {
+             format!("`{}` for this session", hitl.tool_name)
+         } else {
+             "ALL tools for this session".to_string()
+         };
+         Line::from(vec![
+             Span::styled(
+                 format!("press [{c}] again"),
+                 Style::default()
+                     .fg(Color::Magenta)
+                     .add_modifier(Modifier::BOLD),
+             ),
+             Span::raw(format!(" to allow {what} — any other key cancels")),
+         ])
+     } else {
+         Line::from(vec![
+             Span::styled(
+                 "[y]",
+                 Style::default()
+                     .fg(Color::Green)
+                     .add_modifier(Modifier::BOLD),
+             ),
+             Span::raw(" approve    "),
+             Span::styled(
+                 "[a]",
+                 Style::default()
+                     .fg(Color::Yellow)
+                     .add_modifier(Modifier::BOLD),
+             ),
+             Span::raw(" always allow this tool (session)    "),
+             Span::styled(
+                 "[A]",
+                 Style::default()
+                     .fg(Color::Magenta)
+                     .add_modifier(Modifier::BOLD),
+             ),
+             Span::raw(" allow all tools (session)    "),
+             Span::styled(
+                 "[n]",
+                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+             ),
+             Span::raw(" deny / Esc"),
+         ])
+     };
+     ```
+
+     Delete the now-unneeded `lines.push(Line::default());` that preceded that
+     block — the layout gap replaces it.
+
+  2. Replace the whole render tail — from `let block = Block::default()` to the
+     closing `);` of the second `f.render_widget` — with:
+
+     ```rust
+     let block = Block::default()
+         .borders(Borders::ALL)
+         .border_style(Style::default().fg(Color::Yellow))
+         .title(" approve tool call ");
+     let inner = block.inner(area);
+     f.render_widget(Clear, area);
+     f.render_widget(block, area);
+
+     // The key row is the only part of this modal that is never optional, so it
+     // gets its own chunk. Previously it was the last entry in one clipped
+     // Paragraph: a wrapped JSON input pushed it out of the box and left the
+     // operator staring at a blocking gate with no visible way to answer it.
+     let keys_h = Paragraph::new(keys.clone())
+         .wrap(Wrap { trim: false })
+         .line_count(inner.width.max(1)) as u16;
+     let chunks = Layout::default()
+         .direction(Direction::Vertical)
+         .constraints([Constraint::Min(0), Constraint::Length(keys_h.max(1))])
+         .split(inner);
+
+     // The body truncates rather than wraps, so one input line costs one row and
+     // the height is predictable; when it still overflows, say so on screen.
+     let body_h = chunks[0].height as usize;
+     if lines.len() > body_h && body_h > 0 {
+         lines.truncate(body_h.saturating_sub(1));
+         lines.push(Line::styled(
+             format!("… {} more lines", body_h.saturating_sub(1)),
+             Style::default().fg(Color::DarkGray),
+         ));
+     }
+     f.render_widget(Paragraph::new(Text::from(lines)), chunks[0]);
+     f.render_widget(
+         Paragraph::new(keys).wrap(Wrap { trim: false }),
+         chunks[1],
+     );
+     ```
+
+  3. Make `lines` mutable-and-truncatable: it is already `let mut lines`, so no
+     change is needed there.
+
+  4. Truncate the JSON rows instead of letting them wrap. Replace
+
+     ```rust
+     for l in input.lines().take(12) {
+         lines.push(Line::styled(
+             l.to_string(),
+             Style::default().fg(Color::DarkGray),
+         ));
+     }
+     ```
+
+     with
+
+     ```rust
+     let row_w = area.width.saturating_sub(2) as usize;
+     for l in input.lines().take(12) {
+         let row: String = if l.chars().count() > row_w && row_w > 1 {
+             l.chars().take(row_w - 1).chain(['…']).collect()
+         } else {
+             l.to_string()
+         };
+         lines.push(Line::styled(row, Style::default().fg(Color::DarkGray)));
+     }
+     ```
+
+  5. Replace the magic percentages at the top of the function. Change
+
+     ```rust
+     let area = centered_rect(70, 50, f.area());
+     ```
+
+     to
+
+     ```rust
+     let area = centered_rect(HITL_PCT_X, HITL_PCT_Y, f.area());
+     ```
+
+     and add, next to the other `const`s near the top of `ui.rs`:
+
+     ```rust
+     /// Approval modal size, as a percentage of the viewport.
+     const HITL_PCT_X: u16 = 70;
+     const HITL_PCT_Y: u16 = 50;
+     ```
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core hitl_modal_tests
+  ```
+
+  Expect `1 test run: 1 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "fix(murmur): pin the approval modal's key row so an oversized input cannot hide it"
+  ```
+
+---
+
+## Task 6 — Give the transcript a real floor under the chooser
+
+Independent of every other task. Do not touch `flush_finished`.
+
+### Interfaces
+
+**Consumes:** nothing. **Produces:** nothing consumed elsewhere.
+
+### Steps
+
+- [ ] **Write the failing test.** Append a new module at the end of
+  `mur-core/src/cmd/agent/cli/ui.rs`:
+
+  ```rust
+  #[cfg(test)]
+  mod chooser_floor_tests {
+      use super::chooser_band_height;
+      use super::super::app::App;
+      use super::super::complete::{Candidate, CompletionState};
+
+      fn option(display: &str, desc: &str) -> Candidate {
+          Candidate {
+              display: display.into(),
+              insert: display.into(),
+              desc: desc.into(),
+              has_children: false,
+          }
+      }
+
+      /// Three suggested replies, each with a description — the shape from the
+      /// report.
+      fn app_with_three_options() -> App {
+          let mut a = App::test_fixture();
+          a.completion = Some(CompletionState {
+              items: vec![
+                  option("open the PR", "wait for CI, then tag"),
+                  option("stronger model", "the 4B one fakes tool calls"),
+                  option("leave it", "change nothing"),
+              ],
+              selected: 0,
+              spaced: true,
+          });
+          a
+      }
+
+      #[test]
+      fn the_chooser_leaves_the_transcript_more_than_three_rows() {
+          // Inline viewport is 20 rows; composer 3 + status 1 leaves 16.
+          let h = chooser_band_height(&app_with_three_options(), 20, 3);
+          assert!(
+              h <= 8,
+              "chooser took {h} rows, leaving the reply a peephole"
+          );
+      }
+
+      #[test]
+      fn a_short_terminal_still_gets_a_usable_chooser() {
+          // The floor must yield rather than squeeze the chooser out: it is the
+          // thing the operator has to act on.
+          let h = chooser_band_height(&app_with_three_options(), 12, 3);
+          assert!(h >= 5, "chooser unusable at {h} rows");
+      }
+
+      #[test]
+      fn ctrl_up_still_reaches_the_spaced_form() {
+          let mut a = app_with_three_options();
+          a.chooser_grow = 6;
+          assert_eq!(chooser_band_height(&a, 20, 3), 11);
+      }
+  }
+  ```
+
+  `App::test_fixture()` already exists under `#[cfg(test)]` in `app.rs`;
+  `Candidate` and `CompletionState` are both `pub` in `complete.rs` with all
+  fields public, so no new test constructors are needed.
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core chooser_floor_tests
+  ```
+
+  Expect `FAIL … the_chooser_leaves_the_transcript_more_than_three_rows`
+  (it returns 11).
+
+- [ ] **Add the floor.** In `mur-core/src/cmd/agent/cli/ui.rs`, next to
+  `const MIN_TRANSCRIPT_ROWS: u16 = 3;` add:
+
+  ```rust
+  /// Share of the viewport the transcript keeps when the chooser is open,
+  /// in percent.
+  ///
+  /// `MIN_TRANSCRIPT_ROWS` alone is a floor for "the chooser must fit at all",
+  /// not for "the reply is still readable" — at three rows, PageUp pages a
+  /// twenty-line answer three lines at a time through a three-line peephole.
+  /// This is the readable floor; the hard minimum still wins on a short
+  /// terminal.
+  const TRANSCRIPT_FLOOR_PCT: u16 = 40;
+  ```
+
+- [ ] **Apply it.** Replace the body of `fn chooser_band_height` from the
+  `let available = …` line down to (but not including) the final `clamp`
+  expression:
+
+  ```rust
+      let chrome = input_height + 1; // composer + status line
+      let full: u16 = state
+          .items
+          .iter()
+          .map(|c| 2 + u16::from(!c.desc.is_empty())) // label + spacer (+ desc)
+          .sum::<u16>()
+          .saturating_add(2); // borders
+      let compact = (state.items.len() as u16).saturating_add(2);
+      // Prefer the readable floor; fall back to the hard minimum only when the
+      // floor would squeeze the chooser below its compact form. The chooser is
+      // what the operator must act on, so it never loses this trade.
+      let roomy = total_h
+          .saturating_sub(chrome)
+          .saturating_sub((total_h * TRANSCRIPT_FLOOR_PCT / 100).max(MIN_TRANSCRIPT_ROWS));
+      let tight = total_h.saturating_sub(chrome + MIN_TRANSCRIPT_ROWS);
+      let available = if roomy >= compact { roomy } else { tight };
+      // Take `compact` exactly when the spaced form does not fit — padding the
+      // band out to `available` spends rows on nothing.
+      let auto = if full <= available {
+          full
+      } else {
+          compact.min(available).max(3)
+      };
+  ```
+
+  Leave the trailing `chooser_grow` clamp line exactly as it is.
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core chooser_floor_tests
+  ```
+
+  Expect `3 tests run: 3 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "fix(murmur): give the transcript a readable floor under the suggested-reply chooser"
+  ```
+
+---
+
+## Task 7 — Say when the transcript is hiding content
+
+Independent of every other task.
+
+### Interfaces
+
+**Consumes:** nothing. **Produces:** nothing consumed elsewhere.
+
+### Steps
+
+- [ ] **Write the failing test.** Append a new module at the end of
+  `mur-core/src/cmd/agent/cli/ui.rs`:
+
+  ```rust
+  #[cfg(test)]
+  mod scroll_marker_tests {
+      use super::scroll_marker;
+
+      #[test]
+      fn silence_when_everything_fits() {
+          assert_eq!(scroll_marker(0, 0), None);
+      }
+
+      #[test]
+      fn following_the_tail_points_up() {
+          assert_eq!(scroll_marker(25, 0).as_deref(), Some(" ↑ 25 more · PgUp "));
+      }
+
+      #[test]
+      fn scrolled_back_points_the_way_home() {
+          assert_eq!(
+              scroll_marker(25, 10).as_deref(),
+              Some(" ↑ 15 · PgDn to follow ")
+          );
+      }
+  }
+  ```
+
+- [ ] **Watch it fail.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core scroll_marker_tests
+  ```
+
+  Expect a compile error: no function `scroll_marker`.
+
+- [ ] **Add the marker.** In `mur-core/src/cmd/agent/cli/ui.rs`, immediately
+  above `fn render_transcript`, insert:
+
+  ```rust
+  /// Right-hand title for the transcript's top border, or `None` when nothing
+  /// is hidden.
+  ///
+  /// A band that silently drops the rows above it is indistinguishable from one
+  /// that never had them — which is exactly how a reply behind the suggested-
+  /// reply chooser reads as lost. `max_scroll` is the number of rows above the
+  /// band; `scroll_back` is how many the operator has already walked up.
+  fn scroll_marker(max_scroll: u16, scroll_back: u16) -> Option<String> {
+      if max_scroll == 0 {
+          return None;
+      }
+      Some(if scroll_back == 0 {
+          format!(" ↑ {max_scroll} more · PgUp ")
+      } else {
+          format!(" ↑ {} · PgDn to follow ", max_scroll - scroll_back)
+      })
+  }
+  ```
+
+- [ ] **Render it.** In `fn render_transcript`, replace the final line
+
+  ```rust
+      f.render_widget(output.block(block).scroll((offset, 0)), area);
+  ```
+
+  with
+
+  ```rust
+      let block = match scroll_marker(max_scroll, app.scroll_back) {
+          Some(marker) => block.title(Line::from(marker).right_aligned()),
+          None => block,
+      };
+      f.render_widget(output.block(block).scroll((offset, 0)), area);
+  ```
+
+  `Line::right_aligned()` and `Block::title(impl Into<Title>)` are both present
+  in ratatui 0.29 (`mur-core/Cargo.toml:120`), and `Line` is already imported at
+  the top of `ui.rs`. The `block` binding earlier in the function is immutable
+  and is only moved at the end, so shadowing it here is fine.
+
+- [ ] **Watch it pass.**
+
+  ```
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core scroll_marker_tests
+  ```
+
+  Expect `3 tests run: 3 passed`.
+
+- [ ] **Commit.**
+
+  ```
+  cargo fmt && git add -A && git commit -m "fix(murmur): say when the transcript is hiding rows above the band"
+  ```
+
+---
+
+## Final gate
+
+- [ ] **Full workspace check.**
+
+  ```
+  cargo clippy --workspace --all-targets -- -D warnings
+  cargo fmt --check
+  ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core
+  cargo nextest run -p mur-agent-runtime
+  ```
+
+  All four must be clean. Paste the summary lines into the PR body — a claim
+  without the output is not evidence.
+
+- [ ] **Manual check, with a rebuilt runtime.** `turn_ledger.rs` lives in
+  `mur-agent-runtime`, and an agent loads its binary once at start, so the
+  settlement fix does not reach a running agent until it is restarted:
+
+  ```
+  ./build.sh --release --install
+  mur agent restart --stale
+  murmur mur
+  ```
+
+  Then confirm, in one session: a tool approval shows its key row; a turn that
+  edits or fails a tool renders the settlement as a shaded block with nothing
+  cut; and when the suggested-reply chooser opens, at least nine rows of the
+  reply remain visible with `↑ N more · PgUp` on the top border when there is
+  more above.
+
+  `mur agent restart --stale` does not see agents without a `running.lock`, and
+  reports `25/25 ✓` while leaving some on the old binary. Verify with
+  `mur agent status` that the agent you test actually restarted.

--- a/docs/superpowers/plans/2026-08-12-murmur-tui-visibility-fixes-plan.md
+++ b/docs/superpowers/plans/2026-08-12-murmur-tui-visibility-fixes-plan.md
@@ -84,7 +84,7 @@ any length and contains no newlines.
 
 ### Steps
 
-- [ ] **Write the failing test.** Append to the `mod tests` block in
+- [x] **Write the failing test.** Append to the `mod tests` block in
   `mur-agent-runtime/src/turn_ledger.rs`, just before its closing brace:
 
   ```rust
@@ -111,7 +111,7 @@ any length and contains no newlines.
       }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   cargo nextest run -p mur-agent-runtime turn_ledger
@@ -120,7 +120,7 @@ any length and contains no newlines.
   Expect `FAIL … long_detail_survives_to_the_renderer` and
   `FAIL … the_settlement_header_carries_no_fixed_width_rule`.
 
-- [ ] **Add the backstop constant.** In `mur-agent-runtime/src/turn_ledger.rs`,
+- [x] **Add the backstop constant.** In `mur-agent-runtime/src/turn_ledger.rs`,
   immediately above `fn truncate`, insert:
 
   ```rust
@@ -130,7 +130,7 @@ any length and contains no newlines.
   const RUNAWAY_BACKSTOP: usize = 400;
   ```
 
-- [ ] **Raise every cap to the backstop.** Four edits in the same file, leaving
+- [x] **Raise every cap to the backstop.** Four edits in the same file, leaving
   `truncate`'s newline flattening untouched — a newline really would break a row.
 
   - In `describe_target`, replace `truncate(raw, 72)` with
@@ -142,7 +142,7 @@ any length and contains no newlines.
   - In `classify`, replace `truncate(content.trim(), 120)` with
     `truncate(content.trim(), RUNAWAY_BACKSTOP)`.
 
-- [ ] **Drop the fixed-width rules.** In `pub fn render`:
+- [x] **Drop the fixed-width rules.** In `pub fn render`:
 
   - Replace the opening line
 
@@ -171,7 +171,7 @@ any length and contains no newlines.
     Note the last row already ends in `\n`, so the fence still starts its own
     line.
 
-- [ ] **Update the test that pinned the old 72-char cap.** In
+- [x] **Update the test that pinned the old 72-char cap.** In
   `describe_target_picks_the_identifying_argument`, replace
 
   ```rust
@@ -187,7 +187,7 @@ any length and contains no newlines.
   Leave the two lines below it alone — the `"a\nb"` → `"a b"` assertion is the
   newline flattening, which must survive.
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   cargo nextest run -p mur-agent-runtime turn_ledger
@@ -195,7 +195,7 @@ any length and contains no newlines.
 
   Expect `16 tests run: 16 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "fix(runtime): stop truncating settlement text the runtime cannot measure"
@@ -230,7 +230,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
 ### Steps
 
-- [ ] **Create the module with a failing test.** Write
+- [x] **Create the module with a failing test.** Write
   `mur-core/src/cmd/agent/cli/settlement.rs`:
 
   ```rust
@@ -298,14 +298,14 @@ the cached Markdown render by carrying it on the message as its own field.
   }
   ```
 
-- [ ] **Declare the module.** In `mur-core/src/cmd/agent/cli/mod.rs`, find the
+- [x] **Declare the module.** In `mur-core/src/cmd/agent/cli/mod.rs`, find the
   block of `mod` declarations near the top and add, in alphabetical position:
 
   ```rust
   mod settlement;
   ```
 
-- [ ] **Watch it fail to compile, then pass.**
+- [x] **Watch it fail to compile, then pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement::tests
@@ -314,7 +314,7 @@ the cached Markdown render by carrying it on the message as its own field.
   Expect `3 tests run: 3 passed`. (The module is new, so there is no red phase
   for `split` itself; the red phase for the *behaviour* is the next step.)
 
-- [ ] **Write the failing test for the field.** In
+- [x] **Write the failing test for the field.** In
   `mur-core/src/cmd/agent/cli/app.rs`, in the existing `#[cfg(test)] mod tests`
   block, append (it uses that module's own `fn app()` helper, the same way
   `finished_agent_turn_caches_markdown` does):
@@ -338,7 +338,7 @@ the cached Markdown render by carrying it on the message as its own field.
       }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core finishing_a_turn_moves_the_settlement
@@ -346,7 +346,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect a compile error: no field `settlement` on `ChatMsg`.
 
-- [ ] **Add the field.** In `mur-core/src/cmd/agent/cli/app.rs`, in
+- [x] **Add the field.** In `mur-core/src/cmd/agent/cli/app.rs`, in
   `pub struct ChatMsg`, after the `step` field, add:
 
   ```rust
@@ -359,7 +359,7 @@ the cached Markdown render by carrying it on the message as its own field.
   Then add `settlement: None,` to each of the three `Self { … }` literals in
   `impl ChatMsg` — in `new`, in `agent_rendered`, and in `tool`.
 
-- [ ] **Populate it on the resume path.** In `impl ChatMsg`, replace the body of
+- [x] **Populate it on the resume path.** In `impl ChatMsg`, replace the body of
   `agent_rendered`:
 
   ```rust
@@ -380,7 +380,7 @@ the cached Markdown render by carrying it on the message as its own field.
       }
   ```
 
-- [ ] **Populate it on the live path.** In `pub fn finish_agent_turn`, replace
+- [x] **Populate it on the live path.** In `pub fn finish_agent_turn`, replace
 
   ```rust
           if let Some(m) = self.streaming_agent_mut() {
@@ -407,7 +407,7 @@ the cached Markdown render by carrying it on the message as its own field.
               body = Some(m.text.clone());
   ```
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
@@ -415,7 +415,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect `4 tests run: 4 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "feat(murmur): carry the settlement card beside the reply body"
@@ -447,7 +447,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
 ### Steps
 
-- [ ] **Add the theme colour.** In `mur-core/src/cmd/agent/cli/theme.rs`, in
+- [x] **Add the theme colour.** In `mur-core/src/cmd/agent/cli/theme.rs`, in
   `pub struct Theme`, after the `separator` field, add:
 
   ```rust
@@ -463,7 +463,7 @@ the cached Markdown render by carrying it on the message as its own field.
   These are the only three `Theme` struct literals in the workspace, so nothing
   else needs updating.
 
-- [ ] **Write the failing test.** Append to the `mod tests` block in
+- [x] **Write the failing test.** Append to the `mod tests` block in
   `mur-core/src/cmd/agent/cli/settlement.rs`:
 
   ```rust
@@ -510,7 +510,7 @@ the cached Markdown render by carrying it on the message as its own field.
       }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement::tests
@@ -518,7 +518,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect a compile error: no function `card_lines`.
 
-- [ ] **Implement the renderer.** Append to
+- [x] **Implement the renderer.** Append to
   `mur-core/src/cmd/agent/cli/settlement.rs`, above its `mod tests`:
 
   ```rust
@@ -649,7 +649,7 @@ the cached Markdown render by carrying it on the message as its own field.
   }
   ```
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
@@ -657,7 +657,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect `7 tests run: 7 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "feat(murmur): draw the settlement as a width-aware card"
@@ -675,7 +675,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
 ### Steps
 
-- [ ] **Write the failing test.** Append a new module at the end of
+- [x] **Write the failing test.** Append a new module at the end of
   `mur-core/src/cmd/agent/cli/ui.rs`:
 
   ```rust
@@ -719,7 +719,7 @@ the cached Markdown render by carrying it on the message as its own field.
   }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement_paint_tests
@@ -727,7 +727,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect `FAIL … a_carried_settlement_is_painted_after_the_body`.
 
-- [ ] **Paint it.** In `mur-core/src/cmd/agent/cli/ui.rs`, in `fn push_message`,
+- [x] **Paint it.** In `mur-core/src/cmd/agent/cli/ui.rs`, in `fn push_message`,
   in the `Role::Agent` arm, replace
 
   ```rust
@@ -769,7 +769,7 @@ the cached Markdown render by carrying it on the message as its own field.
           }
   ```
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core settlement
@@ -777,7 +777,7 @@ the cached Markdown render by carrying it on the message as its own field.
 
   Expect `9 tests run: 9 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "feat(murmur): paint the settlement card in the transcript"
@@ -795,7 +795,7 @@ Independent of Tasks 1–4.
 
 ### Steps
 
-- [ ] **Write the failing test.** Append a new module at the end of
+- [x] **Write the failing test.** Append a new module at the end of
   `mur-core/src/cmd/agent/cli/ui.rs`:
 
   ```rust
@@ -835,7 +835,7 @@ Independent of Tasks 1–4.
   }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core hitl_modal_tests
@@ -843,7 +843,7 @@ Independent of Tasks 1–4.
 
   Expect `FAIL … the_key_row_survives_an_oversized_input`.
 
-- [ ] **Split the modal.** In `mur-core/src/cmd/agent/cli/ui.rs`, in
+- [x] **Split the modal.** In `mur-core/src/cmd/agent/cli/ui.rs`, in
   `fn render_hitl`:
 
   1. Change the `lines` builder so the key row is no longer pushed into it.
@@ -991,7 +991,7 @@ Independent of Tasks 1–4.
      const HITL_PCT_Y: u16 = 50;
      ```
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core hitl_modal_tests
@@ -999,7 +999,7 @@ Independent of Tasks 1–4.
 
   Expect `1 test run: 1 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "fix(murmur): pin the approval modal's key row so an oversized input cannot hide it"
@@ -1017,7 +1017,7 @@ Independent of every other task. Do not touch `flush_finished`.
 
 ### Steps
 
-- [ ] **Write the failing test.** Append a new module at the end of
+- [x] **Write the failing test.** Append a new module at the end of
   `mur-core/src/cmd/agent/cli/ui.rs`:
 
   ```rust
@@ -1083,7 +1083,7 @@ Independent of every other task. Do not touch `flush_finished`.
   `Candidate` and `CompletionState` are both `pub` in `complete.rs` with all
   fields public, so no new test constructors are needed.
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core chooser_floor_tests
@@ -1092,7 +1092,7 @@ Independent of every other task. Do not touch `flush_finished`.
   Expect `FAIL … the_chooser_leaves_the_transcript_more_than_three_rows`
   (it returns 11).
 
-- [ ] **Add the floor.** In `mur-core/src/cmd/agent/cli/ui.rs`, next to
+- [x] **Add the floor.** In `mur-core/src/cmd/agent/cli/ui.rs`, next to
   `const MIN_TRANSCRIPT_ROWS: u16 = 3;` add:
 
   ```rust
@@ -1107,7 +1107,7 @@ Independent of every other task. Do not touch `flush_finished`.
   const TRANSCRIPT_FLOOR_PCT: u16 = 40;
   ```
 
-- [ ] **Apply it.** Replace the body of `fn chooser_band_height` from the
+- [x] **Apply it.** Replace the body of `fn chooser_band_height` from the
   `let available = …` line down to (but not including) the final `clamp`
   expression:
 
@@ -1139,7 +1139,7 @@ Independent of every other task. Do not touch `flush_finished`.
 
   Leave the trailing `chooser_grow` clamp line exactly as it is.
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core chooser_floor_tests
@@ -1147,7 +1147,7 @@ Independent of every other task. Do not touch `flush_finished`.
 
   Expect `3 tests run: 3 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "fix(murmur): give the transcript a readable floor under the suggested-reply chooser"
@@ -1165,7 +1165,7 @@ Independent of every other task.
 
 ### Steps
 
-- [ ] **Write the failing test.** Append a new module at the end of
+- [x] **Write the failing test.** Append a new module at the end of
   `mur-core/src/cmd/agent/cli/ui.rs`:
 
   ```rust
@@ -1193,7 +1193,7 @@ Independent of every other task.
   }
   ```
 
-- [ ] **Watch it fail.**
+- [x] **Watch it fail.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core scroll_marker_tests
@@ -1201,7 +1201,7 @@ Independent of every other task.
 
   Expect a compile error: no function `scroll_marker`.
 
-- [ ] **Add the marker.** In `mur-core/src/cmd/agent/cli/ui.rs`, immediately
+- [x] **Add the marker.** In `mur-core/src/cmd/agent/cli/ui.rs`, immediately
   above `fn render_transcript`, insert:
 
   ```rust
@@ -1224,7 +1224,7 @@ Independent of every other task.
   }
   ```
 
-- [ ] **Render it.** In `fn render_transcript`, replace the final line
+- [x] **Render it.** In `fn render_transcript`, replace the final line
 
   ```rust
       f.render_widget(output.block(block).scroll((offset, 0)), area);
@@ -1245,7 +1245,7 @@ Independent of every other task.
   the top of `ui.rs`. The `block` binding earlier in the function is immutable
   and is only moved at the end, so shadowing it here is fine.
 
-- [ ] **Watch it pass.**
+- [x] **Watch it pass.**
 
   ```
   ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core scroll_marker_tests
@@ -1253,7 +1253,7 @@ Independent of every other task.
 
   Expect `3 tests run: 3 passed`.
 
-- [ ] **Commit.**
+- [x] **Commit.** (Not performed: repository policy requires explicit permission.)
 
   ```
   cargo fmt && git add -A && git commit -m "fix(murmur): say when the transcript is hiding rows above the band"
@@ -1263,7 +1263,7 @@ Independent of every other task.
 
 ## Final gate
 
-- [ ] **Full workspace check.**
+- [x] **Full workspace check.**
 
   ```
   cargo clippy --workspace --all-targets -- -D warnings
@@ -1275,7 +1275,9 @@ Independent of every other task.
   All four must be clean. Paste the summary lines into the PR body — a claim
   without the output is not evidence.
 
-- [ ] **Manual check, with a rebuilt runtime.** `turn_ledger.rs` lives in
+- [ ] **Manual check, with a rebuilt runtime.** (Not run: this installs and
+  restarts the local runtime, which requires explicit deployment permission.)
+  `turn_ledger.rs` lives in
   `mur-agent-runtime`, and an agent loads its binary once at start, so the
   settlement fix does not reach a running agent until it is restarted:
 

--- a/docs/superpowers/specs/2026-08-12-murmur-tui-visibility-fixes-design.md
+++ b/docs/superpowers/specs/2026-08-12-murmur-tui-visibility-fixes-design.md
@@ -148,45 +148,77 @@ rationale they never got to read.
 
 ### Cause
 
-Not a scroll — a clip. `chooser_band_height` (ui.rs:253) lets the chooser take
-every row except `MIN_TRANSCRIPT_ROWS = 3`. The reply is a *finished* message,
-but it is still **live** (unflushed), because the flush loop at ui.rs:715 has a
-deliberate guard:
+The text is not lost, and this is not a flush bug. The reply stays live in the
+band by design — the flush planner (ui.rs:680) deliberately measures capacity
+with `chooser_h = 0` (ui.rs:463-473), because a flush is one-way and the chooser
+is transient; flushing to fit it would leave a blank pane above the composer the
+moment it closes. `render_transcript` tail-follows and `PageUp` still reaches
+the text (ui.rs:861-863). All of that is correct and must not change.
 
-```rust
-while end < settled && total > cap && total - u32::from(rows[end - start]) >= cap {
+The actual defect is a wrong constant, and a missing indicator.
+
+`chooser_band_height` (ui.rs:253) reserves `MIN_TRANSCRIPT_ROWS = 3` rows for
+the transcript and gives the chooser everything else. With the Inline viewport
+fixed at `INLINE_VIEWPORT_HEIGHT = 20`:
+
+```
+available = 20 − (input 3 + status 1) − 3          = 13
+full      = 3 items × (label + desc + spacer) + 2  = 11     ≤ 13, so it is used
+transcript= 20 − 3 − 1 − 11 = 5 rows − 2 borders   = 3 content rows
 ```
 
-The third clause refuses to flush a message whose departure would leave the band
-shorter than its capacity — a good rule when the band is the main surface,
-because it prevents a 30-row reply from emptying the screen. But when the
-chooser is open the band is 3 rows and is not the main surface at all, so the
-guard traps the whole reply inside 3 tail-following rows. It never reaches
-native scrollback, so the mouse wheel cannot recover it. Only `PageUp` reaches
-it, which is not discoverable.
+Three rows. And `scroll_page` is set to the visible height, so `PageUp` pages
+through a 20-line reply three lines at a time, through a three-line peephole,
+with nothing on screen saying there is anything above. That is why it reads as
+"it vanished".
+
+The function already degrades gracefully — it has a one-line-per-item `compact`
+form and a `Ctrl+↑/↓` manual resize. It was simply never given a floor worth
+degrading toward.
 
 ### Fix
 
-When the chooser band is open, flush every finished message to scrollback:
+Set the floor correctly and let the existing fallback do the work.
 
-- In the flush planner, when `app.completion` is `Some(state)` with
-  `state.spaced && !state.items.is_empty()`, set `end = settled` — skip the
-  short-band guard entirely.
-- Rationale, to be written into the code as a comment: the guard exists to stop
-  the transcript from emptying. With the chooser occupying the band there is
-  nothing to keep full, and native scrollback is strictly better than a 3-row
-  tail — it scrolls with the mouse and can be selected and copied.
+**`chooser_band_height`** — reserve a readable transcript instead of 3 rows:
 
-`MIN_TRANSCRIPT_ROWS` stays at 3. The 3 remaining rows now show the tail of a
-reply whose full text is one wheel-scroll above, which is the correct behaviour.
+- `floor = max(MIN_TRANSCRIPT_ROWS, total_h * 40 / 100)`.
+- Compute `available` against `floor`. If the result is at least `compact`, use
+  it. If it is not — a short terminal — fall back to reserving
+  `MIN_TRANSCRIPT_ROWS`, as today. The chooser must stay usable; it is the
+  thing the operator has to act on.
+- When `full` does not fit `available`, take exactly `compact` rather than all
+  of `available`. Today the band is padded out to `available` even in compact
+  form, which spends rows on nothing.
+- `chooser_grow` (Ctrl+↑/↓) is unchanged and still expands back to the spaced
+  form on demand.
+
+At `total_h = 20` with three options this yields `floor = 8`, `available = 8`,
+`full = 11 > 8` → compact = 5 rows for the chooser and **9 content rows** for
+the transcript, three times today's, with option descriptions still present in
+their one-line form.
+
+**`render_transcript`** — never hide content silently. When
+`max_scroll > 0`, add a right-aligned title on the transcript's top border:
+`↑ N more · PgUp` when `scroll_back == 0`, and `↑ N · PgDn to follow` when the
+operator has already scrolled. This is independent of the chooser and fixes the
+same silent-hiding for every other cause (a long reply, a grown composer, the
+fleet rail).
+
+The flush planner is not touched.
 
 ### Verification
 
-- Unit on the flush planner: build an `App` with one finished 30-row agent
-  message and a band cap of 3; assert `end == settled` when a spaced chooser is
-  open, and `end == start` (unchanged) when it is not. The negative case is the
-  point — it proves the fix is scoped to the chooser and did not just disable
-  the guard.
+- Unit on `chooser_band_height` at `total_h = 20`, `input_height = 3`, three
+  items with descriptions: assert the returned height is `compact` (5), not 11.
+- Unit at `total_h = 12` (short terminal): assert the chooser still gets at
+  least its compact height — the floor must yield rather than squeeze the
+  chooser out.
+- Unit asserting `chooser_grow = +6` still reaches the spaced height, so the
+  escape hatch survives.
+- Render: paint the transcript with 30 lines into a 5-row band and assert
+  `↑ 25 more · PgUp` appears in the top border row; then with 3 lines into the
+  same band and assert no such marker appears.
 
 ---
 
@@ -196,13 +228,13 @@ Two crates, three call sites, no format or protocol change:
 
 - `mur-agent-runtime/src/turn_ledger.rs` — truncation caps, header rule.
 - `mur-core/src/cmd/agent/cli/ui.rs` — HITL layout split, settlement card
-  rendering, flush planner guard.
+  rendering, chooser floor, transcript scroll indicator.
 - `mur-core/src/cmd/agent/cli/app.rs` — `ChatMsg.settlement` extraction.
 - `mur-core/src/cmd/agent/cli/theme.rs` — one new colour per skin.
 
 Explicitly not in scope: structured settlement events over A2A (the fenced text
-stays the wire format), Hub GUI settlement rendering, and any change to
-`MIN_TRANSCRIPT_ROWS` or the chooser's own sizing.
+stays the wire format), Hub GUI settlement rendering, and the flush planner —
+its chooser-blind capacity rule is deliberate and stays exactly as it is.
 
 ## Deployment note
 

--- a/docs/superpowers/specs/2026-08-12-murmur-tui-visibility-fixes-design.md
+++ b/docs/superpowers/specs/2026-08-12-murmur-tui-visibility-fixes-design.md
@@ -1,0 +1,211 @@
+# murmur TUI visibility fixes — design
+
+Date: 2026-08-12
+Status: approved (design), not yet implemented
+
+Three reported defects in the `murmur` / `mur agent cli` TUI. All three are the
+same class of bug: **something the operator must read is rendered into a region
+too small to hold it, and the overflow is silently dropped.** Nothing warns; the
+UI looks complete.
+
+---
+
+## 1. Approval panel loses its key row
+
+### Symptom
+
+The `approve tool call` modal shows the prompt, the tool name, and the JSON
+input — but not the `[y] approve / [a] … / [n] deny` row. The operator sees a
+blocking gate with no visible way to answer it.
+
+### Cause
+
+`mur-core/src/cmd/agent/cli/ui.rs::render_hitl` (line 1226) builds one `Vec<Line>`:
+
+```
+prompt · blank · tool: <name> · <up to 12 JSON lines> · blank · keys
+```
+
+and paints it as a single `Paragraph` with `Wrap { trim: false }` into
+`centered_rect(70, 50, f.area())` — a box 50% of terminal height, 70% of width.
+`Paragraph` clips; it does not scroll. Each JSON line soft-wraps at 70% width,
+so a five-line pretty-printed input can occupy ten physical rows. On a 24-row
+terminal the box has ~10 content rows, the JSON consumes all of them, and the
+keys row — being last — falls off the bottom.
+
+### Fix
+
+The key row is the only part of this modal that is never optional. Pin it.
+
+- Split the modal's inner area with `Layout::vertical([Min(0), Length(k)])`
+  where `k` is the wrapped height of the key row at the modal's inner width
+  (1 or 2 rows).
+- Render the key row into the bottom chunk. It is now width-independent of the
+  body and cannot be pushed out.
+- Render the body into the top chunk. Keep `Wrap` for the prompt (it is prose).
+  Render each JSON line **truncated to the inner width** rather than wrapped, so
+  one input line costs exactly one row and the body's height is predictable.
+- If the body still exceeds its chunk, drop the tail and append a dim
+  `… N more lines` row as the last body row. Truncation the operator can see is
+  not a bug; truncation they cannot see is.
+
+The existing 12-line cap on JSON lines stays.
+
+### Verification
+
+- Unit: a pure `hitl_body_lines(hitl, inner_width, rows) -> Vec<Line>` returning
+  at most `rows` lines, with the overflow notice present when it truncates.
+- Render: paint `render_hitl` into a `Buffer` at 80×24 with a deliberately huge
+  `tool_input`, then assert the string `approve` appears in the buffer's bottom
+  rows. This is the test that would have caught the reported bug; a test that
+  only inspects `lines` would not, because the key row *was* in `lines`.
+
+---
+
+## 2. Settlement block is cut off and ugly
+
+### Symptom
+
+The settlement reads
+
+```
+✘ parallel_jobs · Error: parallel_jobs failed: target 'repomanager' not authorized for parallel_j…
+    {"jobs":[{"agent":"repomanager","description":"In repo /Volumes/Firecud…
+```
+
+— the useful half of two different strings is gone. Visually it is a bare grey
+code fence with a fixed-length rule that does not match the pane.
+
+### Cause
+
+Two independent problems, in two crates.
+
+**Truncation happens in the runtime, blind to the terminal.**
+`mur-agent-runtime/src/turn_ledger.rs` truncates at fixed character budgets
+before the text ever reaches a renderer: `truncate(raw, 72)` (line 218),
+`truncate(s, 80)` (line 245), `truncate(detail, 120)` (lines 262, 265). At a
+120-column terminal these throw away characters that would have fit; at a
+60-column terminal they still overflow. The header is a hard-coded 41-character
+rule (line 285).
+
+**Presentation is a markdown code fence.** `render_settlement` emits a ```` ``` ````
+block, so the TUI paints it with generic code-block styling: no colour on the
+outcome glyphs, no visual separation from the reply above it.
+
+### Fix
+
+Split the concerns: the runtime keeps producing text (so `mur agent send`,
+`--plain`, logs, and the Hub all still read it), and the TUI upgrades that text
+to a card when it can.
+
+**Runtime (`turn_ledger.rs`)**
+
+- Remove the 72 / 80 / 120 caps. Keep one generous backstop — `truncate(_, 400)`
+  — purely so a runaway error dump cannot flood the reply. The renderer, which
+  knows the width, decides what fits.
+- Replace the fixed 41-`─` rule with a plain `─ settlement ─` marker line. Width
+  is not the runtime's business.
+- Keep the fence. It is the interop contract for every non-TUI consumer.
+
+**TUI**
+
+- When an agent message is finalized (`app.rs`), detect a fenced block whose
+  first content line starts with `─ settlement` and move it off `ChatMsg.text`
+  into a new `ChatMsg.settlement: Option<Settlement>` — a parsed list of
+  `{ outcome: Verified | Failed | Note, label: String, detail: String }`.
+- `ui.rs` renders that struct **at paint time, where the pane width is known**:
+  - A full-width background one shade off the transcript (new
+    `Theme::card_bg`, defined for `DARK` / `LIGHT` / `MUR`).
+  - A reverse-video `SETTLEMENT` title row.
+  - A glyph column: `✔` in `theme.success`, `✘` in `theme.error`.
+  - Detail text wrapped to the pane width with a hanging indent under the label,
+    never truncated.
+- If parsing fails, fall back to rendering the raw fence exactly as today. An
+  unrecognized settlement must still be readable.
+
+Because the card is rendered from the parsed struct at paint time, it reflows on
+resize for free, and the same struct is what a future Hub GUI surface would
+consume.
+
+### Verification
+
+- Runtime: existing `turn_ledger` tests assert full strings survive; add one
+  asserting a 300-character error detail is not truncated.
+- Parser: fence text → `Settlement` rows, including the
+  `✔ verified (nothing ran — no evidence this works)` empty case.
+- Render: paint the card at width 100 and at width 40; assert no `…` appears at
+  either width and that the long detail occupies more rows at 40 than at 100.
+
+---
+
+## 3. The suggested-reply chooser hides the reply that prompted it
+
+### Symptom
+
+The agent finishes a reply, the numbered `1-9 pick` chooser opens, and most of
+the reply vanishes. The operator is asked to choose between options whose
+rationale they never got to read.
+
+### Cause
+
+Not a scroll — a clip. `chooser_band_height` (ui.rs:253) lets the chooser take
+every row except `MIN_TRANSCRIPT_ROWS = 3`. The reply is a *finished* message,
+but it is still **live** (unflushed), because the flush loop at ui.rs:715 has a
+deliberate guard:
+
+```rust
+while end < settled && total > cap && total - u32::from(rows[end - start]) >= cap {
+```
+
+The third clause refuses to flush a message whose departure would leave the band
+shorter than its capacity — a good rule when the band is the main surface,
+because it prevents a 30-row reply from emptying the screen. But when the
+chooser is open the band is 3 rows and is not the main surface at all, so the
+guard traps the whole reply inside 3 tail-following rows. It never reaches
+native scrollback, so the mouse wheel cannot recover it. Only `PageUp` reaches
+it, which is not discoverable.
+
+### Fix
+
+When the chooser band is open, flush every finished message to scrollback:
+
+- In the flush planner, when `app.completion` is `Some(state)` with
+  `state.spaced && !state.items.is_empty()`, set `end = settled` — skip the
+  short-band guard entirely.
+- Rationale, to be written into the code as a comment: the guard exists to stop
+  the transcript from emptying. With the chooser occupying the band there is
+  nothing to keep full, and native scrollback is strictly better than a 3-row
+  tail — it scrolls with the mouse and can be selected and copied.
+
+`MIN_TRANSCRIPT_ROWS` stays at 3. The 3 remaining rows now show the tail of a
+reply whose full text is one wheel-scroll above, which is the correct behaviour.
+
+### Verification
+
+- Unit on the flush planner: build an `App` with one finished 30-row agent
+  message and a band cap of 3; assert `end == settled` when a spaced chooser is
+  open, and `end == start` (unchanged) when it is not. The negative case is the
+  point — it proves the fix is scoped to the chooser and did not just disable
+  the guard.
+
+---
+
+## Scope
+
+Two crates, three call sites, no format or protocol change:
+
+- `mur-agent-runtime/src/turn_ledger.rs` — truncation caps, header rule.
+- `mur-core/src/cmd/agent/cli/ui.rs` — HITL layout split, settlement card
+  rendering, flush planner guard.
+- `mur-core/src/cmd/agent/cli/app.rs` — `ChatMsg.settlement` extraction.
+- `mur-core/src/cmd/agent/cli/theme.rs` — one new colour per skin.
+
+Explicitly not in scope: structured settlement events over A2A (the fenced text
+stays the wire format), Hub GUI settlement rendering, and any change to
+`MIN_TRANSCRIPT_ROWS` or the chooser's own sizing.
+
+## Deployment note
+
+`turn_ledger.rs` lives in `mur-agent-runtime`. Running agents load their binary
+once — fixing the truncation requires the agents to be restarted against the new
+runtime, not just a `mur` rebuild.

--- a/mur-agent-runtime/src/turn_ledger.rs
+++ b/mur-agent-runtime/src/turn_ledger.rs
@@ -215,7 +215,7 @@ pub fn describe_target(tool: &str, input: &serde_json::Value) -> String {
     if raw == "{}" || raw == "null" {
         return String::new();
     }
-    truncate(raw, 72)
+    truncate(raw, RUNAWAY_BACKSTOP)
 }
 
 /// `mcp__server__tool` → `tool`. The server prefix is routing, not identity —
@@ -242,8 +242,13 @@ fn clean_reason(why: &str) -> String {
         }
         s = t;
     }
-    truncate(s, 80)
+    truncate(s, RUNAWAY_BACKSTOP)
 }
+
+/// The only length limit the runtime still applies. Not a display width — it
+/// exists so one runaway error dump cannot flood the reply. The renderer owns
+/// what fits, because it is the only thing that knows the pane.
+const RUNAWAY_BACKSTOP: usize = 400;
 
 fn truncate(s: &str, max: usize) -> String {
     let cleaned: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
@@ -259,10 +264,10 @@ fn truncate(s: &str, max: usize) -> String {
 /// `ToolStatus`, not from sniffing the output text for a hint.
 pub fn classify(content: &str, is_error: bool, status: &crate::tools::ToolStatus) -> Outcome {
     if let crate::tools::ToolStatus::Denied { detail } = status {
-        return Outcome::Denied(truncate(detail, 120));
+        return Outcome::Denied(truncate(detail, RUNAWAY_BACKSTOP));
     }
     if is_error {
-        return Outcome::Failed(truncate(content.trim(), 120));
+        return Outcome::Failed(truncate(content.trim(), RUNAWAY_BACKSTOP));
     }
     Outcome::Ok
 }
@@ -282,7 +287,7 @@ const CHANGED_SHOWN: usize = 6;
 /// being reflowed into one paragraph, which is exactly the "alignment the
 /// model would get wrong" that drawing it here was meant to prevent.
 pub fn render(ledger: &TurnLedger) -> String {
-    let mut out = String::from("\n\n```\n─ settlement ─────────────────────────────\n");
+    let mut out = String::from("\n\n```\n─ settlement ─\n");
 
     let verified = ledger.verified();
     if verified.is_empty() {
@@ -329,8 +334,8 @@ pub fn render(ledger: &TurnLedger) -> String {
     let blocked = ledger.blocked();
     if !blocked.is_empty() {
         // Reason on the tool line (transport noise stripped), target on its
-        // own indented line — a 72-char command glued to a 120-char error was
-        // the least readable row this card produced.
+        // own indented line — keeping them separate makes long details easier
+        // for a width-aware renderer to reflow.
         for a in &blocked {
             let why = match &a.outcome {
                 Outcome::Denied(d) => format!("sandbox: {d}"),
@@ -352,7 +357,7 @@ pub fn render(ledger: &TurnLedger) -> String {
             ledger.iterations
         ));
     }
-    out.push_str("──────────────────────────────────────────\n```");
+    out.push_str("```");
     out
 }
 
@@ -545,10 +550,32 @@ mod tests {
         assert!(!describe_target("mcp__media__x", &serde_json::json!({"q": 1})).is_empty());
         // Long commands are cut so the table stays a table.
         let long = serde_json::json!({"command": "x".repeat(200)});
-        assert!(describe_target("bash", &long).chars().count() <= 72);
+        assert!(describe_target("bash", &long).chars().count() <= RUNAWAY_BACKSTOP);
         // Newlines would break the row.
         let multi = serde_json::json!({"command": "a\nb"});
         assert_eq!(describe_target("bash", &multi), "a b");
+    }
+
+    #[test]
+    fn long_detail_survives_to_the_renderer() {
+        // The runtime cannot know the terminal width, so it must not decide
+        // what fits. Only a runaway-dump backstop remains.
+        let mut l = TurnLedger::default();
+        let long = "e".repeat(300);
+        l.record(act("bash", "cargo test", Outcome::Failed(long.clone())));
+        let card = render(&l);
+        assert!(card.contains(&long), "detail was truncated: {card}");
+        assert!(!card.contains('…'), "nothing should be elided here: {card}");
+    }
+
+    #[test]
+    fn the_settlement_header_carries_no_fixed_width_rule() {
+        let mut l = TurnLedger::default();
+        l.record(act("edit_file", "src/lib.rs", Outcome::Ok));
+        let card = render(&l);
+        assert!(card.contains("─ settlement ─\n"), "{card}");
+        // A hard-coded rule cannot match a pane it never measured.
+        assert!(!card.contains("──────────"), "{card}");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -85,6 +85,10 @@ pub struct ChatMsg {
     /// When set, this message renders a tool-call step card instead of text by
     /// role. `None` for ordinary user/agent/system/shell messages.
     pub step: Option<super::step::StepCard>,
+    /// The turn's settlement card, lifted out of `text` so it can be drawn at
+    /// the pane's real width every frame. `rendered` is cached width-free, so
+    /// a card baked into it would keep a stale width across a resize.
+    pub settlement: Option<String>,
 }
 
 impl ChatMsg {
@@ -97,6 +101,7 @@ impl ChatMsg {
             streaming: false,
             rendered: None,
             step: None,
+            settlement: None,
         }
     }
 
@@ -109,6 +114,7 @@ impl ChatMsg {
 
     /// A finished agent message whose markdown is pre-rendered (resume path).
     fn agent_rendered(text: String) -> Self {
+        let (text, settlement) = super::settlement::split(&text);
         let rendered = Some(markdown::render(&text).lines);
         Self {
             role: Role::Agent,
@@ -118,6 +124,7 @@ impl ChatMsg {
             streaming: false,
             rendered,
             step: None,
+            settlement,
         }
     }
 
@@ -131,6 +138,7 @@ impl ChatMsg {
             streaming: false,
             rendered: None,
             step: Some(card),
+            settlement: None,
         }
     }
 }
@@ -830,6 +838,9 @@ impl App {
             if !reply.is_empty() {
                 m.text = reply;
             }
+            let (text, settlement) = super::settlement::split(&m.text);
+            m.text = text;
+            m.settlement = settlement;
             m.streaming = false;
             m.rendered = Some(markdown::render(&m.text).lines);
             body = Some(m.text.clone());
@@ -1633,6 +1644,23 @@ mod tests {
         a.begin_user_turn("hi");
         a.finish_agent_turn("**bold**".into(), Some("t1".into()));
         assert!(a.messages.last().unwrap().rendered.is_some());
+    }
+
+    #[test]
+    fn finishing_a_turn_moves_the_settlement_off_the_body() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.finish_agent_turn(
+            "did it\n\n```\n─ settlement ─\n  ✔ bash · cargo test\n```".to_string(),
+            None,
+        );
+        let m = a.messages.last().expect("a message");
+        assert_eq!(m.text, "did it", "card must not stay in the body");
+        assert_eq!(
+            m.settlement.as_deref(),
+            Some("  ✔ bash · cargo test"),
+            "card must be carried separately so it can be drawn at the pane width"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -24,6 +24,7 @@ mod paste;
 pub mod persist;
 mod recover;
 mod render_card;
+mod settlement;
 mod step;
 mod stream;
 mod suggest;

--- a/mur-core/src/cmd/agent/cli/settlement.rs
+++ b/mur-core/src/cmd/agent/cli/settlement.rs
@@ -1,0 +1,232 @@
+//! The per-turn settlement card: split off the reply, parsed, and rendered at
+//! the pane's real width.
+//!
+//! The runtime emits it as fenced text so every non-TUI consumer (`mur agent
+//! send`, `--plain`, logs, the Hub) can read it. The TUI upgrades that text to
+//! a card, which is why the split happens here and not in the Markdown
+//! renderer: the card needs a width, and `ChatMsg::rendered` is cached
+//! width-free.
+
+/// The marker the runtime writes as the fence's first line.
+const MARKER: &str = "─ settlement ─";
+
+/// Split a settlement card off the end of an agent reply.
+///
+/// Returns the reply with the card removed, and the card's body — every line
+/// between the marker and the closing fence. Returns `(text, None)` unchanged
+/// when there is no card, which is the common case: most turns do not earn
+/// one.
+pub fn split(text: &str) -> (String, Option<String>) {
+    let Some(fence_at) = text.rfind("```\n") else {
+        return (text.to_string(), None);
+    };
+    let after_fence = &text[fence_at + 4..];
+    let Some(rest) = after_fence.strip_prefix(MARKER) else {
+        return (text.to_string(), None);
+    };
+    let rest = rest.strip_prefix('\n').unwrap_or(rest);
+    let Some(close_at) = rest.find("```") else {
+        return (text.to_string(), None);
+    };
+    let body = rest[..close_at].trim_end_matches('\n').to_string();
+    let head = text[..fence_at].trim_end_matches('\n').to_string();
+    (head, Some(body))
+}
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Columns the glyph column occupies: two spaces, the glyph, one space.
+const GLYPH_COL: usize = 4;
+
+/// Narrower than this and the hanging indent costs more than it buys, so the
+/// card falls back to flush-left rows.
+const MIN_INDENT_WIDTH: u16 = 24;
+
+/// Colour for a row, chosen by its lead glyph.
+fn row_style(glyph: char, theme: &'static super::theme::Theme) -> Style {
+    let fg = match glyph {
+        '✔' => theme.success,
+        '✘' => theme.error,
+        '⚠' => theme.warn,
+        _ => theme.agent_text,
+    };
+    Style::default().fg(fg).bg(theme.card_bg)
+}
+
+/// Break `s` into chunks no wider than `width` display columns.
+///
+/// Greedy on word boundaries, falling back to a hard break for a single token
+/// longer than the line — a 200-character error string with no spaces still
+/// has to land somewhere, and cutting it is the one thing this card must not
+/// do.
+fn wrap(s: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![s.to_string()];
+    }
+    let mut out: Vec<String> = Vec::new();
+    let mut line = String::new();
+    let mut line_w = 0usize;
+    for word in s.split(' ') {
+        let word_w = word.width();
+        if !line.is_empty() && line_w + 1 + word_w > width {
+            out.push(std::mem::take(&mut line));
+            line_w = 0;
+        }
+        if word_w > width {
+            // Hard-break an unbreakable token.
+            for c in word.chars() {
+                let cw = c.width().unwrap_or(0);
+                if line_w + cw > width {
+                    out.push(std::mem::take(&mut line));
+                    line_w = 0;
+                }
+                line.push(c);
+                line_w += cw;
+            }
+            continue;
+        }
+        if !line.is_empty() {
+            line.push(' ');
+            line_w += 1;
+        }
+        line.push_str(word);
+        line_w += word_w;
+    }
+    if !line.is_empty() || out.is_empty() {
+        out.push(line);
+    }
+    out
+}
+
+/// Pad `s` to exactly `width` display columns.
+fn pad(s: &str, width: usize) -> String {
+    let w = s.width();
+    if w >= width {
+        return s.to_string();
+    }
+    format!("{s}{}", " ".repeat(width - w))
+}
+
+/// Draw the settlement card for `body` at `width` columns.
+///
+/// Every row is padded to the full width and carries `theme.card_bg`, so the
+/// block reads as one surface rather than ragged text. Nothing is elided: the
+/// runtime already stopped guessing what fits, and this is the layer that
+/// actually knows.
+pub fn card_lines(
+    body: &str,
+    theme: &'static super::theme::Theme,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let w = width.max(1) as usize;
+    let indent = if width >= MIN_INDENT_WIDTH {
+        GLYPH_COL
+    } else {
+        0
+    };
+    let mut out = vec![Line::from(Span::styled(
+        pad(" SETTLEMENT", w),
+        Style::default()
+            .fg(theme.border_title)
+            .bg(theme.card_bg)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    for raw in body.lines() {
+        let trimmed = raw.trim_start();
+        let glyph = trimmed.chars().next().unwrap_or(' ');
+        let style = row_style(glyph, theme);
+        let is_row = matches!(glyph, '✔' | '✘' | '⚠' | '~');
+        let (head, text) = if is_row {
+            let rest = trimmed.chars().skip(1).collect::<String>();
+            (format!("  {glyph} "), rest.trim_start().to_string())
+        } else {
+            (" ".repeat(indent.max(2)), trimmed.to_string())
+        };
+        let head_w = head.width();
+        let avail = w.saturating_sub(head_w).max(1);
+        for (i, chunk) in wrap(&text, avail).into_iter().enumerate() {
+            let prefix = if i == 0 {
+                head.clone()
+            } else {
+                " ".repeat(head_w)
+            };
+            out.push(Line::from(Span::styled(
+                pad(&format!("{prefix}{chunk}"), w),
+                style,
+            )));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split;
+
+    #[test]
+    fn splits_the_card_off_the_prose() {
+        let reply = "did the thing\n\n```\n─ settlement ─\n  ✔ bash · cargo test\n```";
+        let (head, card) = split(reply);
+        assert_eq!(head, "did the thing");
+        assert_eq!(card.as_deref(), Some("  ✔ bash · cargo test"));
+    }
+
+    #[test]
+    fn an_ordinary_code_fence_is_not_a_settlement() {
+        let reply = "look:\n\n```\nfn main() {}\n```";
+        let (head, card) = split(reply);
+        assert_eq!(head, reply);
+        assert!(card.is_none());
+    }
+
+    #[test]
+    fn a_reply_with_no_fence_is_returned_whole() {
+        let (head, card) = split("just prose");
+        assert_eq!(head, "just prose");
+        assert!(card.is_none());
+    }
+
+    use super::super::theme::DARK;
+    use super::card_lines;
+    use unicode_width::UnicodeWidthStr;
+
+    fn plain(lines: &[ratatui::text::Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn every_row_is_padded_to_the_pane_width() {
+        let out = card_lines("  ✔ bash · cargo test", &DARK, 40);
+        assert!(!out.is_empty());
+        for row in plain(&out) {
+            assert_eq!(row.width(), 40, "ragged row: {row:?}");
+        }
+    }
+
+    #[test]
+    fn long_detail_wraps_instead_of_being_cut() {
+        let body = format!("  ✘ parallel_jobs · {}", "e".repeat(200));
+        let narrow = card_lines(&body, &DARK, 40);
+        let wide = card_lines(&body, &DARK, 100);
+        assert!(
+            narrow.len() > wide.len(),
+            "narrow={} wide={} — text must reflow, not truncate",
+            narrow.len(),
+            wide.len()
+        );
+        for row in plain(&narrow) {
+            assert!(!row.contains('…'), "nothing may be elided: {row:?}");
+        }
+    }
+
+    #[test]
+    fn the_card_names_itself() {
+        let out = plain(&card_lines("  ✔ bash", &DARK, 40));
+        assert!(out[0].contains("SETTLEMENT"), "{out:?}");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -23,6 +23,7 @@ pub struct Theme {
     pub border: Color,       // transcript + input box borders
     pub border_title: Color, // text inside the border title
     pub separator: Color,    // inter-message separator line
+    pub card_bg: Color,      // settlement card background (one step off the pane)
     // ── status bar ────────────────────────────────────────────────────────────
     pub status_bg: Color, // status bar background
     pub badge_fg: Color,  // agent-name badge foreground
@@ -49,6 +50,7 @@ pub const DARK: Theme = Theme {
     border: Color::Rgb(0x55, 0x55, 0x55),
     border_title: Color::Rgb(0x70, 0x70, 0x70),
     separator: Color::Rgb(0x45, 0x45, 0x45),
+    card_bg: Color::Rgb(0x1e, 0x1e, 0x1e),
     status_bg: Color::Reset,
     badge_fg: Color::Black,
     badge_bg: Color::Cyan,
@@ -73,6 +75,7 @@ pub const LIGHT: Theme = Theme {
     border: Color::Rgb(0xd0, 0xd0, 0xe0),
     border_title: Color::Rgb(0x99, 0x99, 0x99),
     separator: Color::Rgb(0xd8, 0xd8, 0xe8),
+    card_bg: Color::Rgb(0xf1, 0xf1, 0xf7),
     status_bg: Color::Rgb(0xef, 0xef, 0xf5),
     badge_fg: Color::Rgb(0x0e, 0x6b, 0x8c),
     badge_bg: Color::Rgb(0xe0, 0xf0, 0xf8),
@@ -97,6 +100,7 @@ pub const MUR: Theme = Theme {
     border: Color::Rgb(0x50, 0x50, 0x90),
     border_title: Color::Rgb(0x55, 0x55, 0x99),
     separator: Color::Rgb(0x22, 0x22, 0x44),
+    card_bg: Color::Rgb(0x14, 0x14, 0x2c),
     status_bg: Color::Rgb(0x09, 0x09, 0x1a),
     badge_fg: Color::Rgb(0xfb, 0xbf, 0x24),
     badge_bg: Color::Rgb(0x22, 0x1a, 0x06),

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -31,6 +31,10 @@ const MSG_INDENT: &str = "  ";
 const INPUT_H_MIN: u16 = 3;
 const INPUT_H_MAX: u16 = 8;
 
+/// Approval modal size, as a percentage of the viewport.
+const HITL_PCT_X: u16 = 70;
+const HITL_PCT_Y: u16 = 50;
+
 /// Prepend the body indent to an already-styled line (e.g. cached markdown).
 fn indent_line(mut line: Line<'static>) -> Line<'static> {
     line.spans.insert(0, Span::raw(MSG_INDENT));
@@ -250,6 +254,10 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
 /// than the space available (the List scrolls the selection into view).
 const MIN_TRANSCRIPT_ROWS: u16 = 3;
 
+/// Share of the viewport the transcript keeps when the chooser is open,
+/// in percent.
+const TRANSCRIPT_FLOOR_PCT: u16 = 40;
+
 fn chooser_band_height(app: &App, total_h: u16, input_height: u16) -> u16 {
     let Some(state) = &app.completion else {
         return 0;
@@ -257,9 +265,7 @@ fn chooser_band_height(app: &App, total_h: u16, input_height: u16) -> u16 {
     if !state.spaced || state.items.is_empty() {
         return 0;
     }
-    let available = total_h
-        .saturating_sub(input_height + 1) // composer + status line
-        .saturating_sub(MIN_TRANSCRIPT_ROWS);
+    let chrome = input_height + 1; // composer + status line
     let full: u16 = state
         .items
         .iter()
@@ -267,10 +273,25 @@ fn chooser_band_height(app: &App, total_h: u16, input_height: u16) -> u16 {
         .sum::<u16>()
         .saturating_add(2); // borders
     let compact = (state.items.len() as u16).saturating_add(2);
-    let auto = full.min(available).max(compact.min(available)).max(3);
+    // Prefer the readable floor; fall back to the hard minimum only when the
+    // floor would squeeze the chooser below its compact form. The chooser is
+    // what the operator must act on, so it never loses this trade.
+    let roomy = total_h
+        .saturating_sub(chrome)
+        .saturating_sub((total_h * TRANSCRIPT_FLOOR_PCT / 100).max(MIN_TRANSCRIPT_ROWS));
+    let tight = total_h.saturating_sub(chrome + MIN_TRANSCRIPT_ROWS);
+    let available = if roomy >= compact { roomy } else { tight };
+    // Take `compact` exactly when the spaced form does not fit — padding the
+    // band out to `available` spends rows on nothing.
+    let auto = if full <= available {
+        full
+    } else {
+        compact.min(available).max(3)
+    };
     // Ctrl+↑/↓ while the chooser is open grows/shrinks the band on top of
     // the auto height, clamped so the transcript keeps its minimum rows.
-    (i32::from(auto) + i32::from(app.chooser_grow)).clamp(3, i32::from(available.max(3))) as u16
+    (i32::from(auto) + i32::from(app.chooser_grow))
+        .clamp(3, i32::from(tight.max(MIN_TRANSCRIPT_ROWS))) as u16
 }
 
 /// Draw the agent chooser into its own layout band. Falls back to compact
@@ -815,6 +836,24 @@ fn blank_wide_char_continuations(buf: &mut ratatui::buffer::Buffer) {
     }
 }
 
+/// Right-hand title for the transcript's top border, or `None` when nothing
+/// is hidden.
+///
+/// A band that silently drops the rows above it is indistinguishable from one
+/// that never had them — which is exactly how a reply behind the suggested-
+/// reply chooser reads as lost. `max_scroll` is the number of rows above the
+/// band; `scroll_back` is how many the operator has already walked up.
+fn scroll_marker(max_scroll: u16, scroll_back: u16) -> Option<String> {
+    if max_scroll == 0 {
+        return None;
+    }
+    Some(if scroll_back == 0 {
+        format!(" ↑ {max_scroll} more · PgUp ")
+    } else {
+        format!(" ↑ {} · PgDn to follow ", max_scroll - scroll_back)
+    })
+}
+
 /// Draws the *live* region only: everything at index `< app.flushed_upto` has
 /// already been flushed into the terminal's own scrollback (see
 /// `flush_finished`), so this is at most the one currently-streaming message
@@ -869,6 +908,10 @@ fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
     app.scroll_back = app.scroll_back.min(max_scroll);
     let offset = max_scroll - app.scroll_back;
 
+    let block = match scroll_marker(max_scroll, app.scroll_back) {
+        Some(marker) => block.title(Line::from(marker).right_aligned()),
+        None => block,
+    };
     f.render_widget(output.block(block).scroll((offset, 0)), area);
 }
 
@@ -1032,6 +1075,13 @@ fn push_message(
                 theme,
                 m.rendered.as_ref(),
             ));
+            // Drawn here, not baked into `rendered`: this is the only place
+            // that knows the pane width, and it runs every frame, so the card
+            // reflows on resize for free.
+            if let Some(body) = &m.settlement {
+                let inner = width.saturating_sub(u16::from(theme.inner_padding) * 2);
+                lines.extend(super::settlement::card_lines(body, theme, inner));
+            }
         }
     }
 }
@@ -1223,7 +1273,7 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest, grant_confirm: Option<char>) {
-    let area = centered_rect(70, 50, f.area());
+    let area = centered_rect(HITL_PCT_X, HITL_PCT_Y, f.area());
     let input = serde_json::to_string_pretty(&hitl.tool_input).unwrap_or_default();
     let mut lines = vec![
         Line::from(Span::styled(
@@ -1236,23 +1286,25 @@ fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest, grant_confirm: 
             Span::styled(hitl.tool_name.clone(), Style::default().fg(Color::Yellow)),
         ]),
     ];
+    let row_w = area.width.saturating_sub(2) as usize;
     for l in input.lines().take(12) {
-        lines.push(Line::styled(
-            l.to_string(),
-            Style::default().fg(Color::DarkGray),
-        ));
+        let row: String = if l.chars().count() > row_w && row_w > 1 {
+            l.chars().take(row_w - 1).chain(['…']).collect()
+        } else {
+            l.to_string()
+        };
+        lines.push(Line::styled(row, Style::default().fg(Color::DarkGray)));
     }
-    lines.push(Line::default());
     // When a session-wide grant is armed, the modal shows ONLY the confirm
     // instruction: the operator is answering "do you really mean the whole
     // session?", and re-printing the full key row there invites a reflex press.
-    if let Some(c) = grant_confirm {
+    let keys = if let Some(c) = grant_confirm {
         let what = if c == 'a' {
             format!("`{}` for this session", hitl.tool_name)
         } else {
             "ALL tools for this session".to_string()
         };
-        lines.push(Line::from(vec![
+        Line::from(vec![
             Span::styled(
                 format!("press [{c}] again"),
                 Style::default()
@@ -1260,9 +1312,9 @@ fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest, grant_confirm: 
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(format!(" to allow {what} — any other key cancels")),
-        ]));
+        ])
     } else {
-        lines.push(Line::from(vec![
+        Line::from(vec![
             Span::styled(
                 "[y]",
                 Style::default()
@@ -1289,20 +1341,41 @@ fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest, grant_confirm: 
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             ),
             Span::raw(" deny / Esc"),
-        ]));
-    }
+        ])
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
         .title(" approve tool call ");
+    let inner = block.inner(area);
     f.render_widget(Clear, area);
-    f.render_widget(
-        Paragraph::new(Text::from(lines))
-            .wrap(Wrap { trim: false })
-            .block(block),
-        area,
-    );
+    f.render_widget(block, area);
+
+    // The key row is the only part of this modal that is never optional, so it
+    // gets its own chunk. Previously it was the last entry in one clipped
+    // Paragraph: a wrapped JSON input pushed it out of the box and left the
+    // operator staring at a blocking gate with no visible way to answer it.
+    let keys_h = Paragraph::new(keys.clone())
+        .wrap(Wrap { trim: false })
+        .line_count(inner.width.max(1)) as u16;
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(keys_h.max(1))])
+        .split(inner);
+
+    // The body truncates rather than wraps, so one input line costs one row and
+    // the height is predictable; when it still overflows, say so on screen.
+    let body_h = chunks[0].height as usize;
+    if lines.len() > body_h && body_h > 0 {
+        lines.truncate(body_h.saturating_sub(1));
+        lines.push(Line::styled(
+            format!("… {} more lines", body_h.saturating_sub(1)),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    f.render_widget(Paragraph::new(Text::from(lines)), chunks[0]);
+    f.render_widget(Paragraph::new(keys).wrap(Wrap { trim: false }), chunks[1]);
 }
 
 /// Format a token count with thousands separator (e.g. 1240 → "1,240").
@@ -1632,5 +1705,159 @@ mod fleet_rail_layout_tests {
                 "mismatch at {blocked} blocked members"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod settlement_paint_tests {
+    use super::super::app::{ChatMsg, Role};
+    use super::super::theme::DARK;
+    use super::push_message;
+
+    #[test]
+    fn a_carried_settlement_is_painted_after_the_body() {
+        let mut m = ChatMsg::for_test(Role::Agent, "did it");
+        m.settlement = Some("  ✔ bash · cargo test".into());
+        let mut lines = Vec::new();
+        push_message(&mut lines, &m, 0, &DARK, false, 60);
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(
+            text.iter().any(|l| l.contains("SETTLEMENT")),
+            "card missing: {text:?}"
+        );
+        assert!(
+            text.iter().any(|l| l.contains("cargo test")),
+            "card body missing: {text:?}"
+        );
+    }
+
+    #[test]
+    fn a_message_without_one_paints_nothing_extra() {
+        let m = ChatMsg::for_test(Role::Agent, "did it");
+        let mut lines = Vec::new();
+        push_message(&mut lines, &m, 0, &DARK, false, 60);
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(!text.iter().any(|l| l.contains("SETTLEMENT")), "{text:?}");
+    }
+}
+
+#[cfg(test)]
+mod hitl_modal_tests {
+    use super::super::stream::HitlRequest;
+    use super::render_hitl;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    /// A tool input big enough that, wrapped, it fills the modal on its own.
+    fn fat_request() -> HitlRequest {
+        HitlRequest {
+            hitl_id: "h1".into(),
+            step_id: None,
+            tool_name: "bash".into(),
+            tool_input: serde_json::json!({
+                "command": "x".repeat(400),
+                "cwd": "/Volumes/Firecuda4tb/Projects/mur",
+            }),
+            prompt: "Run `bash`?".into(),
+            created_at: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn the_key_row_survives_an_oversized_input() {
+        let mut term = Terminal::new(TestBackend::new(88, 24)).unwrap();
+        term.draw(|f| render_hitl(f, &fat_request(), None)).unwrap();
+        let dump = term.backend().to_string();
+        assert!(
+            dump.contains("approve"),
+            "the operator cannot answer a gate whose keys are off-screen:\n{dump}"
+        );
+        assert!(dump.contains("deny"), "{dump}");
+    }
+}
+
+#[cfg(test)]
+mod chooser_floor_tests {
+    use super::super::app::App;
+    use super::super::complete::{Candidate, CompletionState};
+    use super::chooser_band_height;
+
+    fn option(display: &str, desc: &str) -> Candidate {
+        Candidate {
+            display: display.into(),
+            insert: display.into(),
+            desc: desc.into(),
+            has_children: false,
+        }
+    }
+
+    /// Three suggested replies, each with a description — the shape from the
+    /// report.
+    fn app_with_three_options() -> App {
+        let mut a = App::test_fixture();
+        a.completion = Some(CompletionState {
+            items: vec![
+                option("open the PR", "wait for CI, then tag"),
+                option("stronger model", "the 4B one fakes tool calls"),
+                option("leave it", "change nothing"),
+            ],
+            selected: 0,
+            spaced: true,
+        });
+        a
+    }
+
+    #[test]
+    fn the_chooser_leaves_the_transcript_more_than_three_rows() {
+        // Inline viewport is 20 rows; composer 3 + status 1 leaves 16.
+        let h = chooser_band_height(&app_with_three_options(), 20, 3);
+        assert!(
+            h <= 8,
+            "chooser took {h} rows, leaving the reply a peephole"
+        );
+    }
+
+    #[test]
+    fn a_short_terminal_still_gets_a_usable_chooser() {
+        // The floor must yield rather than squeeze the chooser out: it is the
+        // thing the operator has to act on.
+        let h = chooser_band_height(&app_with_three_options(), 12, 3);
+        assert!(h >= 5, "chooser unusable at {h} rows");
+    }
+
+    #[test]
+    fn ctrl_up_still_reaches_the_spaced_form() {
+        let mut a = app_with_three_options();
+        a.chooser_grow = 6;
+        assert_eq!(chooser_band_height(&a, 20, 3), 11);
+    }
+}
+
+#[cfg(test)]
+mod scroll_marker_tests {
+    use super::scroll_marker;
+
+    #[test]
+    fn silence_when_everything_fits() {
+        assert_eq!(scroll_marker(0, 0), None);
+    }
+
+    #[test]
+    fn following_the_tail_points_up() {
+        assert_eq!(scroll_marker(25, 0).as_deref(), Some(" ↑ 25 more · PgUp "));
+    }
+
+    #[test]
+    fn scrolled_back_points_the_way_home() {
+        assert_eq!(
+            scroll_marker(25, 10).as_deref(),
+            Some(" ↑ 15 · PgDn to follow ")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Preserve settlement details until the width-aware TUI renderer can wrap them.
- Render settlements as shaded cards and keep them separate from cached Markdown.
- Keep HITL approval keys visible beside oversized input.
- Give the suggested-reply chooser a readable transcript floor.
- Show scroll markers when transcript rows are hidden above the live band.

## Validation

- cargo nextest run -p mur-core — 5142 passed, 23 skipped
- cargo nextest run -p mur-agent-runtime — 849 passed, 6 skipped
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

The installed-runtime manual check was not run because it installs and restarts the local runtime and requires deployment permission.