### PR TITLE
fix(agent): confirm slow cold starts after direct respawn / kick

### DIFF
--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -384,9 +384,12 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
     // ── No installed service → nothing will respawn us automatically ──
     // Spawn the runtime directly, detached, so the respawn-poll loop below
     // (shared with the service-managed path) has a fresh process to find.
+    // The spawned pid rides along so the confirmation window can liveness-gate
+    // its slow cold start instead of treating it as "not coming back".
+    let mut direct_pid: Option<u32> = None;
     if !has_service {
         println!("agent '{name}' has no service installed; respawning runtime directly");
-        direct_respawn(name, &agent_home)?;
+        direct_pid = Some(direct_respawn(name, &agent_home)?);
     }
 
     // ── Poll for fresh running.lock with a different pid ──────────────
@@ -400,6 +403,7 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
         &lock_path,
         old_pid,
         has_service,
+        direct_pid,
     )?;
 
     Ok(match new_pid {
@@ -433,7 +437,10 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
 }
 
 /// Spawn the runtime directly (detached) for an agent with no service unit.
-pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<()> {
+///
+/// Returns the spawned child's pid so callers can liveness-gate the wait for
+/// its fresh `running.lock` (a slow cold start is a healthy start).
+pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<u32> {
     let target = resolve_runtime_target();
     verify_runtime_at(&target)
         .with_context(|| format!("cannot respawn agent '{name}' — runtime attestation failed"))?;
@@ -449,7 +456,7 @@ pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<()> {
         .append(true)
         .open(&stderr_log)
         .map_err(|e| anyhow::anyhow!("open {} for respawn stderr: {e}", stderr_log.display()))?;
-    Command::new(&target)
+    let child = Command::new(&target)
         .arg("--profile")
         .arg(name)
         .env("MUR_HOME", &mur_home)
@@ -463,7 +470,7 @@ pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<()> {
                 target.display()
             )
         })?;
-    Ok(())
+    Ok(child.id())
 }
 
 /// Wait up to `secs` for `lock_path` to hold a pid different from `old_pid`.

--- a/mur-core/src/cmd/agent/restart_confirm.rs
+++ b/mur-core/src/cmd/agent/restart_confirm.rs
@@ -47,6 +47,7 @@ pub(super) fn wait_for_confirmed_lock(
     lock_path: &Path,
     old_pid: u32,
     has_service: bool,
+    direct_pid: Option<u32>,
 ) -> anyhow::Result<Option<(u32, String)>> {
     // Passive: launchd KeepAlive=true respawns on process exit; wait for the
     // new lock to appear.
@@ -54,10 +55,13 @@ pub(super) fn wait_for_confirmed_lock(
 
     if new_pid.is_none() {
         // A runnable fresh process that has not written its lock yet is a slow
-        // cold start, not a failure. Kicking it would kill the in-progress
-        // start and restart the clock. Give it real time instead.
-        if has_service && fresh_runnable_process(name, old_pid) {
-            new_pid = poll_while_runnable(name, lock_path, old_pid, SLOW_START_WAIT_SECS);
+        // cold start, not a failure. Kicking / re-spawning it would kill the
+        // in-progress start and restart the clock. Give it real time instead —
+        // whether the fresh process is the service manager's or one we
+        // pre-spawned directly (no service unit).
+        let fresh = fresh_process_pid(managed_pid(name), direct_pid, old_pid);
+        if fresh.is_some() {
+            new_pid = poll_while_runnable(fresh, lock_path, old_pid, SLOW_START_WAIT_SECS);
         }
 
         // No runnable process (or the slow start gave up): the agent is not
@@ -65,16 +69,19 @@ pub(super) fn wait_for_confirmed_lock(
         // service-manager-tracked zombie counts as not-runnable here, so it is
         // kicked instead of being mistaken for a cold start.
         if new_pid.is_none() {
-            if has_service {
+            let fresh_after = if has_service {
                 match kickstart_service(name) {
                     Ok(true) => {
                         println!("agent '{name}': no respawn seen; kicked the service unit");
+                        // The kick restarts the clock from zero, so gate the
+                        // post-kick window on the service manager's new pid.
+                        managed_pid(name)
                     }
                     Ok(false) => {
                         println!(
                             "agent '{name}': service kickstart failed; falling back to direct respawn"
                         );
-                        direct_respawn(name, agent_home)?;
+                        Some(direct_respawn(name, agent_home)?)
                     }
                     Err(e) => {
                         // Attestation failed — fail-closed: do NOT kick the
@@ -86,27 +93,40 @@ pub(super) fn wait_for_confirmed_lock(
                 }
             } else {
                 println!("agent '{name}': no respawn seen; retrying direct respawn");
-                direct_respawn(name, agent_home)?;
+                Some(direct_respawn(name, agent_home)?)
+            };
+            // A kick / fresh spawn is a cold start from zero: give the fresh
+            // process the same liveness-gated slow-start window. Only when no
+            // fresh pid is known (e.g. the kick raced the service manager's
+            // bookkeeping) fall back to the short fixed window.
+            match fresh_after {
+                Some(pid) => {
+                    new_pid =
+                        poll_while_runnable(Some(pid), lock_path, old_pid, SLOW_START_WAIT_SECS);
+                }
+                None => new_pid = poll_new_lock(lock_path, old_pid, RETRY_WAIT_SECS),
             }
-            new_pid = poll_new_lock(lock_path, old_pid, RETRY_WAIT_SECS);
         }
     }
 
     Ok(new_pid)
 }
 
-/// True when a fresh process is alive and able to write the lock: the service
-/// manager's current pid, runnable (not a zombie), and different from the pid
-/// we signalled. A launchd/systemd-tracked zombie keeps `kill(pid, 0)`
-/// succeeding but will never write a lock.
-fn fresh_runnable_process(name: &str, old_pid: u32) -> bool {
-    managed_pid(name).is_some_and(|pid| pid != old_pid && pid_runnable(pid))
+/// The pid of a fresh process alive and able to write the lock: the first of
+/// the service manager's current pid or a pre-spawned direct pid that differs
+/// from the pid we signalled and is runnable (not a zombie). A zombie keeps
+/// `kill(pid, 0)` succeeding but will never write a lock.
+fn fresh_process_pid(managed: Option<u32>, direct: Option<u32>, old_pid: u32) -> Option<u32> {
+    [managed, direct]
+        .into_iter()
+        .flatten()
+        .find(|pid| *pid != old_pid && pid_runnable(*pid))
 }
 
-/// Poll the lock, but only while a runnable fresh process is alive. Fails fast
-/// on a dead process instead of burning the whole window.
+/// Poll the lock, but only while `fresh_pid` is a runnable fresh process.
+/// Fails fast on a dead process instead of burning the whole window.
 fn poll_while_runnable(
-    name: &str,
+    fresh_pid: Option<u32>,
     lock_path: &Path,
     old_pid: u32,
     secs: u64,
@@ -119,7 +139,7 @@ fn poll_while_runnable(
         if std::time::Instant::now() >= deadline {
             return None;
         }
-        if !fresh_runnable_process(name, old_pid) {
+        if !fresh_pid.is_some_and(|pid| pid != old_pid && pid_runnable(pid)) {
             return None;
         }
     }
@@ -210,5 +230,17 @@ mod tests {
     #[test]
     fn ps_state_empty_means_no_such_process() {
         assert!(!ps_state_runnable(""));
+    }
+
+    #[test]
+    fn poll_while_runnable_fails_closed_without_fresh_pid() {
+        // Negative control: with no fresh pid the gate must give up in a
+        // bounded time instead of burning the whole (slow-start) window —
+        // a lock that never appears must not stall the caller.
+        let lock =
+            std::env::temp_dir().join(format!("mur-restart-confirm-none-{}", std::process::id()));
+        let start = std::time::Instant::now();
+        assert_eq!(poll_while_runnable(None, &lock, 1, 1), None);
+        assert!(start.elapsed() < std::time::Duration::from_secs(10));
     }
 }


### PR DESCRIPTION
## Problem

`mur update --restart-agents` reports `✗ '<agent>' not confirmed running` for slow cold-starting agents even though the agent comes back fine. Seen with `drs-architect` on v2.68.7: the update flagged it as not confirmed, yet the runtime wrote its lock ~2.5 min later and the agent was healthy.

## Root cause

`mur update --restart-agents` and `mur agent restart` share `wait_for_confirmed_lock` (`mur-core/src/cmd/agent/restart_confirm.rs`). The liveness-gated slow-start window (#929) only applied to **service-managed** agents. A serviceless agent gets a fixed ~150s window (120s passive + 30s retry) that expires while its freshly spawned runtime is still cold-starting (sandbox apply + model load can take minutes), falsely reporting failure.

## Fix

Extend the liveness-gated slow-start window to both missing halves:

1. **Pre-spawned direct pid**: `restart_agents` already spawns the runtime directly for serviceless agents before entering the confirm window. That spawned pid now rides into `wait_for_confirmed_lock` and gates the slow-start wait exactly like a service manager's pid would.
2. **Post-kick / post-spawn window**: after an active kick or direct respawn, the agent's cold-start clock restarts from zero — the same situation that motivated #929. The wait after it is now liveness-gated (240s while the fresh process stays runnable), falling back to the short 30s fixed window only when no fresh pid is known (e.g. the kick raced the service manager's bookkeeping).

Behavior is otherwise unchanged: fail-closed on attestation failure, zombie still gets kicked, bounded total wait (a dead process fails fast instead of burning the window).

## Tests

- New negative-control test: `poll_while_runnable_fails_closed_without_fresh_pid` — with no fresh pid the gate gives up in bounded time instead of burning the slow-start window.
- `cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check` all clean; restart + restart_confirm tests pass.