### PR TITLE
fix(install): make an install or restart that changed nothing say so

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,14 +52,7 @@ echo "   Size: $(du -h "$BINARY" | cut -f1)"
 
 # Step 3: Install if requested
 if $INSTALL; then
-#  echo "📥 Installing to /usr/local/bin/mur..."
-#  cp "$BINARY" /usr/local/bin/mur
-  echo "📥 Installing to /opt/homebrew/bin/mur..."
-  sudo cp "$BINARY" /opt/homebrew/bin/mur
-  # Re-sign: cp can leave a stale ad-hoc code-signing verdict, causing macOS to
-  # silently SIGKILL the freshly installed binary on next launch. Force a fresh sign.
-  #
-  # One-time setup for stable signing identity (avoids TCC re-prompts on every
+  # One-time setup for a stable signing identity (avoids TCC re-prompts on every
   # rebuild): ad-hoc signing (-s -) gives each build a fresh CDHash, so macOS
   # treats it as a new binary and re-prompts for removable-volume access every
   # time. launchd-managed background agents can't show that prompt, so their
@@ -68,16 +61,39 @@ if $INSTALL; then
   # self-signed one is fine for local use), then export its name:
   #   export MUR_CODESIGN_IDENTITY="Your Certificate Name"
   # With that set, rebuilds keep a consistent identity and TCC grants survive
-  # reinstalls. Leave it unset to keep today's ad-hoc signing behavior.
+  # reinstalls. Leave it unset to keep ad-hoc signing behavior.
   CODESIGN_IDENTITY="${MUR_CODESIGN_IDENTITY:--}"
-  sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/mur || true
+  SIGN_FAILED=false
+
+  # Sign BEFORE installing, as the invoking user — never under sudo.
+  #
+  # `sudo codesign -s "Developer ID ..."` cannot succeed: it runs as root, and
+  # the identity lives in the *user's* login keychain, so it fails with
+  # errSecInternalComponent every single time. This used to run post-copy under
+  # sudo with `|| true`, so every install silently shipped an ad-hoc signature —
+  # the exact thing MUR_CODESIGN_IDENTITY exists to prevent. A Mach-O signature
+  # is embedded in the file, so the `cp` below preserves it.
+  sign() {
+    [ -f "$1" ] || return 0
+    if ! codesign --force -s "$CODESIGN_IDENTITY" "$1"; then
+      echo "⚠ codesign FAILED for $1 (identity: $CODESIGN_IDENTITY)"
+      SIGN_FAILED=true
+    fi
+  }
+
+  BIN_DIR="$(dirname "$BINARY")"
+  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+    sign "$BIN_DIR/$b"
+  done
+
+  echo "📥 Installing to /opt/homebrew/bin/mur..."
+  sudo cp "$BINARY" /opt/homebrew/bin/mur
   sudo ln -sfn /opt/homebrew/bin/mur /opt/homebrew/bin/murmur
   echo "Installed murmur -> /opt/homebrew/bin/mur (symlink)"
 
   MCP_BINARY="$SCRIPT_DIR/target/release/mur-mcp-server"
   if [ -f "$MCP_BINARY" ]; then
     sudo cp "$MCP_BINARY" /opt/homebrew/bin/mur-mcp-server
-    sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/mur-mcp-server || true
     echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
   fi
 
@@ -86,7 +102,6 @@ if $INSTALL; then
   GATEWAY_BINARY="$SCRIPT_DIR/target/release/mur-research-gateway"
   if [ -f "$GATEWAY_BINARY" ]; then
     sudo cp "$GATEWAY_BINARY" /opt/homebrew/bin/mur-research-gateway
-    sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/mur-research-gateway || true
     echo "Installed mur-research-gateway -> /opt/homebrew/bin/mur-research-gateway"
   fi
 
@@ -96,7 +111,6 @@ if $INSTALL; then
   DAEMON_BINARY="$SCRIPT_DIR/target/release/murmurd"
   if [ -f "$DAEMON_BINARY" ]; then
     sudo cp "$DAEMON_BINARY" /opt/homebrew/bin/murmurd
-    sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/murmurd || true
     echo "Installed murmurd -> /opt/homebrew/bin/murmurd"
   fi
 
@@ -109,7 +123,6 @@ if $INSTALL; then
   LOCAL_BIN="$HOME/.local/bin"; mkdir -p "$LOCAL_BIN"
   if [ -f "$RUNTIME_BINARY" ]; then
     cp "$RUNTIME_BINARY" "$LOCAL_BIN/.mur-agent-runtime.new"
-    codesign --force -s "$CODESIGN_IDENTITY" "$LOCAL_BIN/.mur-agent-runtime.new" || true
     mv -f "$LOCAL_BIN/.mur-agent-runtime.new" "$LOCAL_BIN/mur-agent-runtime"
     echo "Installed mur-agent-runtime -> $LOCAL_BIN/mur-agent-runtime (canonical; keeps new agents current)"
   fi
@@ -121,6 +134,12 @@ if $INSTALL; then
     if [ "${STALE:-0}" -gt 0 ]; then
       echo "⚠ $STALE agent(s) are running a stale runtime — run 'mur agent restart --stale' (--dry-run to list)"
     fi
+  fi
+
+  if $SIGN_FAILED; then
+    echo "⚠ installed with an AD-HOC signature — every rebuild looks like a new"
+    echo "  program to macOS, so headless agents can lose keychain/TCC grants."
+    echo "  Check that '$CODESIGN_IDENTITY' is in your login keychain, then re-run."
   fi
 
   echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -217,7 +217,21 @@ pub fn cmd_create(
     if symlink.symlink_metadata().is_ok() {
         fs::remove_file(&symlink)?;
     }
-    let target = resolve_runtime_target();
+    // Prefer the canonical runtime that lives in this same bin dir — the copy
+    // `build.sh --install` / `mur update` keep fresh. `resolve_runtime_target()`
+    // points at whatever sits beside the *current* `mur`, which for a Homebrew
+    // install is inside the keg: an absolute symlink into a directory no
+    // installer ever refreshes, so the agent silently never upgrades again.
+    let canonical = bin_dir.join(if cfg!(windows) {
+        "mur-agent-runtime.exe"
+    } else {
+        "mur-agent-runtime"
+    });
+    let target = if canonical.exists() {
+        canonical
+    } else {
+        resolve_runtime_target()
+    };
     #[cfg(unix)]
     std::os::unix::fs::symlink(&target, &symlink)
         .with_context(|| format!("symlink {} -> {}", symlink.display(), target.display()))?;

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -14,9 +14,7 @@ use anyhow::{Context, Result, bail};
 use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
 use super::attest::verify_runtime_at;
-use super::{
-    pid_alive, resolve_bin_dir, resolve_mur_home, resolve_runtime_target, restart_confirm, stale,
-};
+use super::{pid_alive, resolve_bin_dir, resolve_mur_home, restart_confirm, stale};
 
 /// Extra grace period added on top of the runtime's `stop_timeout_secs` before
 /// the SIGKILL fallback fires.  The SIGKILL wait MUST outlast the runtime's own
@@ -42,7 +40,8 @@ pub(crate) fn kill_wait_secs(stop_timeout_secs: u64) -> u64 {
 /// - `names` non-empty → those agents (each must have a running.lock;
 ///   validated before any restart happens — no partial action)
 /// - `all = true` → all agents with a running.lock
-/// - `stale_only = true` → only running agents where `is_stale(lock, on_disk_sha())`
+/// - `stale_only = true` → only running agents where `is_stale` holds against
+///   [`stale::on_disk_sha_for`] — that agent's OWN runtime, not a global one
 ///
 /// If none of the three selectors is active an error is returned — bare
 /// `mur agent restart` (no args) must never silently restart everything.
@@ -408,14 +407,31 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
 
     Ok(match new_pid {
         Some((_pid, new_sha)) => {
+            let landed = if new_sha.is_empty() {
+                on_disk_sha
+            } else {
+                new_sha.as_str()
+            };
+            if restart_changed_nothing(&old_sha, on_disk_sha, landed) {
+                // The process is alive, so every liveness check passes — and the
+                // binary is the one we were replacing. Reporting this as success
+                // is how an upgrade silently doesn't happen.
+                let line = format!(
+                    "'{name}' came back on the SAME binary ({}) — expected {}; its runtime is {}",
+                    short8(&old_sha),
+                    short8(on_disk_sha),
+                    stale::runtime_path_for(name).display()
+                );
+                eprintln!("✗ {line}");
+                return Ok(RestartReport {
+                    ok: false,
+                    detail: line,
+                });
+            }
             let line = format!(
                 "agent '{name}' restarted ({} → {})",
                 short8(&old_sha),
-                short8(if new_sha.is_empty() {
-                    on_disk_sha
-                } else {
-                    &new_sha
-                }),
+                short8(landed),
             );
             println!("{line}");
             RestartReport {
@@ -441,7 +457,11 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
 /// Returns the spawned child's pid so callers can liveness-gate the wait for
 /// its fresh `running.lock` (a slow cold start is a healthy start).
 pub(super) fn direct_respawn(name: &str, agent_home: &Path) -> Result<u32> {
-    let target = resolve_runtime_target();
+    // The agent's OWN runtime, not the one beside `mur`. These are not always
+    // the same file, and when they differ this path used to relaunch the exact
+    // binary `--stale` had just flagged — a restart that reported success and
+    // changed nothing.
+    let target = stale::runtime_path_for(name);
     verify_runtime_at(&target)
         .with_context(|| format!("cannot respawn agent '{name}' — runtime attestation failed"))?;
     let mur_home = resolve_mur_home()?;
@@ -571,6 +591,20 @@ fn service_unit_path(_name: &str) -> Option<PathBuf> {
 
 fn read_lock(path: &Path) -> std::io::Result<Option<LockFile>> {
     mur_common::lock_file::read(path)
+}
+
+/// Did a restart that was supposed to move the agent onto a new binary fail to?
+///
+/// `true` only when all three are known and the agent was expected to change
+/// (`on_disk != old`) but did not (`landed == old`). A restart of an
+/// already-current agent legitimately lands on the same sha, so that is NOT a
+/// failure — which is exactly why this cannot be written as `landed == old`.
+fn restart_changed_nothing(old: &str, on_disk: &str, landed: &str) -> bool {
+    const UNKNOWN: &str = "unknown";
+    if old.is_empty() || on_disk.is_empty() || old == UNKNOWN || on_disk == UNKNOWN {
+        return false;
+    }
+    on_disk != old && landed == old
 }
 
 fn read_build_sha(lock_path: &Path) -> Option<String> {
@@ -861,5 +895,32 @@ mod tests {
             // expected (the key assertion is that we didn't panic).
             Ok(true) => panic!("kick should not succeed without a unit loaded"),
         }
+    }
+
+    #[test]
+    fn a_restart_that_lands_on_the_same_binary_is_not_a_success() {
+        // The exact shape of the reported bug: --stale picked the agent because
+        // on-disk moved to `new`, but the respawn relaunched `old`.
+        assert!(restart_changed_nothing("old", "new", "old"));
+    }
+
+    #[test]
+    fn restarting_an_already_current_agent_is_still_a_success() {
+        // Negative control. Without this, "landed == old" alone would call every
+        // ordinary restart of an up-to-date agent a failure.
+        assert!(!restart_changed_nothing("same", "same", "same"));
+    }
+
+    #[test]
+    fn a_restart_that_moved_to_the_new_binary_is_a_success() {
+        assert!(!restart_changed_nothing("old", "new", "new"));
+    }
+
+    #[test]
+    fn unknown_shas_never_manufacture_a_failure() {
+        // We cannot tell, so we do not accuse.
+        assert!(!restart_changed_nothing("unknown", "new", "unknown"));
+        assert!(!restart_changed_nothing("old", "unknown", "old"));
+        assert!(!restart_changed_nothing("", "new", ""));
     }
 }

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -44,30 +44,35 @@ fn build_id(bin: &Path) -> String {
     sha
 }
 
-/// Build-id of the runtime sitting next to the current `mur` binary.
-///
-/// Only correct as a staleness baseline for an agent whose own symlink points
-/// here — prefer [`on_disk_sha_for`], which cannot get that wrong.
-pub fn on_disk_sha() -> String {
-    build_id(&resolve_runtime_target())
-}
-
-/// Build-id of the binary that will *actually* be exec'd for `agent`.
+/// The runtime binary that will *actually* be exec'd for `agent`.
 ///
 /// A restart does not run the runtime next to `mur`; it runs the agent's own
 /// `~/.local/bin/mur_agent_<name>` — that path is literally `ProgramArguments[0]`
 /// in the service descriptor, and those symlinks do not all point at the same
 /// runtime (a dev checkout, an older keg, and `mur update`'s copy can coexist).
-/// Comparing every agent against one global runtime therefore answers a question
-/// nobody asked: `--stale` can restart an agent that comes back on the same old
-/// binary, and stay silent about one that is genuinely behind.
+///
+/// This is the single source of truth for "which binary belongs to this agent".
+/// Both the staleness verdict and the direct respawn read it, because when they
+/// each resolved it their own way they disagreed: the verdict measured the
+/// agent's symlink while the respawn exec'd the runtime beside `mur`, so a
+/// restart could relaunch the very binary it had just called stale and still
+/// print a tick.
 ///
 /// Falls back to the global runtime when the agent has no symlink yet.
-pub fn on_disk_sha_for(agent: &str) -> String {
+pub fn runtime_path_for(agent: &str) -> PathBuf {
     match resolve_bin_dir().map(|d| d.join(format!("mur_agent_{agent}"))) {
-        Ok(link) if link.symlink_metadata().is_ok() => build_id(&link),
-        _ => on_disk_sha(),
+        Ok(link) if link.symlink_metadata().is_ok() => link,
+        _ => resolve_runtime_target(),
     }
+}
+
+/// Build-id of the binary that will *actually* be exec'd for `agent`.
+///
+/// Comparing every agent against one global runtime answers a question nobody
+/// asked: `--stale` can restart an agent that comes back on the same old
+/// binary, and stay silent about one that is genuinely behind.
+pub fn on_disk_sha_for(agent: &str) -> String {
+    build_id(&runtime_path_for(agent))
 }
 
 /// Return `true` when the agent whose lock is `lock` is running a stale binary.


### PR DESCRIPTION
## Problem

Three silent no-ops found while installing #932/#933 on a live machine. All the same shape: **the tool had the evidence in hand and still reported success.**

```
$ mur agent restart mur
agent 'mur' restarted (e2b2413f → e2b2413f)

restart summary — 1/1 confirmed running:
  ✓ agent 'mur' restarted (e2b2413f → e2b2413f)
```

Same sha on both sides of the arrow, printed, then ticked.

## Root causes

**1. `sudo codesign` cannot ever work.** `build.sh --install` ran

```bash
sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/mur || true
```

as root, while the Developer ID lives in the *user's* login keychain. It fails with `errSecInternalComponent` on every install, and `|| true` swallows it — so every `--install` silently shipped the linker's ad-hoc signature. That is precisely what `MUR_CODESIGN_IDENTITY` exists to prevent: ad-hoc gives a fresh CDHash per build, macOS treats each install as a new program, and headless agents lose the keychain/TCC grants they need.

Fixed by signing **before** the copy, as the invoking user — a Mach-O signature is embedded in the file, so `cp` preserves it — and by naming the consequence when signing fails instead of hiding it.

**2. Two definitions of "this agent's runtime".** `stale::on_disk_sha_for` measured the agent's own `~/.local/bin/mur_agent_<name>`, while `direct_respawn` exec'd `resolve_runtime_target()` — the runtime beside `mur`. On a Homebrew install those are different files, so a restart relaunched the exact binary `--stale` had just flagged. Both now read `stale::runtime_path_for`, so they cannot diverge again.

**3. Agent creation pinned the symlink into the keg.** `lifecycle.rs` created `mur_agent_<name>` pointing at `resolve_runtime_target()` — for a Homebrew `mur`, an absolute path inside `/opt/homebrew/Cellar/...`, which no installer refreshes. Those agents never upgrade again, and `--stale` is *correct* to stay quiet about them (their own baseline never moves), so the operator sees "everything current" forever. On the reporting machine this hid 14 of 27 running agents. Creation now prefers the canonical runtime in the same bin dir — the copy `build.sh --install` / `mur update` keep fresh.

## Also

A restart that lands on the same sha it was replacing is now reported as a failure, not a tick — the last line of defence if these ever drift apart again.

## Tests

New, in `cmd::agent::restart::tests`:

- `a_restart_that_lands_on_the_same_binary_is_not_a_success` — the reported bug.
- `restarting_an_already_current_agent_is_still_a_success` — **negative control**. This is why the check is not `landed == old`: an ordinary restart of an up-to-date agent legitimately lands on the same sha, and calling that a failure would be a worse bug than the one being fixed.
- `a_restart_that_moved_to_the_new_binary_is_a_success`
- `unknown_shas_never_manufacture_a_failure`

```
cargo nextest run -p mur-core --lib restart::tests
     Summary [0.053s] 17 tests run: 17 passed, 2379 skipped

cargo nextest run -p mur-core --lib stale::tests
     Summary [0.018s] 4 tests run: 4 passed, 2392 skipped

cargo clippy -p mur-core --all-targets -- -D warnings   # clean
cargo fmt --check                                        # clean
bash -n build.sh                                         # clean
```

Deleting `direct_respawn`'s old call site left `stale::on_disk_sha` with no callers; clippy's `--all-targets` caught it and it is removed rather than `#[allow]`-ed.

## Not fixed here

`sudo cp` writes *through* the Homebrew symlink into the keg, so a local `--install` mutates `/opt/homebrew/Cellar/mur/<v>/bin/mur` and a later `brew upgrade`/`reinstall` silently reverts it. Pre-existing behaviour, out of scope for this PR, worth its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)