### PR TITLE
fix(build): install without sudo, and never through Homebrew's symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Operational guidance for Claude Code working in this repository. Detailed runtim
 
 # ── Build only ──
 ./build.sh                      # Release build with embedded web dashboard
-./build.sh --install            # Build + install to /opt/homebrew/bin/mur
+./build.sh --install            # Build + install to ~/.local/bin (no sudo; MUR_INSTALL_DIR overrides)
 
 # ── Manual build (without embedded dashboard) ──
 cargo build --workspace         # Debug build

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ cargo nextest run --workspace    # tests (CI uses nextest)
 cargo clippy --workspace -- -D warnings
 
 ./build.sh                       # release build with the embedded web dashboard
-./install.sh                     # build + install to /opt/homebrew/bin/mur
+./install.sh                     # build + install to ~/.local/bin (no sudo; MUR_INSTALL_DIR overrides)
 ```
 
 The two Tauri apps (`mur-hub-gui`, legacy `mur-agent-gui`) build from their own

--- a/build.sh
+++ b/build.sh
@@ -41,10 +41,14 @@ MUR_WEB_DIST="$MUR_WEB_DIR/dist" cargo build $RELEASE
 
 echo "✅ Build complete"
 
+# Honor CARGO_TARGET_DIR: cargo writes there, so hardcoding $SCRIPT_DIR/target
+# made the script look for a binary cargo never put there — and every later
+# `[ -f ... ]` guard then quietly skipped its file.
+TARGET_DIR="${CARGO_TARGET_DIR:-$SCRIPT_DIR/target}"
 if [ "$RELEASE" = "--release" ]; then
-  BINARY="$SCRIPT_DIR/target/release/mur"
+  BINARY="$TARGET_DIR/release/mur"
 else
-  BINARY="$SCRIPT_DIR/target/debug/mur"
+  BINARY="$TARGET_DIR/debug/mur"
 fi
 
 echo "   Binary: $BINARY"
@@ -86,45 +90,70 @@ if $INSTALL; then
     sign "$BIN_DIR/$b"
   done
 
-  echo "📥 Installing to /opt/homebrew/bin/mur..."
-  sudo cp "$BINARY" /opt/homebrew/bin/mur
-  sudo ln -sfn /opt/homebrew/bin/mur /opt/homebrew/bin/murmur
-  echo "Installed murmur -> /opt/homebrew/bin/mur (symlink)"
-
-  MCP_BINARY="$SCRIPT_DIR/target/release/mur-mcp-server"
-  if [ -f "$MCP_BINARY" ]; then
-    sudo cp "$MCP_BINARY" /opt/homebrew/bin/mur-mcp-server
-    echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
+  # `mur` is not optional. Every other artifact is guarded by `[ -f ]` because a
+  # partial workspace build legitimately lacks some of them, but if the main
+  # binary is missing then the build did not produce what we are about to claim
+  # we installed — and a run that installs nothing must not print a tick.
+  if [ ! -f "$BINARY" ]; then
+    echo "❌ $BINARY does not exist — nothing to install."
+    echo "   (cargo writes to \$CARGO_TARGET_DIR when set; this script looked in $TARGET_DIR)"
+    exit 1
   fi
 
-  # The research gateway (stdio MCP server for tiered web fetch/search).
-  # Agent sandboxes spawn it by name off PATH, so it must land next to `mur`.
-  GATEWAY_BINARY="$SCRIPT_DIR/target/release/mur-research-gateway"
-  if [ -f "$GATEWAY_BINARY" ]; then
-    sudo cp "$GATEWAY_BINARY" /opt/homebrew/bin/mur-research-gateway
-    echo "Installed mur-research-gateway -> /opt/homebrew/bin/mur-research-gateway"
-  fi
+  # Install into a user-writable dir — never through Homebrew's symlink.
+  #
+  # `/opt/homebrew/bin/mur` is a symlink into the keg, and `cp` follows symlinks,
+  # so `sudo cp` here was silently overwriting
+  # `/opt/homebrew/Cellar/mur/<version>/bin/mur`. Brew never notices (it does not
+  # checksum installed kegs), so `mur --version` kept reporting the released
+  # version while running a local build, and the next `brew upgrade`/`reinstall`
+  # reverted the dev build with no message. Writing to our own directory instead
+  # leaves the package manager's files alone — and needs no sudo at all, which
+  # also removes the password prompt that made `--install` unusable from any
+  # non-interactive shell.
+  INSTALL_DIR="${MUR_INSTALL_DIR:-$HOME/.local/bin}"
+  mkdir -p "$INSTALL_DIR"
+  echo "📥 Installing to $INSTALL_DIR..."
 
-  # The background daemon. `mur daemon start` looks for `murmurd` alongside
-  # `mur`, so install it too — otherwise the daemon (and the Hub/phone voice
-  # path that runs through it) is unavailable on a release install.
-  DAEMON_BINARY="$SCRIPT_DIR/target/release/murmurd"
-  if [ -f "$DAEMON_BINARY" ]; then
-    sudo cp "$DAEMON_BINARY" /opt/homebrew/bin/murmurd
-    echo "Installed murmurd -> /opt/homebrew/bin/murmurd"
-  fi
+  # Atomic cp+mv: a running agent holding the old inode would otherwise give
+  # ETXTBSY. It keeps its process (and its old binary) until restarted.
+  install_bin() {
+    src="$1"; name="$2"
+    [ -f "$src" ] || return 0
+    cp "$src" "$INSTALL_DIR/.$name.new"
+    mv -f "$INSTALL_DIR/.$name.new" "$INSTALL_DIR/$name"
+    echo "Installed $name -> $INSTALL_DIR/$name"
+  }
 
-  # mur-agent-runtime (already built by the workspace build above) is what new
-  # agents symlink to via PATH (resolve_runtime_target). Keep the canonical copy at
-  # ~/.local/bin fresh, else newly-created/restarted agents inherit a STALE runtime
-  # (e.g. one missing channel/delegate). Atomic cp+mv avoids ETXTBSY for agents
-  # running off it; they pick up the new binary on their next restart.
-  RUNTIME_BINARY="$(dirname "$BINARY")/mur-agent-runtime"
-  LOCAL_BIN="$HOME/.local/bin"; mkdir -p "$LOCAL_BIN"
-  if [ -f "$RUNTIME_BINARY" ]; then
-    cp "$RUNTIME_BINARY" "$LOCAL_BIN/.mur-agent-runtime.new"
-    mv -f "$LOCAL_BIN/.mur-agent-runtime.new" "$LOCAL_BIN/mur-agent-runtime"
-    echo "Installed mur-agent-runtime -> $LOCAL_BIN/mur-agent-runtime (canonical; keeps new agents current)"
+  # mur-research-gateway is spawned by name off PATH from inside agent sandboxes,
+  # so $INSTALL_DIR must stay one of `standard_exec_dirs()` in
+  # mur-agent-runtime/src/exec_dirs.rs. mur-agent-runtime is what agent symlinks
+  # resolve to, so a stale copy here means new and restarted agents inherit it.
+  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+    install_bin "$BIN_DIR/$b" "$b"
+  done
+  ln -sfn "$INSTALL_DIR/mur" "$INSTALL_DIR/murmur"
+  echo "Installed murmur -> $INSTALL_DIR/mur (symlink)"
+
+  # An install nothing can reach is not an install. `standard_exec_dirs()` puts
+  # /opt/homebrew/bin BEFORE ~/.local/bin, so a copy left there by an older
+  # `--install` (or by Homebrew) shadows what we just wrote — for the shell AND
+  # for every agent sandbox. Name it rather than let the next upgrade look like
+  # it did nothing.
+  SHADOWED=false
+  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+    [ -f "$INSTALL_DIR/$b" ] || continue
+    winner="$(command -v "$b" 2>/dev/null || true)"
+    if [ -n "$winner" ] && [ "$winner" != "$INSTALL_DIR/$b" ]; then
+      echo "⚠ $b: PATH resolves to $winner, NOT the copy just installed"
+      SHADOWED=true
+    fi
+  done
+  if $SHADOWED; then
+    echo "  Older copies shadow this install. Remove them, e.g.:"
+    echo "    sudo rm /opt/homebrew/bin/{mur,murmur,mur-mcp-server,mur-research-gateway,murmurd,mur-agent-runtime}"
+    echo "  (a Homebrew-managed 'mur' can be restored with: brew link --overwrite mur)"
+    echo "  Then re-check with: command -v mur"
   fi
 
   # Nudge: running agents keep their OLD process until restarted, so they're
@@ -142,5 +171,8 @@ if $INSTALL; then
     echo "  Check that '$CODESIGN_IDENTITY' is in your login keychain, then re-run."
   fi
 
-  echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"
+  # Report the version of the copy we actually wrote, not whatever `mur`
+  # happens to resolve to — those differ exactly when the shadow warning above
+  # fired, which is precisely when a wrong version string would mislead.
+  echo "✅ Installed: $("$INSTALL_DIR/mur" --version 2>/dev/null || echo 'done')"
 fi

--- a/docs/BUILD-SCRIPTS.md
+++ b/docs/BUILD-SCRIPTS.md
@@ -19,7 +19,7 @@ Builds `mur-web` (the web dashboard) first, then compiles the `mur` binary with 
 | Flag        | Description                                              |
 |-------------|----------------------------------------------------------|
 | `--release` | Build in release mode *(default if no flag is given)*    |
-| `--install` | Copy the built binary to `/opt/homebrew/bin/mur`         |
+| `--install` | Copy the built binaries to `~/.local/bin` (`MUR_INSTALL_DIR` overrides) |
 
 ### Environment Variables
 
@@ -32,7 +32,7 @@ Builds `mur-web` (the web dashboard) first, then compiles the `mur` binary with 
 1. Runs `npm run build` in the `mur-web` directory
 2. Sets `MUR_WEB_DIST` to `<mur-web>/dist` and runs `cargo build --release`
 3. Prints binary path and size
-4. If `--install`: copies the binary to `/opt/homebrew/bin/mur`
+4. If `--install`: signs, then copies the binaries to `~/.local/bin`, and warns if anything earlier on `PATH` shadows them
 
 ### Example
 
@@ -63,4 +63,4 @@ A one-liner convenience script that runs:
 ./install.sh
 ```
 
-This builds the release binary with the embedded web dashboard and copies it to `/opt/homebrew/bin/mur`.
+This builds the release binary with the embedded web dashboard and copies it to `~/.local/bin`. It never writes into Homebrew's prefix: `/opt/homebrew/bin/mur` is a symlink into the keg, and copying through it silently replaced the packaged build.


### PR DESCRIPTION
Follow-on to #934, which flagged this as out of scope.

## Problem

`/opt/homebrew/bin/mur` is a symlink into the keg, and `cp` follows symlinks. So

```bash
sudo cp "$BINARY" /opt/homebrew/bin/mur
```

was overwriting `/opt/homebrew/Cellar/mur/<version>/bin/mur` **in place**. Homebrew does not checksum installed kegs, so nothing ever noticed: `mur --version` reported the released version while running a local build, and the next `brew upgrade` / `brew reinstall` reverted the dev build with no message.

## Fix

Install into `$MUR_INSTALL_DIR` (default `~/.local/bin`). That leaves the package manager's files alone and needs **no sudo at all** — which also removes the password prompt that made `--install` impossible from any non-interactive shell. That prompt is why the codesign step in #934 ended up under sudo in the first place.

`~/.local/bin` is already in `standard_exec_dirs()` (`mur-agent-runtime/src/exec_dirs.rs:24`), so agent sandboxes still resolve `mur-research-gateway` by name.

## The new failure mode this introduces, and how it is handled

`standard_exec_dirs()` lists `/opt/homebrew/bin` **before** `~/.local/bin`. A copy left there by an older `--install` therefore shadows the new one — for the shell *and* for every agent sandbox. Silently relocating the install would have replaced one invisible staleness bug with another, so the install now checks what each name actually resolves to and names the winner:

```
⚠ mur: PATH resolves to /opt/homebrew/bin/mur, NOT the copy just installed
⚠ mur-mcp-server: PATH resolves to /opt/homebrew/bin/mur-mcp-server, NOT the copy just installed
  Older copies shadow this install. Remove them, e.g.:
    sudo rm /opt/homebrew/bin/{mur,murmur,mur-mcp-server,mur-research-gateway,murmurd,mur-agent-runtime}
  (a Homebrew-managed 'mur' can be restored with: brew link --overwrite mur)
```

## Two more silent no-ops, found by actually running it

A shell script has no unit tests, so the run *is* the test — and the first run failed usefully:

- **`$SCRIPT_DIR/target` was hardcoded.** With `CARGO_TARGET_DIR` set, the script looked where cargo had never written, and every `[ -f "$src" ] || return 0` guard then quietly skipped its file. Now honors `CARGO_TARGET_DIR`.
- **With no binaries found it still succeeded.** It created a dangling `murmur` symlink and printed `✅ Installed`. `mur` is now mandatory — missing means `exit 1` — and the final version line reads the copy just written rather than whatever `PATH` resolves to. Those two differ exactly when the shadow warning fires, which is precisely when a wrong version string would mislead.

The second of those was a bug in this PR's own new code, committing the same sin the #934 series exists to fix.

## Verification

End-to-end against a scratch `MUR_INSTALL_DIR`:

```
📥 Installing to .../instdir...
Installed mur -> .../instdir/mur
Installed mur-mcp-server -> .../instdir/mur-mcp-server
Installed mur-research-gateway -> .../instdir/mur-research-gateway
Installed murmurd -> .../instdir/murmurd
Installed mur-agent-runtime -> .../instdir/mur-agent-runtime
Installed murmur -> .../instdir/mur (symlink)
⚠ mur: PATH resolves to /opt/homebrew/bin/mur, NOT the copy just installed
   [... 4 more, correctly naming each winner ...]
✅ Installed: mur 2.68.7
```

Checked afterwards: no sudo prompt and exit 0; six entries present; `codesign -dv` on the installed copy still shows `TeamIdentifier=JQ2C2UA8JV`, so the Developer ID signature survives the copy; no leftover `.mur*.new` temp files; `bash -n build.sh` clean.

Docs updated: `CLAUDE.md`, `README.md`, `docs/BUILD-SCRIPTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)