### PR TITLE
fix(settlement): stop printing a blocked target the reason already names

### DIFF
--- a/mur-agent-runtime/src/turn_ledger.rs
+++ b/mur-agent-runtime/src/turn_ledger.rs
@@ -344,7 +344,14 @@ pub fn render(ledger: &TurnLedger) -> String {
             };
             let tool = short_tool(&a.tool);
             out.push_str(&format!("  ✘ {tool} · {why}\n"));
-            if !a.target.is_empty() && a.target != tool {
+            // Skip the target line when the reason already names it. Tools that
+            // fail on a path usually quote that path in their message, so this
+            // printed it twice — invisible while `clean_reason` truncated at 80
+            // chars (the cap cut the path back out), obvious once the card
+            // stopped truncating. Fall back to printing it whenever the reason
+            // does not contain it verbatim: repeating the target is a cosmetic
+            // wart, losing it is a missing fact.
+            if !a.target.is_empty() && a.target != tool && !why.contains(a.target.as_str()) {
                 out.push_str(&format!("      {}\n", a.target));
             }
         }
@@ -625,5 +632,41 @@ mod tests {
         );
         assert!(!card.contains("tool execution failed"), "{card}");
         assert!(card.contains("      ls; grep"), "{card}");
+    }
+
+    #[test]
+    fn a_reason_that_already_names_the_target_does_not_repeat_it() {
+        // write_file quotes the offending path in its own message, so the card
+        // was printing that path on the reason line and again as the target.
+        let path = "/tmp/scratchpad/settlement-test.txt";
+        let mut l = TurnLedger::default();
+        l.record(act(
+            "write_file",
+            path,
+            Outcome::Failed(format!(
+                "tool execution failed: path not write-entitled: {path} (grant it via `mur agent perm allow-write`)"
+            )),
+        ));
+        let card = render(&l);
+        assert_eq!(
+            card.matches(path).count(),
+            1,
+            "target printed more than once:\n{card}"
+        );
+    }
+
+    #[test]
+    fn a_reason_that_omits_the_target_still_prints_it() {
+        // Negative control. Without this, "never print the target" would look
+        // like it fixed the duplication while quietly dropping the one fact
+        // that says WHICH file the failure was about.
+        let mut l = TurnLedger::default();
+        l.record(act(
+            "write_file",
+            "/tmp/some/file.txt",
+            Outcome::Failed("disk quota exceeded".into()),
+        ));
+        let card = render(&l);
+        assert!(card.contains("/tmp/some/file.txt"), "target lost:\n{card}");
     }
 }


### PR DESCRIPTION
Cosmetic follow-on to #934, spotted while verifying the settlement card live in `murmur`.

## Problem

A tool that fails on a path usually quotes that path in its own message, so the card printed it twice:

```
  ✘ write_file · path not write-entitled: /tmp/.../scratchpad/settlement-test.txt
    (grant it via `mur agent perm allow-write`)
    /tmp/.../scratchpad/settlement-test.txt
```

This was invisible before #934: `clean_reason` truncated at 80 characters, and the cap happened to cut the path back out of the reason line. Removing that truncation made an existing redundancy visible — the fix did not introduce it.

## Fix

Skip the target line only when the reason contains it verbatim:

```rust
if !a.target.is_empty() && a.target != tool && !why.contains(a.target.as_str()) {
```

The fallback direction is deliberate. Repeating the target is a cosmetic wart; losing it drops the one fact that says *which* file the failure was about. So anything short of a verbatim match still prints it.

## Tests

- `a_reason_that_already_names_the_target_does_not_repeat_it` — asserts the path appears exactly once.
- `a_reason_that_omits_the_target_still_prints_it` — **negative control**. Without it, simplifying this to "blocked rows never print a target" would make the duplication go away and look correct while silently dropping the target on every failure that does not quote it.

```
cargo nextest run -p mur-agent-runtime turn_ledger
     Summary [0.034s] 18 tests run: 18 passed, 839 skipped

cargo nextest run -p mur-agent-runtime a_reason_that
     Summary [0.013s] 2 tests run: 2 passed, 855 skipped

cargo clippy -p mur-agent-runtime --all-targets -- -D warnings   # clean
cargo fmt --check                                                 # clean
```

Reminder for whoever installs this: `turn_ledger.rs` is in `mur-agent-runtime`, so agents keep the old card until restarted (`mur agent restart --stale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)