### PR TITLE
chore(release): bump workspace version to 2.68.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.68.7"
+version = "2.68.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.7"
+version = "2.68.8"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release bump for 2.68.8. **Merging this PR is the release** — `tag.yml` tags the merge commit and dispatches `release.yml` (crates.io publish is irreversible), so this PR is the approval gate.

## What ships

| PR | |
|---|---|
| #932 | `fix(murmur)`: make TUI content visibility explicit — approval modal's key row can no longer be pushed out of the box, the settlement renders as a width-aware card instead of a truncated code fence, and the suggested-reply chooser leaves the transcript a readable floor with an `↑ N more · PgUp` marker when rows are hidden |
| #933 | `fix(agent)`: liveness-gated slow-start window after a direct respawn or kick, so a slow cold start is no longer reported as a failure |
| #934 | `fix(install)`: make an install or restart that changed nothing say so — signing before the copy (as the user, never sudo), respawning from the agent's own runtime, and failing a restart that lands on the same binary |
| #935 | `fix(build)`: install to `~/.local/bin` without sudo, never through Homebrew's symlink into the keg |
| #936 | `fix(settlement)`: stop printing a blocked target the reason already names |

All five are fixes; no new surface and no breaking change, hence a patch bump.

## Version hygiene

Both lock files moved with `Cargo.toml` — the root one and `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace crate's version:

```
$ grep -c '2\.68\.7' Cargo.toml Cargo.lock mur-hub-gui/src-tauri/Cargo.lock
Cargo.toml:0
Cargo.lock:0
mur-hub-gui/src-tauri/Cargo.lock:0

$ grep -c '2\.68\.8' Cargo.toml Cargo.lock mur-hub-gui/src-tauri/Cargo.lock
Cargo.toml:1
Cargo.lock:12
mur-hub-gui/src-tauri/Cargo.lock:6
```

Verified by counting rather than by reading the sed output: the `sed -i ''` form fails silently on macOS (exit 0, file unchanged), so a bump that "looks applied" is not evidence it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)