### PR TITLE
fix(runtime): fail the turn when a provider reports a tool call but returns none

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1725,6 +1725,28 @@ impl TaskRunner {
                 }
             }
 
+            // A provider that reports ToolUse owes us the calls it made, so
+            // both being empty is a contradiction: the model called a tool and
+            // the call was lost inside the provider client. Falling through
+            // would push an empty ToolUse into history and hand `resp.text`
+            // back as the reply — shipping the model's narration ("The exact
+            // output is ...") to the user as though the tool had run.
+            // Fabricated results are worse than a failed turn, so stop here.
+            // Not recoverable: the same request against the same client
+            // reproduces it, so a retry only repeats the lie (#938).
+            if resp.stop_reason == StopReason::ToolUse && resp.tool_calls.is_empty() {
+                return Err(task_error(
+                    "llm_error",
+                    format!(
+                        "model {} reported a tool call but the provider client returned \
+                         none; refusing to pass the model's own narration off as a tool \
+                         result",
+                        resp.model
+                    ),
+                    false,
+                ));
+            }
+
             history.push(RichMessage::ToolUse {
                 text: if resp.text.is_empty() {
                     None
@@ -2519,6 +2541,46 @@ mod tests {
                 assert_eq!(task.state, TaskState::Failed);
                 let err = task.error.expect("Failed task must carry an error");
                 assert_eq!(err.code, "llm_error");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    /// A provider that reports ToolUse but hands back no calls must fail the
+    /// turn rather than deliver the model's narration as though the tool had
+    /// run (#938). The text here is the exact fabrication shape observed in
+    /// the wild: the model states a command's output when no command ran.
+    #[tokio::test]
+    async fn tool_use_stop_without_calls_fails_instead_of_fabricating() {
+        use crate::llm::stub::SequenceLlm;
+        let responses: Vec<crate::llm::LlmResponse> = vec![crate::llm::LlmResponse {
+            text: "The exact output of git rev-list --count HEAD is: 2469".into(),
+            input_tokens: 5,
+            output_tokens: 5,
+            model: "test".into(),
+            tool_calls: vec![],
+            stop_reason: crate::llm::StopReason::ToolUse,
+        }];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_max_iterations(50),
+        );
+        let outcome = runner.run_sync(loop_spec("fabricate")).await;
+        match outcome {
+            TaskOutcome::Failed(task) => {
+                let rendered = format!("{task:?}");
+                let err = task.error.expect("Failed task must carry an error");
+                assert_eq!(err.code, "llm_error");
+                assert!(
+                    !err.recoverable,
+                    "a call dropped in the provider client reproduces on retry"
+                );
+                assert!(
+                    !rendered.contains("2469"),
+                    "the model's fabricated tool output must never reach the user, got: {rendered}"
+                );
             }
             other => panic!("expected Failed, got {other:?}"),
         }


### PR DESCRIPTION
Step 1 of #938.

## What this changes

`StopReason::ToolUse` arriving with an empty `tool_calls` list is a contradictory state: the provider told us the model called a tool, and we have no call to execute. `run_agentic_loop` treated it as an ordinary end-of-turn and returned `resp.text`, so the model's *narration* was delivered as the answer.

In practice that means an agent answers:

```
The exact output of git rev-list --count HEAD is:
2469
```

with no tool card, no error, `state: Completed`, `error: None` — while the real answer is **2287** and no command ever ran.

This commit fails the turn instead, with a message naming what went wrong and which model it came from. Marked non-recoverable: the same request against the same client reproduces it, so retrying only repeats the fabrication.

## What this deliberately does NOT change

The underlying drop. `mur-agent-runtime/src/llm/openai.rs` streaming never reads `delta["tool_calls"]` and returns a hardcoded `tool_calls: vec![]` — that is step 2 in #938, and it needs the intermittency question in that issue resolved first (a `provider: openai` agent sometimes executes tools successfully, which the current code reading does not explain).

Splitting it this way means the fabrication stops now, on a small reviewable diff, without waiting on the root-cause work.

## Verification

New regression test `tool_use_stop_without_calls_fails_instead_of_fabricating` asserts three things: the turn fails, the error is non-recoverable, and the fabricated number never appears anywhere in the returned task.

Red/green confirmed rather than assumed — with the guard disabled the test fails with the production symptom:

```
expected Failed, got Completed(Task { state: Completed, error: None,
  messages: [ user: "fabricate",
              agent: "The exact output of git rev-list --count HEAD is: 2469" ] })
```

- `cargo nextest run -p mur-agent-runtime` → **852 passed**, 6 skipped, 0 failed
- `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → clean
- `cargo fmt --check -p mur-agent-runtime` → clean

## Blast radius

One added guard in `run_agentic_loop`, before the history push, so no empty `ToolUse` entry is recorded either. No existing test constructs `ToolUse` with empty `tool_calls` (all four call sites pass a real call), and agents on `provider: anthropic` — 25 of 27 locally — never reach the state.
