### PR TITLE
fix(runtime): assemble streamed tool calls on the OpenAI path

### DIFF
--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -399,6 +399,20 @@ impl LlmClient for OpenAiClient {
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
         let mut stop_reason = StopReason::EndTurn;
+        // Streamed tool calls arrive as fragments: `id` and `function.name`
+        // usually land once, `function.arguments` is concatenated across any
+        // number of chunks, and `index` is what ties the fragments of one call
+        // together (a turn can open several calls at once). Accumulate by index
+        // and assemble after the stream closes — reading only the final chunk
+        // loses every call, which is how a model's tool call used to vanish and
+        // its narration got returned as the answer (#938).
+        #[derive(Default)]
+        struct PartialToolCall {
+            id: String,
+            name: String,
+            arguments: String,
+        }
+        let mut partial: std::collections::BTreeMap<u64, PartialToolCall> = Default::default();
         while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
@@ -440,6 +454,29 @@ impl LlmClient for OpenAiClient {
                         })
                         .await;
                 }
+                if let Some(calls) = delta["tool_calls"].as_array() {
+                    for tc in calls {
+                        let slot = partial
+                            .entry(tc["index"].as_u64().unwrap_or(0))
+                            .or_default();
+                        // Later fragments carry only `arguments`; never let an
+                        // absent or empty field clobber what an earlier chunk
+                        // already established.
+                        if let Some(id) = tc["id"].as_str()
+                            && !id.is_empty()
+                        {
+                            slot.id = id.to_string();
+                        }
+                        if let Some(name) = tc["function"]["name"].as_str()
+                            && !name.is_empty()
+                        {
+                            slot.name = name.to_string();
+                        }
+                        if let Some(args) = tc["function"]["arguments"].as_str() {
+                            slot.arguments.push_str(args);
+                        }
+                    }
+                }
                 // The final content chunk carries `finish_reason`; surface a
                 // max_tokens cut (`"length"`) so the caller can mark the reply
                 // as truncated instead of passing it off as complete.
@@ -458,7 +495,23 @@ impl LlmClient for OpenAiClient {
                 }
             }
         }
-        if text.is_empty() {
+        // A fragment set with no name never became a usable call (a server that
+        // opened an index and then said nothing more about it); dropping it is
+        // safer than inventing a nameless tool.
+        let tool_calls: Vec<crate::llm::ToolCallResult> = partial
+            .into_values()
+            .filter(|p| !p.name.is_empty())
+            .map(|p| crate::llm::ToolCallResult {
+                call_id: p.id,
+                tool_name: p.name,
+                input: serde_json::from_str(&p.arguments)
+                    .unwrap_or(serde_json::Value::Object(Default::default())),
+            })
+            .collect();
+        // A turn that goes straight to a tool call carries no text at all, and
+        // that is a complete, correct response — only a turn with neither text
+        // nor calls is the blank reply this guard exists to catch.
+        if text.is_empty() && tool_calls.is_empty() {
             return Err(LlmError::InvalidResponse("empty streamed response".into()));
         }
         Ok(LlmResponse {
@@ -466,7 +519,7 @@ impl LlmClient for OpenAiClient {
             input_tokens,
             output_tokens,
             model: self.model.clone(),
-            tool_calls: vec![],
+            tool_calls,
             stop_reason,
         })
     }

--- a/mur-agent-runtime/tests/llm_openai_streaming.rs
+++ b/mur-agent-runtime/tests/llm_openai_streaming.rs
@@ -1,0 +1,157 @@
+//! Streaming tool-call assembly for the OpenAI-compatible client.
+//!
+//! Regression cover for #938: `generate_stream` used to read only
+//! `delta.content` and return a hardcoded empty `tool_calls`, so every tool
+//! call a model made over this transport was discarded and its narration was
+//! returned as the answer. These tests drive the real streaming path against
+//! the two chunk shapes seen in production.
+
+use httpmock::prelude::*;
+use mur_agent_runtime::llm::openai::OpenAiClient;
+use mur_agent_runtime::llm::{LlmClient, LlmRequest, RichMessage, StopReason};
+
+fn user(text: &str) -> LlmRequest {
+    LlmRequest {
+        messages: vec![RichMessage::Text {
+            role: "user".into(),
+            content: text.into(),
+        }],
+        max_tokens: Some(200),
+        ..Default::default()
+    }
+}
+
+/// Drive `generate_stream` against a canned SSE body and return the response.
+async fn stream_of(sse: &str) -> mur_agent_runtime::llm::LlmResponse {
+    let server = MockServer::start_async().await;
+    let _mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(sse);
+        })
+        .await;
+    let client = OpenAiClient::new(server.base_url(), "k".into(), "test-model".into());
+    let (tx, _rx) = tokio::sync::mpsc::channel(64);
+    client
+        .generate_stream(user("what branch?"), tx)
+        .await
+        .expect("streamed tool call must not be an error")
+}
+
+/// oMLX (and other single-shot servers) send the whole call in one delta.
+#[tokio::test]
+async fn whole_tool_call_in_one_delta_is_assembled() {
+    let sse = concat!(
+        r#"data: {"choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_3dfd3226","type":"function","function":{"name":"bash","arguments":"{\"command\": \"git branch --show-current\"}"}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "\n\ndata: [DONE]\n\n",
+    );
+    let resp = stream_of(sse).await;
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    assert_eq!(resp.tool_calls.len(), 1, "the call must survive the stream");
+    let call = &resp.tool_calls[0];
+    assert_eq!(call.call_id, "call_3dfd3226");
+    assert_eq!(call.tool_name, "bash");
+    assert_eq!(call.input["command"], "git branch --show-current");
+}
+
+/// DeepSeek opens the call with an empty `arguments`, then streams the JSON in
+/// fragments. Concatenating them in order is the whole point of the accumulator.
+#[tokio::test]
+async fn fragmented_arguments_are_concatenated_in_order() {
+    let sse = concat!(
+        r#"data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_00","type":"function","function":{"name":"bash","arguments":""}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"comm"}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"and\": \"git "}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"status\"}"}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "\n\ndata: [DONE]\n\n",
+    );
+    let resp = stream_of(sse).await;
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.tool_calls[0].call_id, "call_00");
+    assert_eq!(resp.tool_calls[0].tool_name, "bash");
+    assert_eq!(
+        resp.tool_calls[0].input["command"], "git status",
+        "argument fragments must be joined, not overwritten"
+    );
+}
+
+/// Two calls opened in the same turn are kept apart by their `index`, and a
+/// later fragment carrying only `arguments` must not blank the name or id.
+#[tokio::test]
+async fn parallel_calls_are_kept_separate_by_index() {
+    let sse = concat!(
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"a","type":"function","function":{"name":"bash","arguments":"{\"command\":\"pwd\"}"}},{"index":1,"id":"b","type":"function","function":{"name":"read_file","arguments":""}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"path\":\"/tmp/x\"}"}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "\n\ndata: [DONE]\n\n",
+    );
+    let resp = stream_of(sse).await;
+    assert_eq!(resp.tool_calls.len(), 2);
+    assert_eq!(resp.tool_calls[0].tool_name, "bash");
+    assert_eq!(resp.tool_calls[0].input["command"], "pwd");
+    assert_eq!(
+        resp.tool_calls[1].tool_name, "read_file",
+        "a fragment with no name must not clobber the established one"
+    );
+    assert_eq!(resp.tool_calls[1].call_id, "b");
+    assert_eq!(resp.tool_calls[1].input["path"], "/tmp/x");
+}
+
+/// A turn that goes straight to a tool call carries no text. That is a
+/// complete response, not the blank reply the empty-stream guard is for.
+#[tokio::test]
+async fn tool_call_without_text_is_not_an_empty_response() {
+    let sse = concat!(
+        r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"bash","arguments":"{\"command\":\"ls\"}"}}]}}]}"#,
+        "\n\n",
+        r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+        "\n\ndata: [DONE]\n\n",
+    );
+    let resp = stream_of(sse).await;
+    assert!(resp.text.is_empty());
+    assert_eq!(resp.tool_calls.len(), 1);
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+}
+
+/// Neither text nor calls is still an error — the guard must keep catching the
+/// genuinely blank reply it was written for.
+#[tokio::test]
+async fn stream_with_neither_text_nor_calls_still_errors() {
+    let server = MockServer::start_async().await;
+    let _mock = server
+        .mock_async(|when, then| {
+            when.method(POST).path("/chat/completions");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .body(concat!(
+                    r#"data: {"choices":[{"index":0,"delta":{"content":""}}]}"#,
+                    "\n\ndata: [DONE]\n\n",
+                ));
+        })
+        .await;
+    let client = OpenAiClient::new(server.base_url(), "k".into(), "test-model".into());
+    let (tx, _rx) = tokio::sync::mpsc::channel(64);
+    let err = client
+        .generate_stream(user("hi"), tx)
+        .await
+        .expect_err("a reply with no text and no calls must still be rejected");
+    assert!(
+        format!("{err}").contains("empty streamed response"),
+        "got: {err}"
+    );
+}


### PR DESCRIPTION
Step 2 of #938. Follows #941, which made this state fail loudly instead of fabricating; this stops it happening.

## The bug

`generate_stream` in `mur-agent-runtime/src/llm/openai.rs` consumed `delta.content` and `delta.reasoning`, derived `StopReason::ToolUse` correctly from `finish_reason` — and then returned a hardcoded `tool_calls: vec![]`. `delta["tool_calls"]` was never read anywhere in the file, so every tool call made over this transport was silently discarded.

Both servers observed in production do send calls this way:

```json
{"delta":{"tool_calls":[{"index":0,"id":"call_3dfd3226","type":"function",
  "function":{"name":"bash","arguments":"{\"command\": \"git branch --show-current\"}"}}]}}
{"delta":{},"finish_reason":"tool_calls"}
```

## The fix

Accumulate fragments into a `BTreeMap<u64, PartialToolCall>` keyed by `index`, assembled after the stream closes. The wire format spreads one call across chunks:

- `id` and `function.name` usually arrive once, on the opening fragment
- `function.arguments` is concatenated over any number of chunks
- `index` is what distinguishes calls when a turn opens several at once

Later fragments carry only `arguments`, so an absent or empty `id`/`name` must never clobber what an earlier chunk established — that is what the emptiness checks guard.

Two production shapes are covered: oMLX sends the whole call in one delta; DeepSeek opens with `arguments: ""` and streams the JSON in pieces.

**Also narrowed the empty-stream guard.** `text.is_empty()` alone rejected a turn that goes straight to a tool call — a complete, correct response with no prose. It now fires only when there is neither text nor calls, so the blank-reply case it was written for still errors.

## Verification

New integration test file drives the real streaming path through `httpmock` with canned SSE bodies — not an extracted helper:

| test | covers |
|---|---|
| `whole_tool_call_in_one_delta_is_assembled` | oMLX single-delta shape |
| `fragmented_arguments_are_concatenated_in_order` | DeepSeek fragmented `arguments` |
| `parallel_calls_are_kept_separate_by_index` | two calls in one turn; a name-less fragment must not clobber |
| `tool_call_without_text_is_not_an_empty_response` | tool-call-only turn is not an error |
| `stream_with_neither_text_nor_calls_still_errors` | the original guard still catches blank replies |

Red/green confirmed by stashing the source change and re-running: **4 of the 5 fail against the old code**, and the fifth (`stream_with_neither_text_nor_calls_still_errors`) passes both before and after, which is correct — it pins behaviour this PR must preserve.

- `cargo nextest run -p mur-agent-runtime` → **857 passed**, 6 skipped, 0 failed
- `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → clean
- `cargo fmt --check -p mur-agent-runtime` → clean

## Still open in #938

The intermittency noted in the issue — a `provider: openai` agent that *sometimes* executed tools successfully — is still unexplained by code reading. This PR makes the streaming path correct regardless of that answer, but the question is worth closing out separately in case it points at a second path.

Not verified end-to-end against a live agent yet: the running runtime binaries predate both fixes, and redeploying means restarting agents.
