### PR TITLE
fix(cli): stop the status line stating two different things about one fact (#940)

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1423,10 +1423,9 @@ impl TaskRunner {
                         }
                     };
                     if !decision.allow {
-                        let reason_str = decision.reason.as_deref().unwrap_or("denied");
                         return Err(task_error(
                             "hitl_denied",
-                            format!("tool call denied: {reason_str}"),
+                            deny_message(decision.reason.as_deref()),
                             false,
                         ));
                     }
@@ -2109,6 +2108,19 @@ fn last_assistant_text(history: &[crate::llm::RichMessage]) -> Option<String> {
 }
 
 /// Build a `TaskError` for a failed task outcome.
+/// Operator-facing text for a refused tool call.
+///
+/// A bare `"denied"` reason — what the CLI sends when the user just presses `n`
+/// — adds nothing the prefix has not already said, and appending it anyway
+/// printed `tool call denied: denied` (#940). Only a reason that carries new
+/// information is appended.
+fn deny_message(reason: Option<&str>) -> String {
+    match reason.map(str::trim) {
+        Some(r) if !r.is_empty() && r != "denied" => format!("tool call denied: {r}"),
+        _ => "tool call denied".to_string(),
+    }
+}
+
 fn task_error(code: &str, message: String, recoverable: bool) -> TaskError {
     TaskError {
         code: code.to_string(),
@@ -3931,5 +3943,32 @@ mod step_tests {
         assert!(truncated);
         assert_eq!(full_len, big.len());
         assert!(out.is_char_boundary(out.len())); // never split a char
+    }
+}
+
+/// #940: the deny path stuttered — `tool call denied: denied`.
+#[cfg(test)]
+mod deny_message_tests {
+    use super::deny_message;
+
+    #[test]
+    fn a_bare_denial_is_not_repeated() {
+        // What the CLI sends for a plain `n` press.
+        assert_eq!(deny_message(Some("denied")), "tool call denied");
+        assert_eq!(deny_message(Some("  denied  ")), "tool call denied");
+        assert_eq!(deny_message(Some("")), "tool call denied");
+        assert_eq!(deny_message(None), "tool call denied");
+    }
+
+    #[test]
+    fn a_reason_that_says_something_survives() {
+        assert_eq!(
+            deny_message(Some("timed out")),
+            "tool call denied: timed out"
+        );
+        assert_eq!(
+            deny_message(Some("no approval channel available")),
+            "tool call denied: no approval channel available"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -467,9 +467,14 @@ pub struct App {
     /// Set to `true` when `StepStarted` fires this turn; used by the footer
     /// to distinguish "pure chat" from "agentic" turns.
     pub saw_step_this_turn: bool,
-    /// A HITL approval arrived this turn (any runtime). Paired with
+    /// A tool was *approved* this turn (any runtime). Paired with
     /// `saw_step_this_turn` to detect an old runtime that ran a tool but
     /// streamed no step events.
+    ///
+    /// Set at the decision, not at the request: a denied call never executes,
+    /// so a missing step stream says nothing about the runtime's age. Setting
+    /// it on arrival made every deny print "this agent ran a tool without
+    /// streaming step detail" about a tool that did not run (#940).
     pub saw_hitl_this_turn: bool,
     /// The "restart for step view" hint has been shown once this session.
     pub step_hint_shown: bool,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -108,7 +108,7 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /open (outstanding items)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 #[allow(clippy::too_many_arguments)]
@@ -1435,11 +1435,15 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
             // single tool call and said nothing the card couldn't: it doubled
             // the height of the scrollback for zero extra information.
             (true, true) => {
+                app.saw_hitl_this_turn = true;
                 if let Some(sid) = &req.step_id {
                     app.mark_card_auto_approved(sid);
                 }
             }
-            (true, false) => app.push_success(format!("approved `{}`", req.tool_name)),
+            (true, false) => {
+                app.saw_hitl_this_turn = true;
+                app.push_success(format!("approved `{}`", req.tool_name))
+            }
             (false, _) => app.push_warn(format!("denied `{}`", req.tool_name)),
         }
     }
@@ -1870,7 +1874,8 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
     match msg {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
         StreamMsg::Hitl { req, .. } => {
-            app.saw_hitl_this_turn = true;
+            // NB: `saw_hitl_this_turn` is set in `decide`, on approval — not
+            // here. See its doc comment (#940).
             // Flag the card so it renders the inline approval row. Whether
             // that row is actually VISIBLE is recomputed every frame by the
             // renderer (`ui::inline_row_visible`) rather than cached here: a
@@ -2352,6 +2357,64 @@ mod hitl_key_tests {
         assert!(app.hitl.is_none(), "the gate is answerable again");
     }
 
+    /// #940: after denying a call the transcript advised restarting the agent
+    /// "for the step view" of a tool that never executed. The hint's premise is
+    /// "a tool ran but streamed no step detail" — a deny satisfies the second
+    /// half for free, so the flag now moves at the decision, not at the request.
+    /// Opens the gate the way the runtime does — through `handle_stream`, which
+    /// is where the flag used to be set. Calling `gate()` directly would skip
+    /// the very line under test and pass either way.
+    fn gate_via_stream(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+        let task_id = "t1".to_string();
+        app.current_task_id = Some(task_id.clone());
+        let req = stream::HitlRequest {
+            hitl_id: "h1".into(),
+            step_id: None,
+            tool_name: "bash".into(),
+            tool_input: serde_json::json!({}),
+            prompt: "approve?".into(),
+            created_at: std::time::Instant::now(),
+        };
+        handle_stream(app, StreamMsg::Hitl { req, task_id }, tx);
+        assert!(app.hitl.is_some(), "the gate opened");
+    }
+
+    #[tokio::test]
+    async fn denying_a_call_does_not_arm_the_old_runtime_hint() {
+        let (tx, _rx) = mpsc::channel(16);
+        let mut app = App::test_fixture();
+        app.begin_user_turn("do it");
+        gate_via_stream(&mut app, &tx);
+        handle_event(&mut app, key('n'), &tx).await;
+        assert!(app.hitl.is_none(), "the deny landed");
+        assert!(
+            !app.saw_hitl_this_turn,
+            "a denied call never ran, so nothing is missing a step stream"
+        );
+        app.maybe_step_hint();
+        assert!(
+            !app.messages.iter().any(|m| m.text.contains("restart")),
+            "no restart advice for a tool that did not execute"
+        );
+    }
+
+    /// Control for the above: an *approved* call with no step events is exactly
+    /// the old-runtime case the hint exists for, and must still fire.
+    #[tokio::test]
+    async fn approving_a_call_still_arms_the_old_runtime_hint() {
+        let (tx, _rx) = mpsc::channel(16);
+        let mut app = App::test_fixture();
+        app.begin_user_turn("do it");
+        gate_via_stream(&mut app, &tx);
+        handle_event(&mut app, key('y'), &tx).await;
+        assert!(app.saw_hitl_this_turn, "an approved call executes");
+        app.maybe_step_hint();
+        assert!(
+            app.messages.iter().any(|m| m.text.contains("restart")),
+            "the old-runtime hint must survive the #940 fix"
+        );
+    }
+
     /// The bug this guards: typing a message while a gate was open let the
     /// first `a` approve the call AND grant the tool for the whole session,
     /// with the character deleted from the message ("modal" arrived "modl").
@@ -2469,5 +2532,37 @@ mod hitl_key_tests {
 
         // Idempotent: nothing left to retire.
         assert!(!expire_stale_hitl(&mut app));
+    }
+}
+
+/// #940: `/open` worked, the chat footer advertised it, and `/help` did not
+/// list it — so the one place a user goes to learn the command surface was the
+/// one place it was missing.
+#[cfg(test)]
+mod help_coverage_tests {
+    use super::HELP;
+    use super::app::{SlashCmd, parse_slash};
+
+    /// Primary (non-alias) names of every slash command the parser accepts.
+    /// Each entry is fed through the real parser, so this list cannot name a
+    /// command that does not exist; `/help` then has to mention all of them.
+    const COMMANDS: &[&str] = &[
+        "help", "clear", "card", "sessions", "channels", "open", "auto", "verbose", "skin", "mcp",
+        "skill", "remember", "memories", "forget", "panel", "exit",
+    ];
+
+    #[test]
+    fn help_lists_every_command_the_parser_accepts() {
+        for name in COMMANDS {
+            let parsed = parse_slash(&format!("/{name}"));
+            assert!(
+                !matches!(parsed, Some(SlashCmd::Unknown(_)) | None),
+                "/{name} is in the documented list but the parser rejects it: {parsed:?}"
+            );
+            assert!(
+                HELP.contains(&format!("/{name}")),
+                "/{name} works but /help never mentions it"
+            );
+        }
     }
 }

--- a/mur-core/src/cmd/agent/cli/persist.rs
+++ b/mur-core/src/cmd/agent/cli/persist.rs
@@ -22,12 +22,15 @@ pub struct TurnRecord {
     pub task_id: Option<String>,
 }
 
-/// Live-channel id + state for the CLI status bar.
+/// Live-channel id for the CLI status bar.
+///
+/// Id only. The channel's persisted lifecycle state used to ride along here and
+/// be rendered beside the live turn state, which is a second source for one
+/// fact — and it lost, because it was refreshed at two call sites while the
+/// turn state is refreshed every frame (#940).
 #[derive(Debug, Clone)]
 pub struct ChannelMeta {
     pub id: String,
-    /// kebab-case `ChannelState` string (e.g. "working").
-    pub state: String,
 }
 
 /// Listing entry; `id` is the channel id (was the session file stem).
@@ -80,16 +83,11 @@ impl Session {
         self.channel_id.as_deref()
     }
 
-    /// Read the live channel's id + state for the status bar.
+    /// Read the live channel's id for the status bar.
     /// Returns `None` until the first `append` creates the channel.
     pub fn current(&self) -> Option<ChannelMeta> {
         let id = self.channel_id.clone()?;
-        let ch = self.svc.store().load_manifest(&id).ok()?;
-        let state = serde_json::to_string(&ch.state)
-            .unwrap_or_default()
-            .trim_matches('"')
-            .to_string();
-        Some(ChannelMeta { id, state })
+        Some(ChannelMeta { id })
     }
 
     /// Append one turn, creating the channel on first write. `role` ∈
@@ -259,9 +257,6 @@ mod tests {
         s.append("user", "hi", None, &[]).unwrap();
         let meta = s.current().expect("channel exists after first append");
         assert!(!meta.id.is_empty());
-        assert!(!meta.state.is_empty());
-        // state must not contain JSON quotes — must be bare kebab
-        assert!(!meta.state.contains('"'));
     }
 
     /// #716: options offered via `suggest_replies` must land in the agent

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -1201,9 +1201,14 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::raw("  "));
     }
     if let Some(meta) = &app.channel {
+        // Id only. The chip used to append `meta.state`, a persisted channel
+        // lifecycle word refreshed at just two points, next to the live turn
+        // state a few columns to its right — so the bar routinely read
+        // `⏵ 019ff831:working   ready`. Two sources for one fact; the live one
+        // wins and the stale one is gone (#940).
         let short: String = meta.id.chars().take(8).collect();
         spans.push(Span::styled(
-            format!(" ⏵ {}:{} ", short, meta.state),
+            format!(" ⏵ {short} "),
             Style::default().fg(theme.agent),
         ));
         spans.push(Span::raw("  "));
@@ -1534,7 +1539,12 @@ fn footer_segments(
         (Some(c), Some(cap)) => format!("${c:.2} / ${cap:.2}"),
         (Some(c), None) => format!("${c:.3} est"),
         (None, Some(cap)) => format!("/ ${cap:.2}"),
-        (None, None) => "\u{2014}".to_string(), // em dash
+        // No per-token price for this model (local runtimes, and any registry
+        // entry added without `--input-cost`). An em dash in the same slot as
+        // "$0.125 est" read as "this turn was free" rather than "we cannot
+        // price it" — same field, two meanings, no way to tell them apart
+        // (#940).
+        (None, None) => "no price".to_string(),
     };
 
     let ctx = match pricing.window {
@@ -1658,10 +1668,12 @@ mod footer_fmt_tests {
     const WIDE: usize = 200;
 
     #[test]
-    fn shows_tokens_and_dash_cost_when_unpriced() {
+    fn shows_tokens_and_names_the_reason_when_unpriced() {
         let s = footer_segments(1240, 0, 1240, 0, 0, &Pricing::default(), None, WIDE);
         assert!(s.contains("1,240 tok") || s.contains("1240 tok"));
-        assert!(s.contains('\u{2014}')); // em dash — no price
+        // Was an em dash, which sat in the same slot as "$0.125 est" and so
+        // read as a cost of zero rather than an absent price (#940).
+        assert!(s.contains("no price"), "got: {s}");
     }
 
     #[test]
@@ -2055,6 +2067,79 @@ mod scroll_marker_tests {
         assert_eq!(
             scroll_marker(25, 10).as_deref(),
             Some(" ↑ 15 · PgDn to follow ")
+        );
+    }
+}
+
+/// #940: the observability footer must never render a figure whose blank case
+/// is indistinguishable from a real one.
+#[cfg(test)]
+mod footer_cost_tests {
+    use super::super::footer::Pricing;
+    use super::footer_segments;
+
+    /// A model with no per-token price used to render an em dash in the exact
+    /// slot where a priced model renders `$0.125 est` — so "we cannot price
+    /// this" and "this cost nothing" were the same pixel. Two agents side by
+    /// side in a multiplexer is where it bit.
+    #[test]
+    fn an_unpriced_model_says_so_rather_than_going_blank() {
+        let unpriced = Pricing {
+            in_per_1k: None,
+            out_per_1k: None,
+            window: Some(32_000),
+        };
+        let out = footer_segments(10, 20, 100, 200, 3_762, &unpriced, None, 200);
+        assert!(
+            out.contains("no price"),
+            "an unpriced model must name the reason, got: {out}"
+        );
+        assert!(
+            !out.contains('\u{2014}'),
+            "the bare em dash reads as a cost of zero, got: {out}"
+        );
+    }
+
+    /// Control: pricing present still produces a number, so the fix above did
+    /// not simply replace the cost segment.
+    #[test]
+    fn a_priced_model_still_shows_the_estimate() {
+        let priced = Pricing {
+            in_per_1k: Some(3.0),
+            out_per_1k: Some(15.0),
+            window: Some(32_000),
+        };
+        let out = footer_segments(10, 20, 1_000, 1_000, 3_762, &priced, None, 200);
+        assert!(out.contains('$'), "priced model must show a cost: {out}");
+        assert!(!out.contains("no price"), "got: {out}");
+    }
+}
+
+/// #940: the status bar rendered a persisted channel-lifecycle word next to the
+/// live turn state, so it routinely read `⏵ 019ff831:working   ready`.
+#[cfg(test)]
+mod status_chip_tests {
+    use super::super::app::App;
+    use super::super::persist::ChannelMeta;
+    use super::render_status;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn the_channel_chip_states_the_id_and_leaves_the_state_word_to_the_live_one() {
+        let mut app = App::test_fixture();
+        app.channel = Some(ChannelMeta {
+            id: "019ff831dead".into(),
+        });
+        let mut term = Terminal::new(TestBackend::new(120, 1)).unwrap();
+        term.draw(|f| render_status(f, &app, f.area())).unwrap();
+        let dump = term.backend().to_string();
+
+        assert!(dump.contains("019ff831"), "chip must show the id: {dump}");
+        assert!(dump.contains("ready"), "live turn state stays: {dump}");
+        assert!(
+            !dump.contains("019ff831:"),
+            "the chip must not append a second state word: {dump}"
         );
     }
 }

--- a/mur-core/src/cmd/agent/cli/welcome.rs
+++ b/mur-core/src/cmd/agent/cli/welcome.rs
@@ -217,7 +217,15 @@ pub fn welcome_lines(
     }
     lines.push(Line::default());
 
-    // One-line identity: agent · cwd.
+    // One-line identity: agent · shell cwd.
+    //
+    // Labelled "shell:" because that is all it is. This is the directory the
+    // TUI was launched from, handed to the agent as a bash-cwd hint on the
+    // first message — it is NOT the runtime's session cwd, which stays at
+    // `~/.mur/agents/<name>` and is what a relative path in `read_file`
+    // resolves against. Unlabelled it read as "the agent works here", so
+    // relative paths were handed over that could not resolve and the failure
+    // looked like a missing file (#940).
     lines.push(Line::from(vec![
         Span::styled(
             agent.to_string(),
@@ -225,7 +233,7 @@ pub fn welcome_lines(
                 .fg(theme.agent)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("  ·  ", Style::default().fg(theme.separator)),
+        Span::styled("  ·  shell ", Style::default().fg(theme.separator)),
         Span::styled(pretty_cwd(cwd), Style::default().fg(theme.system)),
     ]));
     lines.push(Line::default());
@@ -354,6 +362,32 @@ mod tests {
         assert_eq!(pretty_cwd(Some(std::path::Path::new("/a/b"))), "/a/b");
         // None renders a neutral placeholder.
         assert_eq!(pretty_cwd(None), "·");
+    }
+
+    /// #940: the identity line printed a bare path that reads as "the agent
+    /// works here". It is the *shell's* cwd, passed along only as a bash hint;
+    /// the runtime's session cwd stays at `~/.mur/agents/<name>`, so a relative
+    /// path handed to `read_file` on the strength of this line cannot resolve.
+    #[test]
+    fn the_identity_line_labels_the_path_as_the_shell_cwd() {
+        let lines = welcome_lines(
+            &super::super::theme::DARK,
+            MascotMode::Off,
+            "repomanager",
+            Some(std::path::Path::new("/a/b/c")),
+            true,
+        );
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(text.contains("repomanager"), "agent name stays: {text}");
+        assert!(text.contains("/a/b/c"), "path stays: {text}");
+        assert!(
+            text.contains("shell"),
+            "the path must be labelled, not left to read as the agent's cwd: {text}"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -241,9 +241,10 @@ pub(crate) fn load_profile_for_edit(name: &str) -> Result<(PathBuf, _AgentProfil
 /// `model:` block is only the fallback for a profile that has no ref. But every
 /// writer of `model_ref` left the old block untouched, so profiles accumulated
 /// a provider / model id that named an endpoint the agent had not dialled in
-/// months — across 27 installed agents the two disagreed on every one, and
-/// during #938 the stale block sent the investigation after a provider-dispatch
-/// bug that did not exist (#940).
+/// months — 10 of 27 installed agents disagreed, three of them across
+/// providers (a block reading `anthropic` for an agent dialling a local
+/// openai-compatible endpoint), and during #938 that stale block sent the
+/// investigation after a provider-dispatch bug that did not exist (#940).
 ///
 /// Best-effort: an unreadable registry or an unknown ref leaves the profile
 /// exactly as it was. This heals a profile on its next save; it never blocks one.
@@ -361,10 +362,10 @@ mod tests {
     }
     /// #940: `model_ref` is what the runtime resolves; the legacy `model:` block
     /// is only a fallback for a profile that has none. Every writer of
-    /// `model_ref` left the old block alone, so across 27 installed agents the
-    /// two disagreed on every single one — and a human reading profile.yaml to
-    /// answer "which model is this agent on" got a provider, a model id, and an
-    /// endpoint that were all wrong.
+    /// `model_ref` left the old block alone, so 10 of 27 installed agents
+    /// disagreed — and a human reading profile.yaml to answer "which model is
+    /// this agent on" got a provider, a model id, and an endpoint that were all
+    /// wrong.
     #[test]
     fn a_saved_profile_cannot_name_a_model_it_does_not_use() {
         use mur_common::model::{ModelEntry, ModelRegistry};

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -234,6 +234,41 @@ pub(crate) fn load_profile_for_edit(name: &str) -> Result<(PathBuf, _AgentProfil
     Ok((path, profile))
 }
 
+/// Mirror the resolved `model_ref` registry entry back into the legacy
+/// `model:` block so the two cannot disagree.
+///
+/// `model_ref` wins at runtime (`mur_common::model::resolve_model_refs`); the
+/// `model:` block is only the fallback for a profile that has no ref. But every
+/// writer of `model_ref` left the old block untouched, so profiles accumulated
+/// a provider / model id that named an endpoint the agent had not dialled in
+/// months — across 27 installed agents the two disagreed on every one, and
+/// during #938 the stale block sent the investigation after a provider-dispatch
+/// bug that did not exist (#940).
+///
+/// Best-effort: an unreadable registry or an unknown ref leaves the profile
+/// exactly as it was. This heals a profile on its next save; it never blocks one.
+fn sync_model_block(profile: &mut _AgentProfile, reg: &mur_common::model::ModelRegistry) {
+    let Some(key) = profile.model_ref.as_deref() else {
+        return;
+    };
+    let Some(entry) = reg.models.get(key) else {
+        return;
+    };
+    profile.model.provider = entry.provider.clone();
+    profile.model.name = entry.model.clone();
+}
+
+fn sync_model_block_from_disk(profile: &mut _AgentProfile) {
+    if profile.model_ref.is_none() {
+        return;
+    }
+    if let Ok(reg) = mur_common::model::ModelRegistry::default_path()
+        .and_then(|p| mur_common::model::ModelRegistry::load_from(&p))
+    {
+        sync_model_block(profile, &reg);
+    }
+}
+
 pub(crate) fn save_profile(path: &Path, profile: &mut _AgentProfile) -> Result<()> {
     // Fail-closed guard (#717): a profile save must never *introduce* a skill
     // ref that does not resolve to an installed skill under the agent dir.
@@ -255,6 +290,7 @@ pub(crate) fn save_profile(path: &Path, profile: &mut _AgentProfile) -> Result<(
         skill::validate_skill_refs(agent_dir, &added)?;
     }
 
+    sync_model_block_from_disk(profile);
     profile.updated_at = chrono::Utc::now().to_rfc3339();
     let yaml = serde_yaml_ng::to_string(profile).context("serialize profile.yaml")?;
     write_atomic(path, yaml.as_bytes())?;
@@ -322,5 +358,58 @@ mod tests {
     fn non_bundle_path_returns_none() {
         let exe = Path::new("/opt/homebrew/bin/mur");
         assert_eq!(runtime_target_in_bundle(exe, "mur-agent-runtime"), None);
+    }
+    /// #940: `model_ref` is what the runtime resolves; the legacy `model:` block
+    /// is only a fallback for a profile that has none. Every writer of
+    /// `model_ref` left the old block alone, so across 27 installed agents the
+    /// two disagreed on every single one — and a human reading profile.yaml to
+    /// answer "which model is this agent on" got a provider, a model id, and an
+    /// endpoint that were all wrong.
+    #[test]
+    fn a_saved_profile_cannot_name_a_model_it_does_not_use() {
+        use mur_common::model::{ModelEntry, ModelRegistry};
+
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "omlx".into(),
+            ModelEntry {
+                provider: "openai".into(),
+                model: "Qwen3.5-4B-MLX-4bit".into(),
+                ..Default::default()
+            },
+        );
+
+        let mut p = _AgentProfile::default_for_tests();
+        // The exact drift observed in the field.
+        p.model.provider = "anthropic".into();
+        p.model.name = "claude-sonnet-4-6".into();
+        p.model_ref = Some("omlx".into());
+
+        sync_model_block(&mut p, &reg);
+        assert_eq!(p.model.provider, "openai");
+        assert_eq!(p.model.name, "Qwen3.5-4B-MLX-4bit");
+        assert_eq!(p.model_ref.as_deref(), Some("omlx"), "the ref still rules");
+    }
+
+    /// Fail-open, both ways: no ref means the block IS the source of truth, and
+    /// a ref the registry has never heard of must not blank out the fallback.
+    #[test]
+    fn an_unresolvable_ref_leaves_the_block_untouched() {
+        use mur_common::model::ModelRegistry;
+        let reg = ModelRegistry::default();
+
+        let mut p = _AgentProfile::default_for_tests();
+        p.model.provider = "anthropic".into();
+        p.model.name = "claude-opus-4-7".into();
+
+        let mut no_ref = p.clone();
+        no_ref.model_ref = None;
+        sync_model_block(&mut no_ref, &reg);
+        assert_eq!(no_ref.model.name, "claude-opus-4-7");
+
+        let mut dangling = p.clone();
+        dangling.model_ref = Some("never_registered".into());
+        sync_model_block(&mut dangling, &reg);
+        assert_eq!(dangling.model.name, "claude-opus-4-7");
     }
 }

--- a/mur-core/src/cmd/agent/model_resolve.rs
+++ b/mur-core/src/cmd/agent/model_resolve.rs
@@ -92,9 +92,10 @@ pub fn apply_model_choice(mur_home: &Path, slug: &str, choice: &ModelChoice) -> 
         serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
             .with_context(|| format!("parse {}", profile_path.display()))?;
     profile.model_ref = Some(key.clone());
-    let yaml = serde_yaml_ng::to_string(&profile)?;
-    std::fs::write(&profile_path, yaml)
-        .with_context(|| format!("write {}", profile_path.display()))?;
+    // Through the shared saver so the legacy `model:` block is re-synced from
+    // the registry entry we just wrote, instead of being left naming whatever
+    // provider the agent was created with (#940).
+    super::save_profile(&profile_path, &mut profile)?;
 
     Ok(key)
 }


### PR DESCRIPTION
Closes #940.

Five reported defects (three in the issue body, two added as a comment while verifying #938). All the same shape as the A1-A7 batch: **one fact, two surfaces, they disagree.**

| # | Was | Now |
|---|-----|-----|
| 1 | `⏵ 019ff831:working   ready` | `⏵ 019ff831   ready` |
| 1b | `—` for cost on an unpriced model | `no price` |
| 2a | deny → "this agent ran a tool without streaming step detail — restart it" | nothing; the hint needs a tool to have *run* |
| 2b | `tool call denied: denied` | `tool call denied` |
| 3 | `/open` worked but `/help` omitted it | listed, and a test enforces it |
| 4 | ` repomanager  ·  …/Projects/mur` | ` repomanager  ·  shell …/Projects/mur` |
| 5 | `profile.yaml` naming a model the runtime never dials | `save_profile` mirrors the resolved registry entry |

## Notes on the two structural ones

**Item 1** — `ChannelMeta.state` was removed, not just left unrendered. Keeping the field would have left the second source of truth sitting there for the next person to render.

**Item 5** — the root cause is that `model_ref` won at runtime while every writer of it left the legacy `model:` block untouched. Fixed at the single choke point (`save_profile`), so an agent's block heals on its next profile edit of any kind. `apply_model_choice` was writing the file directly and now routes through the same saver. Fail-open by design: an unreadable registry or a ref the registry has never heard of leaves the profile exactly as it was — a dangling ref must not blank out the fallback block.

**Already-drifted profiles** heal on their next save, which for an untouched agent may be never. Nothing in this PR force-migrates the 27 installed agents; say the word if a one-shot sweep is wanted.

## Verification

Red first, in every case. `8/8` new tests failed against the reverted behaviour with the assertion that names the defect.

One of them initially **passed while proving nothing**: `denying_a_call_does_not_arm_the_old_runtime_hint` used the existing `gate()` helper, which sets `app.hitl` directly and never runs `handle_stream` — the exact function holding the line under test. Rerouted through `handle_stream` with a matching `current_task_id`, it then failed red for the right reason.

One pre-existing test (`shows_tokens_and_dash_cost_when_unpriced`) asserted the em dash. It was pinning the defect, so it was updated to the new contract rather than worked around.

```
cargo nextest run -p mur-core --lib          2401 passed, 0 failed
cargo nextest run -p mur-agent-runtime        859 passed, 0 failed
cargo clippy --all-targets -- -D warnings     clean
cargo fmt --check                             clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)