### PR TITLE
docs(readme): complete the `mur model` row in the command tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ mur
 ├── sync         (16+ AI tools) · status · fleet pull/push/both
 ├── hook         unified hook entry for AI tools (prompt / tool / stop / session-start)
 ├── chat         conversations archive + ask
-├── model        add · list · show · remove · migrate
+├── model        add · list · show · remove · doctor · prices · role · route · default · fallback · migrate
 ├── source       external knowledge — Obsidian · Notion · Joplin
 ├── project      index · search   (semantic code search)
 ├── daemon       start · stop · restart · status · serve · sleep


### PR DESCRIPTION
Follow-up to #945.

The command tree's `model` row listed five subcommands. `ModelCmd` has eleven:

```
├── model        add · list · show · remove · doctor · prices · role · route · default · fallback · migrate
```

`doctor` is new in #945, but `prices`, `role`, `route`, `default` and `fallback` had been missing for longer. The tree is the one place a reader goes to see the whole surface, so a partial row there is worse than no row at all.

Verified against `ModelCmd` in `mur-core/src/cmd/model.rs`, not from memory. Top-level command count unchanged (28).

Docs site and product page are a separate PR in `mur-server` — that one deploys to the public `app.mur.run` and needs a human on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)