### PR TITLE
fix(llm): survive a renamed model id, and never substitute one silently

### DIFF
--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -11,7 +11,7 @@ use mur_common::config::{ModelSwitchConfig, RetryConfig};
 use mur_common::model::{choose_by_difficulty, resolve_model_refs};
 
 use super::{
-    BackgroundKind, LlmClient, LlmError, LlmRequest, LlmResponse, RequestIntent, Retryability,
+    BackgroundKind, Disposition, LlmClient, LlmError, LlmRequest, LlmResponse, RequestIntent,
     RichMessage, classify,
 };
 use crate::telemetry_writer::Event;
@@ -259,7 +259,26 @@ impl FallbackLlmClient {
                         return (Ok(resp), meta);
                     }
                     Err(e) => match classify(&e) {
-                        Retryability::Fatal => {
+                        // Permanent for this candidate, plausibly fine on the
+                        // next: skip the retry budget entirely and advance.
+                        // Backing off three times against a model id the
+                        // endpoint does not serve buys nothing but latency.
+                        Disposition::AdvanceNow => {
+                            tracing::info!(
+                                model_ref,
+                                error = %e,
+                                "llm fallback: permanent for this candidate, advancing chain now"
+                            );
+                            // Cool it down so a later request this session does
+                            // not pay the same failing round-trip again.
+                            self.cooldown.mark(
+                                model_ref,
+                                Instant::now() + Duration::from_secs(self.retry.cooldown_secs),
+                            );
+                            last = Some(e);
+                            continue 'candidates;
+                        }
+                        Disposition::Stop => {
                             // Structural failure is escalatable ONLY under
                             // Background+Smart, within the per-call cap.
                             let structural = matches!(e, LlmError::InvalidResponse(_));
@@ -282,7 +301,7 @@ impl FallbackLlmClient {
                             };
                             return (Err(e), meta);
                         }
-                        Retryability::Retryable => {
+                        Disposition::RetryThenAdvance => {
                             tracing::info!(model_ref, attempt, error = %e, "llm fallback: retryable failure");
                             if attempt < self.retry.max_retries {
                                 tokio::time::sleep(backoff_delay(

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -206,7 +206,9 @@ impl FallbackLlmClient {
         req: &LlmRequest,
     ) -> (Result<LlmResponse, LlmError>, RoutingMeta) {
         let now = Instant::now();
-        let mut last: Option<LlmError> = None;
+        // Every candidate's failure, in order. Reporting only the last one
+        // made the diagnosis an accident of chain order (#947).
+        let mut failures: Vec<(String, LlmError)> = Vec::new();
         let candidates = self.candidates_for(req);
 
         // Structural-failure escalation (cascade) is allowed ONLY for
@@ -242,7 +244,10 @@ impl FallbackLlmClient {
             let client = match (self.factory)(model_ref) {
                 Ok(c) => c,
                 Err(e) => {
-                    last = Some(LlmError::Http(format!("build {model_ref}: {e}")));
+                    failures.push((
+                        model_ref.clone(),
+                        LlmError::Http(format!("build {model_ref}: {e}")),
+                    ));
                     continue;
                 }
             };
@@ -275,7 +280,7 @@ impl FallbackLlmClient {
                                 model_ref,
                                 Instant::now() + Duration::from_secs(self.retry.cooldown_secs),
                             );
-                            last = Some(e);
+                            failures.push((model_ref.clone(), e));
                             continue 'candidates;
                         }
                         Disposition::Stop => {
@@ -289,7 +294,7 @@ impl FallbackLlmClient {
                                     escalations,
                                     "smart cascade: structural fail, escalating"
                                 );
-                                last = Some(e);
+                                failures.push((model_ref.clone(), e));
                                 continue 'candidates; // advance to next candidate (the better model)
                             }
                             // Interactive / over-cap / non-structural Fatal → surface (Phase-1 boundary).
@@ -317,14 +322,14 @@ impl FallbackLlmClient {
                                     model_ref,
                                     "llm fallback: cooling down, advancing chain"
                                 );
-                                last = Some(e);
+                                failures.push((model_ref.clone(), e));
                             }
                         }
                     },
                 }
             }
         }
-        let err = last.unwrap_or_else(|| LlmError::InvalidResponse("no model candidates".into()));
+        let err = crate::llm::all_candidates_failed(failures);
         let meta = RoutingMeta {
             attempts,
             escalations,

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -197,14 +197,77 @@ async fn auth_still_does_not_advance() {
     assert!(matches!(err, LlmError::Http(_)), "never tried b");
 }
 
+/// Exhaustion used to return only the LAST candidate's error, which made the
+/// diagnosis an accident of chain order — a wrong API key on the primary was
+/// invisible behind a rate limit on the third candidate. Now every failure is
+/// listed, and the one the operator can actually act on leads.
 #[tokio::test]
-async fn exhaustion_returns_last_error() {
+async fn exhaustion_reports_every_candidate_and_leads_with_the_actionable_one() {
     let mut s = HashMap::new();
-    s.insert("a".into(), vec![Err(LlmError::RateLimit)]);
-    s.insert("b".into(), vec![Err(LlmError::ServerError(503))]);
+    // All three ADVANCE. An Auth here would short-circuit and never reach
+    // exhaustion at all — that is the next test.
+    s.insert(
+        "a".into(),
+        vec![Err(LlmError::ModelNotFound("claude-sonnet-4-6".into()))],
+    );
+    s.insert("b".into(), vec![Err(LlmError::RateLimit)]); // weather — not fixable
+    s.insert("c".into(), vec![Err(LlmError::ServerError(503))]);
+    let fb = FallbackLlmClient::new(
+        vec!["a".into(), "b".into(), "c".into()],
+        factory_for(s),
+        retry0(),
+    );
+    let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+
+    let LlmError::AllCandidatesFailed { source, summary } = &err else {
+        panic!("expected an aggregate, got {err:?}");
+    };
+    // `a` failed FIRST and `c` failed LAST; `a` leads because a model id that
+    // no longer exists is something the operator can go and fix, and a 503 is
+    // not. Returning the last error made this an accident of chain order.
+    assert!(
+        matches!(**source, LlmError::ModelNotFound(_)),
+        "lead was {source:?}"
+    );
+    for candidate in ["a", "b", "c"] {
+        assert!(
+            summary.contains(candidate),
+            "{candidate} missing: {summary}"
+        );
+    }
+    assert!(
+        summary.contains("rate limit") && summary.contains("503"),
+        "{summary}"
+    );
+}
+
+/// A Stop-class failure on the primary still stops immediately — the aggregate
+/// only exists for a chain that actually ran out.
+#[tokio::test]
+async fn a_single_stop_still_short_circuits_without_an_aggregate() {
+    let mut s = HashMap::new();
+    s.insert("a".into(), vec![Err(LlmError::Auth(401, "bad key".into()))]);
+    s.insert("b".into(), vec![Ok(())]);
     let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
     let err = fb.generate(LlmRequest::default()).await.unwrap_err();
-    assert!(matches!(err, LlmError::ServerError(503))); // last candidate's error
+    assert!(matches!(err, LlmError::Auth(401, _)), "{err:?}");
+}
+
+/// An unrecognised 4xx now advances rather than killing the turn: the set of
+/// reasons an endpoint can refuse one specific candidate is open and growing
+/// (payload too large, unsupported modality, region, tier), while the set that
+/// must never fall back is just auth.
+#[tokio::test]
+async fn an_unrecognised_4xx_advances_to_the_next_candidate() {
+    let mut s = HashMap::new();
+    s.insert(
+        "a".into(),
+        vec![Err(LlmError::Rejected(413, "payload too large".into()))],
+    );
+    s.insert("b".into(), vec![Ok(())]);
+    let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+    let resp = fb.generate(LlmRequest::default()).await.unwrap();
+    assert_eq!(resp.text, "b");
 }
 
 #[test]

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -143,6 +143,60 @@ async fn fatal_error_does_not_advance() {
     assert!(matches!(err, LlmError::Http(_))); // returned a's fatal error, never tried b
 }
 
+/// A renamed or retired model id is exactly what a fallback chain is for. It
+/// used to be lumped into the `Http` catch-all and stop the turn outright,
+/// leaving a perfectly good fallback unused.
+#[tokio::test]
+async fn a_model_not_found_advances_to_the_next_candidate() {
+    let mut s = HashMap::new();
+    s.insert(
+        "a".into(),
+        vec![Err(LlmError::ModelNotFound("claude-sonnet-4-6".into()))],
+    );
+    s.insert("b".into(), vec![Ok(())]);
+    let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+    let resp = fb.generate(LlmRequest::default()).await.unwrap();
+    assert_eq!(resp.text, "b", "the chain must survive a retired model id");
+}
+
+/// ...and it must advance WITHOUT spending the retry budget. A 404 cannot
+/// become a 200 by asking the same endpoint again, so backing off against it
+/// is pure latency. The script makes the difference observable: candidate `a`
+/// would succeed on its second call, so any retry at all returns "a".
+#[tokio::test]
+async fn a_model_not_found_does_not_burn_retries_on_the_same_candidate() {
+    let retry3 = RetryConfig {
+        max_retries: 3,
+        backoff_base_ms: 1,
+        cooldown_secs: 60,
+    };
+    let mut s = HashMap::new();
+    s.insert(
+        "a".into(),
+        vec![Err(LlmError::ModelNotFound("gone".into())), Ok(())],
+    );
+    s.insert("b".into(), vec![Ok(())]);
+    let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry3);
+    let resp = fb.generate(LlmRequest::default()).await.unwrap();
+    assert_eq!(
+        resp.text, "b",
+        "a retry would have hit a's scripted Ok and returned \"a\""
+    );
+}
+
+/// Control for the two above: auth still stops the chain dead. Falling back
+/// here would re-present the same broken credential to a second provider and
+/// bury a config error the operator has to fix.
+#[tokio::test]
+async fn auth_still_does_not_advance() {
+    let mut s = HashMap::new();
+    s.insert("a".into(), vec![Err(LlmError::Http("status 401".into()))]);
+    s.insert("b".into(), vec![Ok(())]);
+    let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+    let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+    assert!(matches!(err, LlmError::Http(_)), "never tried b");
+}
+
 #[tokio::test]
 async fn exhaustion_returns_last_error() {
     let mut s = HashMap::new();

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -201,27 +201,70 @@ pub enum LlmError {
     /// kill the turn outright while a perfectly good fallback sat unused.
     #[error("model not found: {0}")]
     ModelNotFound(String),
+    /// Authentication or authorization refused (401/403). The one class that
+    /// must never advance the chain: the operator configured something wrong,
+    /// and routing around it converts a loud, fixable failure into a silent
+    /// permanent one.
+    #[error("auth refused ({0}): {1}")]
+    Auth(u16, String),
+    /// This endpoint refused this request, for a reason that is specific to
+    /// this candidate rather than to the request itself — payload too large
+    /// for its window, unsupported modality, region or tier restriction, or a
+    /// provider-specific 4xx we have not enumerated. Another candidate may
+    /// accept it.
+    #[error("rejected ({0}): {1}")]
+    Rejected(u16, String),
+    /// Every candidate failed. `source` carries the most *actionable* of their
+    /// errors — a configuration error the operator can fix outranks weather
+    /// they cannot — so classification upstream stays correct, while `summary`
+    /// lists what each candidate actually said. Reporting only the last
+    /// candidate's error, which is what this replaces, made the diagnosis an
+    /// accident of chain order.
+    #[error("{summary}")]
+    AllCandidatesFailed {
+        source: Box<LlmError>,
+        summary: String,
+    },
 }
 
 impl LlmError {
-    /// Map a non-success HTTP status into a typed error. Centralises what was
-    /// previously scattered `status == 429` checks + a lumped `Http(String)`.
+    /// Map a non-success HTTP status into a typed error.
+    ///
+    /// The default for an unrecognised 4xx is `Rejected` (advance), not `Http`
+    /// (stop. The set of failures that must NOT fall back is small, closed and
+    /// stable across providers — it is authentication, and nothing else. The
+    /// set that *should* fall back is open and still growing: every provider
+    /// invents its own codes for "too big", "wrong media type", "not enabled
+    /// in your region", "model not in your tier". Enumerating the open set and
+    /// defaulting the tail to stop is what let a renamed model kill turns for
+    /// months while a fallback sat unused.
+    ///
+    /// Enumerate the closed set; default to the open one.
     pub fn from_status(status: u16, body: String) -> LlmError {
         match status {
+            // Closed set: never fall back. Presenting the same broken
+            // credential to a second provider fails identically and buries a
+            // configuration error only the operator can fix.
+            401 | 403 => LlmError::Auth(status, body),
             429 => LlmError::RateLimit,
             402 => LlmError::InsufficientCredit,
             404 => LlmError::ModelNotFound(body),
             408 => LlmError::Timeout,
             500..=599 => LlmError::ServerError(status),
+            // Open set: this endpoint refused this request. Another candidate
+            // — different context window, different modality support,
+            // different region — may well accept it.
+            400..=499 => LlmError::Rejected(status, body),
             _ => LlmError::Http(format!("status {status}: {body}")),
         }
     }
 
     /// Map a reqwest transport error into a typed error. Central rule: an
     /// error without an HTTP status is a transport failure (`Connect`,
-    /// Retryable) — the server never rendered a verdict, so it can't be the
-    /// auth/bad-request class that `Http` reserves Fatal for. Request-builder
-    /// errors (malformed URL/body) stay `Http`: retrying can't fix them.
+    /// retry-then-advance) — the server never rendered a verdict, so it can't
+    /// be the auth/bad-request class. Request-builder errors (malformed
+    /// URL/body) stay `Http`: that is our own bug, and no other candidate will
+    /// like the request any better.
     pub fn from_reqwest(e: &reqwest::Error) -> LlmError {
         if e.is_timeout() {
             LlmError::Timeout
@@ -261,12 +304,53 @@ pub fn classify(e: &LlmError) -> Disposition {
         | LlmError::Timeout
         | LlmError::Connect(_)
         | LlmError::ServerError(_) => Disposition::RetryThenAdvance,
-        // Neither of these gets better by asking the same endpoint again:
-        // an account without credit does not acquire any within three
-        // exponential backoffs, and a model id the endpoint does not serve
-        // will not appear. Both may be fine on the next candidate.
-        LlmError::InsufficientCredit | LlmError::ModelNotFound(_) => Disposition::AdvanceNow,
-        LlmError::Http(_) | LlmError::InvalidResponse(_) => Disposition::Stop,
+        // None of these gets better by asking the same endpoint again: an
+        // account without credit does not acquire any within three backoffs, a
+        // model id the endpoint does not serve will not appear, and a refusal
+        // aimed at this candidate's limits is not a matter of timing. All three
+        // may be fine on the next candidate.
+        LlmError::InsufficientCredit | LlmError::ModelNotFound(_) | LlmError::Rejected(..) => {
+            Disposition::AdvanceNow
+        }
+        // `Auth` is the closed set that must never fall back. `Http` here means
+        // a malformed request we built or a response we could not parse — our
+        // bug, which no other candidate will like any better.
+        LlmError::Auth(..) | LlmError::Http(_) | LlmError::InvalidResponse(_) => Disposition::Stop,
+        // Already exhausted; classify as whatever the operator should act on.
+        LlmError::AllCandidatesFailed { source, .. } => classify(source),
+    }
+}
+
+/// How much the operator can do about a failure. Used to pick which candidate's
+/// error leads when the whole chain is exhausted: a wrong API key is worth
+/// surfacing over a rate limit, whatever order they happened to occur in.
+fn actionability(e: &LlmError) -> u8 {
+    match classify(e) {
+        Disposition::Stop => 2,             // config error / our bug — fix it
+        Disposition::AdvanceNow => 1,       // candidate-specific — maybe fix it
+        Disposition::RetryThenAdvance => 0, // weather — wait it out
+    }
+}
+
+/// Fold every candidate's failure into one error: the most actionable one
+/// leads (so upstream classification is right), and the summary says what each
+/// candidate actually reported.
+pub fn all_candidates_failed(failures: Vec<(String, LlmError)>) -> LlmError {
+    let Some(lead) = failures
+        .iter()
+        .max_by_key(|(_, e)| actionability(e))
+        .map(|(_, e)| e.clone())
+    else {
+        return LlmError::InvalidResponse("no model candidates".into());
+    };
+    let listed = failures
+        .iter()
+        .map(|(r, e)| format!("{r}: {e}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    LlmError::AllCandidatesFailed {
+        source: Box::new(lead),
+        summary: format!("all {} model candidates failed — {listed}", failures.len()),
     }
 }
 
@@ -376,13 +460,15 @@ mod tests {
             LlmError::from_status(503, "x".into()),
             LlmError::ServerError(503)
         ));
+        // 400 is no longer the `Http` catch-all: an unrecognised 4xx is a
+        // refusal by THIS endpoint and may well succeed on the next candidate.
         assert!(matches!(
             LlmError::from_status(400, "x".into()),
-            LlmError::Http(_)
+            LlmError::Rejected(400, _)
         ));
         assert!(matches!(
             LlmError::from_status(401, "x".into()),
-            LlmError::Http(_)
+            LlmError::Auth(401, _)
         ));
     }
 
@@ -458,10 +544,12 @@ mod tests {
             LlmError::from_status(408, String::new()),
             LlmError::Timeout
         ));
-        // 401 stays Http → Stop: auth errors must never advance the chain.
-        let e = LlmError::from_status(401, "unauthorized".into());
-        assert!(matches!(e, LlmError::Http(_)));
-        assert!(matches!(classify(&e), Disposition::Stop));
+        // Auth is the one closed set that must never advance the chain.
+        for status in [401, 403] {
+            let e = LlmError::from_status(status, "unauthorized".into());
+            assert!(matches!(e, LlmError::Auth(..)), "{status}: {e:?}");
+            assert_eq!(classify(&e), Disposition::Stop, "{status}");
+        }
     }
 }
 

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -178,8 +178,8 @@ pub enum LlmError {
     Http(String),
     /// Transport-level failure — the request never got an HTTP status back
     /// (connect refused, DNS, TLS, connection reset). The server rendered no
-    /// verdict, so unlike `Http` this is Retryable: switching models can't
-    /// mask an auth/config error the server never reported.
+    /// verdict, so unlike `Http` this retries and then advances: switching
+    /// models can't mask an auth/config error the server never reported.
     #[error("connect: {0}")]
     Connect(String),
     #[error("rate limit")]
@@ -192,6 +192,15 @@ pub enum LlmError {
     ServerError(u16),
     #[error("insufficient credit")]
     InsufficientCredit,
+    /// The endpoint does not serve this model id (HTTP 404). Distinct from
+    /// `Http` because the two need opposite handling: a 404 is permanent for
+    /// this candidate — retrying it with backoff can only waste the retry
+    /// budget — but it is exactly what the fallback chain exists for, so the
+    /// chain must advance immediately. Providers retire and rename ids
+    /// continuously; lumping this in with auth failures made a renamed model
+    /// kill the turn outright while a perfectly good fallback sat unused.
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
 }
 
 impl LlmError {
@@ -201,6 +210,7 @@ impl LlmError {
         match status {
             429 => LlmError::RateLimit,
             402 => LlmError::InsufficientCredit,
+            404 => LlmError::ModelNotFound(body),
             408 => LlmError::Timeout,
             500..=599 => LlmError::ServerError(status),
             _ => LlmError::Http(format!("status {status}: {body}")),
@@ -223,23 +233,40 @@ impl LlmError {
     }
 }
 
-/// Whether a failed call should advance the fallback chain (Retryable) or
-/// return immediately (Fatal — auth/bad-request/malformed, where switching
-/// models would only hide the real problem).
+/// What the fallback loop should do with a failed call.
+///
+/// Named for the action, not the error: the previous name (`Retryability`,
+/// `Retryable`) said "retry" while the variant actually meant "retry this
+/// candidate `max_retries` times, cool it down, then advance" — two decisions
+/// behind one word. The third state was the one missing: a failure that is
+/// permanent for this candidate but may well succeed on the next.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Retryability {
-    Retryable,
-    Fatal,
+pub enum Disposition {
+    /// Transient. Retry this candidate with backoff; advance once the budget
+    /// is spent.
+    RetryThenAdvance,
+    /// Permanent for this candidate, plausibly fine on another. Advance
+    /// immediately — retrying cannot change the answer, and the backoff
+    /// sleeps are pure latency.
+    AdvanceNow,
+    /// Continuing is pointless or actively harmful. Auth failures live here:
+    /// falling back would re-present the same broken credential to a second
+    /// provider and bury a configuration error the operator has to fix.
+    Stop,
 }
 
-pub fn classify(e: &LlmError) -> Retryability {
+pub fn classify(e: &LlmError) -> Disposition {
     match e {
         LlmError::RateLimit
         | LlmError::Timeout
         | LlmError::Connect(_)
-        | LlmError::ServerError(_)
-        | LlmError::InsufficientCredit => Retryability::Retryable,
-        LlmError::Http(_) | LlmError::InvalidResponse(_) => Retryability::Fatal,
+        | LlmError::ServerError(_) => Disposition::RetryThenAdvance,
+        // Neither of these gets better by asking the same endpoint again:
+        // an account without credit does not acquire any within three
+        // exponential backoffs, and a model id the endpoint does not serve
+        // will not appear. Both may be fine on the next candidate.
+        LlmError::InsufficientCredit | LlmError::ModelNotFound(_) => Disposition::AdvanceNow,
+        LlmError::Http(_) | LlmError::InvalidResponse(_) => Disposition::Stop,
     }
 }
 
@@ -360,21 +387,69 @@ mod tests {
     }
 
     #[test]
-    fn classify_retryable_vs_fatal() {
-        use Retryability::*;
-        assert!(matches!(classify(&LlmError::RateLimit), Retryable));
-        assert!(matches!(classify(&LlmError::Timeout), Retryable));
-        assert!(matches!(classify(&LlmError::ServerError(500)), Retryable));
-        assert!(matches!(classify(&LlmError::InsufficientCredit), Retryable));
+    fn transient_failures_retry_then_advance() {
+        use Disposition::*;
+        assert!(matches!(classify(&LlmError::RateLimit), RetryThenAdvance));
+        assert!(matches!(classify(&LlmError::Timeout), RetryThenAdvance));
+        assert!(matches!(
+            classify(&LlmError::ServerError(500)),
+            RetryThenAdvance
+        ));
         assert!(matches!(
             classify(&LlmError::Connect("connection refused".into())),
-            Retryable
+            RetryThenAdvance
         ));
-        assert!(matches!(classify(&LlmError::Http("400".into())), Fatal));
+    }
+
+    /// A failure that is permanent for THIS candidate but not for the chain.
+    /// Retrying either of these against the same endpoint cannot change the
+    /// answer — an account does not acquire credit inside three backoffs, and
+    /// a model id the endpoint does not serve will not materialise — so they
+    /// must advance without spending the retry budget.
+    #[test]
+    fn permanent_for_this_candidate_advances_without_retrying() {
+        use Disposition::*;
+        assert!(matches!(
+            classify(&LlmError::ModelNotFound("no such model".into())),
+            AdvanceNow
+        ));
+        assert!(matches!(
+            classify(&LlmError::InsufficientCredit),
+            AdvanceNow
+        ));
+    }
+
+    /// Auth must never fall back. Presenting the same broken credential to a
+    /// second provider fails identically and buries a config error the operator
+    /// has to fix — and could spend money under a misconfiguration nobody asked
+    /// for.
+    #[test]
+    fn auth_and_malformed_stop_the_chain() {
+        use Disposition::*;
+        assert!(matches!(
+            classify(&LlmError::Http("status 401: unauthorized".into())),
+            Stop
+        ));
+        assert!(matches!(classify(&LlmError::Http("400".into())), Stop));
         assert!(matches!(
             classify(&LlmError::InvalidResponse("x".into())),
-            Fatal
+            Stop
         ));
+    }
+
+    /// 404 must not land in the `Http` catch-all, which is `Stop`. This is the
+    /// status a provider returns for a renamed or retired model id, and it is
+    /// precisely what a fallback chain exists to survive.
+    #[test]
+    fn a_404_becomes_model_not_found_not_a_generic_http_error() {
+        let e = LlmError::from_status(404, "model claude-sonnet-4-6 not found".into());
+        assert!(matches!(e, LlmError::ModelNotFound(_)), "{e:?}");
+        assert_eq!(classify(&e), Disposition::AdvanceNow);
+        // 401 shares the catch-all and must keep stopping.
+        assert_eq!(
+            classify(&LlmError::from_status(401, "unauthorized".into())),
+            Disposition::Stop
+        );
     }
 
     #[test]
@@ -383,10 +458,10 @@ mod tests {
             LlmError::from_status(408, String::new()),
             LlmError::Timeout
         ));
-        // 401 stays Http → Fatal: auth errors must never advance the chain.
+        // 401 stays Http → Stop: auth errors must never advance the chain.
         let e = LlmError::from_status(401, "unauthorized".into());
         assert!(matches!(e, LlmError::Http(_)));
-        assert!(matches!(classify(&e), Retryability::Fatal));
+        assert!(matches!(classify(&e), Disposition::Stop));
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -462,8 +462,19 @@ pub struct App {
     pub turn_out: u64,
     /// Last-known context fill from the runtime's `Task.usage.context_tokens`.
     pub ctx_tokens: u64,
-    /// Agent's model pricing loaded at startup (used by the footer renderer).
+    /// Pricing for the model that answered the LAST turn — not necessarily the
+    /// one this agent is configured with, because the runtime's fallback chain
+    /// substitutes another when a candidate is unreachable, out of credit, or
+    /// serving a retired model id. Re-resolved per turn from `usage.model_ref`.
     pub pricing: super::footer::Pricing,
+    /// Every registry entry's pricing, so a substitution can be re-priced
+    /// without touching disk mid-turn. `None` in tests and in plain mode.
+    pub pricing_book: Option<super::PricingBook>,
+    /// Registry key of the model that answered most recently, once it has
+    /// differed from the configured one. Drives the substitution notice, and
+    /// remembers what we already told the user so a long session does not
+    /// repeat itself every turn.
+    pub answered_key: Option<String>,
     /// Set to `true` when `StepStarted` fires this turn; used by the footer
     /// to distinguish "pure chat" from "agentic" turns.
     pub saw_step_this_turn: bool,
@@ -592,6 +603,8 @@ impl App {
             turn_out: 0,
             ctx_tokens: 0,
             pricing: super::footer::Pricing::default(),
+            pricing_book: None,
+            answered_key: None,
             saw_step_this_turn: false,
             saw_hitl_this_turn: false,
             step_hint_shown: false,
@@ -701,6 +714,44 @@ impl App {
         if let Some(c) = super::footer::context_tokens(usage) {
             self.ctx_tokens = c;
         }
+        // The runtime reports which model actually answered. Despite the field
+        // name this is the provider's model NAME (`LlmResponse.model`), not a
+        // registry key — the runtime writes `resp.model` into it.
+        //
+        // This arrived on every turn and was thrown away here, while the footer
+        // priced the session from the configured `model_ref` looked up once at
+        // startup. So whenever the fallback chain substituted a model, the
+        // `$x est` figure was computed at the wrong rates and nothing said so.
+        if let Some(answered) = usage.get("model_ref").and_then(|v| v.as_str()) {
+            self.apply_answering_model(answered);
+        }
+    }
+
+    /// Re-price from the model that actually answered, and say so once when it
+    /// is not the configured one.
+    fn apply_answering_model(&mut self, answered: &str) {
+        let Some(book) = &self.pricing_book else {
+            return;
+        };
+        let Some(key) = book.key_for_model(answered).map(str::to_string) else {
+            // A model the registry has never heard of: we cannot price it, and
+            // guessing at the configured model's rates is how the wrong number
+            // got shown in the first place.
+            self.pricing = super::footer::Pricing::default();
+            return;
+        };
+        self.pricing = book.pricing_for_key(&key);
+        let configured = book.configured_key.clone();
+        // Announce only on a CHANGE, so a long session substituted once does
+        // not repeat the notice every turn.
+        if Some(&key) != configured.as_ref() && self.answered_key.as_ref() != Some(&key) {
+            let from = configured.as_deref().unwrap_or("the configured model");
+            self.push_system(format!(
+                "⇄ answered by '{key}' ({answered}), not '{from}' — the runtime fell back. \
+                 Cost below is now priced for '{key}'."
+            ));
+        }
+        self.answered_key = Some(key);
     }
 
     /// Reveal suggestions captured this turn: one → ghost placeholder, many →

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -64,31 +64,84 @@ use self::persist::Session;
 use self::stream::{StreamMsg, build_params, cancel_task, respond_hitl, spawn_stream};
 use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
 
-/// Load the agent's model pricing from `~/.mur/models.yaml`. Falls back to
-/// `Pricing::default()` (all `None` fields) on any error or when the agent
-/// uses an inline model rather than a `model_ref:` registry alias. The footer
-/// renderer treats `None` costs/window as "unknown" and shows `—`.
-fn load_pricing(home: &std::path::Path, agent: &str) -> footer::Pricing {
-    let pricing = footer::Pricing::default();
-    let Ok((_, profile)) = crate::cmd::agent::load_profile_for_edit(agent) else {
-        return pricing;
-    };
-    let Some(model_ref) = profile.model_ref else {
-        return pricing;
-    };
-    let reg_path = home.join("models.yaml");
-    let Ok(reg) = mur_common::model::ModelRegistry::load_from(&reg_path) else {
-        return pricing;
-    };
-    let Some(entry) = reg.models.get(&model_ref) else {
-        return pricing;
-    };
-    let (input, output) = entry.effective_costs();
-    footer::Pricing {
-        in_per_1k: input,
-        out_per_1k: output,
-        window: entry.context_window,
+/// Every model the registry knows how to price, plus which one this agent is
+/// configured to use.
+///
+/// Pricing used to be resolved once at startup from `profile.model_ref` and
+/// applied to the whole session. That is only correct while the agent actually
+/// runs the model it was configured with — and the runtime's fallback chain
+/// substitutes a different one whenever a candidate is unreachable, out of
+/// credit, or serving a model id the provider has retired. The footer went on
+/// charging at the configured model's rates, so the `$x est` figure was
+/// confidently wrong and nothing said a substitution had happened. The runtime
+/// already reports which model answered; this book is what lets the footer use
+/// it (#947).
+pub(crate) struct PricingBook {
+    /// Registry key → pricing, for every entry.
+    by_key: std::collections::HashMap<String, footer::Pricing>,
+    /// Provider-side model name → registry key. Populated from each entry's
+    /// `model:` field.
+    key_of_model: std::collections::HashMap<String, String>,
+    /// The key this agent's profile points at, when it uses one.
+    pub configured_key: Option<String>,
+}
+
+impl PricingBook {
+    pub fn pricing_for_key(&self, key: &str) -> footer::Pricing {
+        self.by_key.get(key).cloned().unwrap_or_default()
     }
+
+    /// Registry key for a provider-reported model name.
+    ///
+    /// Exact match first, then the LONGEST registry model id that prefixes the
+    /// reported name — providers append build dates (`claude-haiku-4-5` is
+    /// reported as `claude-haiku-4-5-20251001`). Longest-first matters: a
+    /// shorter, older id would otherwise shadow a newer one that shares its
+    /// prefix.
+    pub fn key_for_model(&self, model: &str) -> Option<&str> {
+        if let Some(k) = self.key_of_model.get(model) {
+            return Some(k.as_str());
+        }
+        self.key_of_model
+            .iter()
+            .filter(|(name, _)| !name.is_empty() && model.starts_with(name.as_str()))
+            .max_by_key(|(name, _)| name.len())
+            .map(|(_, k)| k.as_str())
+    }
+}
+
+/// Build the pricing book and resolve the agent's configured key. Falls back to
+/// an empty book (every lookup → unknown pricing) on any read error.
+fn load_pricing(home: &std::path::Path, agent: &str) -> (footer::Pricing, PricingBook) {
+    let mut book = PricingBook {
+        by_key: Default::default(),
+        key_of_model: Default::default(),
+        configured_key: None,
+    };
+    let Ok(reg) = mur_common::model::ModelRegistry::load_from(&home.join("models.yaml")) else {
+        return (footer::Pricing::default(), book);
+    };
+    for (key, entry) in &reg.models {
+        let (input, output) = entry.effective_costs();
+        book.by_key.insert(
+            key.clone(),
+            footer::Pricing {
+                in_per_1k: input,
+                out_per_1k: output,
+                window: entry.context_window,
+            },
+        );
+        book.key_of_model.insert(entry.model.clone(), key.clone());
+    }
+    book.configured_key = crate::cmd::agent::load_profile_for_edit(agent)
+        .ok()
+        .and_then(|(_, p)| p.model_ref);
+    let current = book
+        .configured_key
+        .as_deref()
+        .map(|k| book.pricing_for_key(k))
+        .unwrap_or_default();
+    (current, book)
 }
 
 /// How many recent conversations `/sessions` lists.
@@ -333,7 +386,9 @@ async fn run_tui(
         app.fleet = Some(fleet_rail::FleetRail::start(f));
     }
     app.skills = complete::load_agent_skills(&agent);
-    app.pricing = load_pricing(&home, &agent);
+    let (initial_pricing, book) = load_pricing(&home, &agent);
+    app.pricing = initial_pricing;
+    app.pricing_book = Some(book);
     if unknown_skin {
         app.push_system(format!(
             "unknown skin '{skin_name}', using dark — valid: dark, light, mur"
@@ -2118,7 +2173,7 @@ fn run_plain(
     use std::io::Write as _;
     let out2 = RefCell::new(io::stdout());
     let mut context: Option<String> = None;
-    let pricing = load_pricing(home, agent);
+    let (pricing, _book) = load_pricing(home, agent);
     // Tools the operator granted with `[a]` this session. Plain mode had no
     // such set, so `[a]lways` approved exactly one call — the prompt said one
     // thing and the code did another.
@@ -2564,5 +2619,191 @@ mod help_coverage_tests {
                 "/{name} works but /help never mentions it"
             );
         }
+    }
+}
+
+/// #947: pricing used to be resolved once at startup from the configured
+/// `model_ref`. The runtime substitutes a different model whenever a candidate
+/// is unreachable, out of credit, or serving a retired id — and the footer went
+/// on charging at the configured rates.
+#[cfg(test)]
+mod pricing_book_tests {
+    use super::PricingBook;
+    use super::footer::Pricing;
+    use std::collections::HashMap;
+
+    fn book() -> PricingBook {
+        let mut by_key = HashMap::new();
+        let mut key_of_model = HashMap::new();
+        by_key.insert(
+            "omlx".to_string(),
+            Pricing {
+                in_per_1k: None,
+                out_per_1k: None,
+                window: Some(32_000),
+            },
+        );
+        key_of_model.insert("Qwen3.5-4B-MLX-4bit".to_string(), "omlx".to_string());
+        by_key.insert(
+            "claude_haiku".to_string(),
+            Pricing {
+                in_per_1k: Some(0.001),
+                out_per_1k: Some(0.005),
+                window: Some(200_000),
+            },
+        );
+        key_of_model.insert("claude-haiku-4-5".to_string(), "claude_haiku".to_string());
+        // A newer id sharing the older one's prefix — the shadowing trap.
+        by_key.insert(
+            "claude_haiku_5".to_string(),
+            Pricing {
+                in_per_1k: Some(0.002),
+                out_per_1k: Some(0.01),
+                window: Some(400_000),
+            },
+        );
+        key_of_model.insert(
+            "claude-haiku-4-5-turbo".to_string(),
+            "claude_haiku_5".to_string(),
+        );
+        PricingBook {
+            by_key,
+            key_of_model,
+            configured_key: Some("omlx".to_string()),
+        }
+    }
+
+    #[test]
+    fn a_provider_build_suffix_still_resolves_to_its_entry() {
+        let b = book();
+        // Exact.
+        assert_eq!(b.key_for_model("claude-haiku-4-5"), Some("claude_haiku"));
+        // Providers append a build date; the entry must still be found.
+        assert_eq!(
+            b.key_for_model("claude-haiku-4-5-20251001"),
+            Some("claude_haiku")
+        );
+    }
+
+    /// Longest prefix wins. A shorter, older id must not shadow a newer one
+    /// that shares its prefix — that mis-prices every call to the new model.
+    #[test]
+    fn the_longest_matching_id_wins_not_the_first() {
+        let b = book();
+        assert_eq!(
+            b.key_for_model("claude-haiku-4-5-turbo-20260101"),
+            Some("claude_haiku_5")
+        );
+    }
+
+    #[test]
+    fn an_unknown_model_resolves_to_nothing_rather_than_the_nearest_guess() {
+        assert_eq!(book().key_for_model("gpt-9-unreleased"), None);
+    }
+}
+
+/// #947: the substitution must reach the user — a silent downgrade changes both
+/// cost and quality with nothing on screen to show it happened.
+#[cfg(test)]
+mod fallback_visibility_tests {
+    use super::PricingBook;
+    use super::app::{App, Role};
+    use super::footer::Pricing;
+    use std::collections::HashMap;
+
+    fn app_with_book() -> App {
+        let mut by_key = HashMap::new();
+        let mut key_of_model = HashMap::new();
+        // Configured: a local model with no price at all.
+        by_key.insert("omlx".to_string(), Pricing::default());
+        key_of_model.insert("Qwen3.5-4B-MLX-4bit".to_string(), "omlx".to_string());
+        // The global fallback: a metered cloud model.
+        by_key.insert(
+            "claude_haiku".to_string(),
+            Pricing {
+                in_per_1k: Some(0.001),
+                out_per_1k: Some(0.005),
+                window: Some(200_000),
+            },
+        );
+        key_of_model.insert("claude-haiku-4-5".to_string(), "claude_haiku".to_string());
+
+        let mut a = App::test_fixture();
+        a.pricing_book = Some(PricingBook {
+            by_key,
+            key_of_model,
+            configured_key: Some("omlx".to_string()),
+        });
+        a.pricing = Pricing::default();
+        a
+    }
+
+    fn usage(model: &str) -> serde_json::Value {
+        serde_json::json!({ "input_tokens": 1000, "output_tokens": 1000, "model_ref": model })
+    }
+
+    fn notices(a: &App) -> usize {
+        a.messages
+            .iter()
+            .filter(|m| m.role == Role::System && m.text.contains("fell back"))
+            .count()
+    }
+
+    /// The exact production shape: a local free model 404s, the chain
+    /// substitutes a metered cloud one, and the footer used to keep pricing it
+    /// as the local model — showing "no price" for a turn that cost money.
+    #[test]
+    fn a_substituted_model_reprices_the_turn_and_says_so() {
+        let mut a = app_with_book();
+        assert!(
+            a.pricing.in_per_1k.is_none(),
+            "configured model is unpriced"
+        );
+
+        a.apply_usage(&usage("claude-haiku-4-5-20251001"));
+
+        assert_eq!(
+            a.pricing.in_per_1k,
+            Some(0.001),
+            "must re-price from the model that actually answered"
+        );
+        assert_eq!(notices(&a), 1, "the substitution must be announced");
+    }
+
+    /// Announced on the change, not on every turn — a long session that fell
+    /// back once must not repeat itself forever.
+    #[test]
+    fn the_notice_does_not_repeat_while_the_substitution_holds() {
+        let mut a = app_with_book();
+        for _ in 0..4 {
+            a.apply_usage(&usage("claude-haiku-4-5"));
+        }
+        assert_eq!(notices(&a), 1);
+    }
+
+    /// Control: answering with the configured model says nothing at all.
+    #[test]
+    fn the_configured_model_answering_is_not_an_event() {
+        let mut a = app_with_book();
+        a.apply_usage(&usage("Qwen3.5-4B-MLX-4bit"));
+        assert_eq!(notices(&a), 0);
+        assert!(a.pricing.in_per_1k.is_none());
+    }
+
+    /// A model the registry cannot price must show "unknown", never inherit the
+    /// configured model's rates — that is the wrong-number bug in miniature.
+    #[test]
+    fn an_unpriceable_answer_does_not_inherit_the_configured_rates() {
+        let mut a = app_with_book();
+        a.pricing = Pricing {
+            in_per_1k: Some(9.99),
+            out_per_1k: Some(9.99),
+            window: Some(1),
+        };
+        a.apply_usage(&usage("some-model-nobody-registered"));
+        assert!(
+            a.pricing.in_per_1k.is_none(),
+            "stale rates must not survive an unpriceable answer"
+        );
     }
 }


### PR DESCRIPTION
Closes the whole fallback/error-classification thread agreed after #945 — A, B1, B2 and B3 together rather than A alone.

**Why they ship together.** A (404 advances) *opens* a silent-substitution path; B1 (visibility) is the light on that door. Landing A by itself would have traded a loud failure for an invisible permanent one — and a wrong dollar figure. That coupling only became clear after digging into what the TUI does with the data it already receives.

---

## 1. A renamed model id killed the turn

A provider retiring or renaming a model returns **404**. `from_status` had no case for it, so it fell into the `Http` catch-all → `Fatal` → turn dies, while a perfectly good fallback candidate sat unused. No 404 or `model_not_found` handling existed anywhere in the crate.

"Make 404 retryable" would have been wrong: `Retryable` meant *retry this candidate `max_retries` times with backoff, cool it down, then advance*, and a 404 cannot become a 200 by asking again. The missing thing was a third state.

```
Retryability{Retryable, Fatal}  →  Disposition{RetryThenAdvance, AdvanceNow, Stop}
```

Named for what the caller does, not what happened. The old name said "retry" while the variant decided two separate things — which is how a whole class of failure landed on the wrong side unnoticed.

## 2. The substitution was invisible, and the cost display lied

`load_pricing` resolved rates **once at startup** from `profile.model_ref` and priced the whole session with them. Correct only while the agent runs what it was configured with.

The runtime was already telling the truth — `task_runner` writes `resp.model` into `usage.model_ref`, every turn, across the wire. `App::apply_usage` read the three token counts and **threw the model away**.

One fact, two sources, the display reading the stale one — the same shape as #940, for the fourth time this week.

**This is not theoretical.** 23 of 27 installed agents have no per-agent `fallback_chain`, so they inherit the global one:

```yaml
models:
  fallback_chain: [claude_haiku, claude_sonnet]
```

So a local, free oMLX endpoint that 404s (local server restarted with a different model loaded — routine) now substitutes a **metered cloud model**, and the footer showed `no price`.

Now: re-priced per turn from the model that actually answered, announced once when it changes, and an unpriceable answer shows unknown rather than inheriting the configured rates. Build suffixes resolve by **longest** prefix (`claude-haiku-4-5-20251001` → `claude_haiku`) so a shorter older id can't shadow a newer one sharing it.

## 3. Exhaustion reported whichever failure happened to be last

Three `last = Some(e)` writes, one `last.unwrap_or_else(...)` — diagnosis by accident of chain order. A wrong API key on the primary was invisible behind a rate limit on the third candidate.

Now folded into `AllCandidatesFailed`, whose `source` is the **most actionable** error (a config error the operator can fix outranks weather they cannot), so upstream classification stays correct, while the summary reports what each candidate said.

## 4. Enumerate the closed set; default to the open one

`from_status` enumerated the *recoverable* codes and defaulted the tail to `Http` → Stop. That's backwards. The set that must never fall back is small, closed, stable across providers: **authentication**. The set that should is open and growing — payload too large, unsupported modality, region, tier, and whatever the next provider invents.

| Status | Before | After |
|---|---|---|
| 401 / 403 | `Http` → Fatal | `Auth` → **Stop** (unchanged behaviour) |
| 404 | `Http` → Fatal | `ModelNotFound` → **AdvanceNow** |
| 402 | retry 3× → advance | `InsufficientCredit` → **AdvanceNow** |
| other 4xx | `Http` → Fatal | `Rejected` → **AdvanceNow** |
| builder / parse errors | `Http` → Fatal | `Http` → **Stop** (our own bug) |
| 429 / 408 / 5xx / connect | Retryable | **RetryThenAdvance** (unchanged) |

A malformed request of our own now costs N failing calls instead of one — which is precisely why §3 is a prerequisite, not a follow-up.

## Verification

**A test caught a mistake in my own reasoning.** The first exhaustion test used an Auth failure on the primary and asserted an aggregate. It short-circuits — Auth is `Stop` — so it never exhausts. Rewritten around three advancing failures, with the Auth case pinned separately by `a_single_stop_still_short_circuits_without_an_aggregate`.

The load-bearing retry test: candidate `a` is scripted to fail 404 **then succeed**, with `max_retries=3`. Any retry at all returns `"a"`. It returns `"b"` — so "advanced" and "advanced *without burning the budget*" are distinguishable, which a test asserting only the former could not do.

All new assertions were run against reverted behaviour first; the visibility ones fail red when `apply_usage` goes back to discarding the field.

```
cargo nextest -p mur-agent-runtime   867 passed
cargo nextest -p mur-core --lib     2417 passed
clippy --all-targets -D warnings    clean
```

## Still deferred, deliberately

**Same-provider awareness** — 429 and 402 are account-level, so advancing to another model on the same account is a guaranteed-wasted round-trip. Correct in principle, but chains are 2-3 long and `cooldown` already exists; the cost outweighs the gain. Noted rather than built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)