### PR TITLE
chore(release): bump workspace version to 2.69.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.68.8"
+version = "2.69.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.8"
+version = "2.69.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
⚠️ **Merging this PR IS the release.** `tag.yml` tags `v2.69.0` on the merge commit and dispatches `release.yml`, which publishes to **crates.io — irreversible, yank-only**. There is no later gate; this PR is the release approval.

## Why minor, not patch

This cycle adds a new top-level subcommand (`mur model doctor`) and changes runtime behaviour a user can observe: a 404, a 402, or an unrecognised 4xx from a provider now **advances the fallback chain** instead of killing the turn, and a substituted model is announced and re-priced in the CLI footer.

## Contents — 7 commits since 2.68.8

| PR | |
|---|---|
| #941 | fail the turn when a provider reports a tool call but returns none |
| #942 | assemble streamed tool calls on the OpenAI path |
| #943 | show the whole command in the approval gate, and keep its keys usable |
| #944 | stop the status line stating two different things about one fact |
| #945 | preview resolves `model_ref`; new `mur model doctor` |
| #946 | complete the `mur model` row in the README command tree |
| #947 | survive a renamed model id, and never substitute one silently |

## Behaviour changes worth calling out in the release notes

- **Fallback chain**: 404 (retired/renamed model id), 402 (no credit) and unrecognised 4xx now advance to the next candidate. 401/403 still stop the chain dead — auth must never fall back.
- **CLI footer**: priced per turn from the model that actually answered, not from the configured `model_ref` looked up at startup. A substitution is announced once. An unpriceable model shows `no price` instead of an em dash that read as "free".
- **Approval gate**: the whole tool input is shown (wrapped, scrollable) instead of truncated at 12 lines; `Ctrl+U` clears the composer so the decision keys stay reachable.
- **`mur model doctor`** (new): offline, read-only audit of the model registry and every agent profile. Never rewrites a model id.

## Version hygiene

Both lock files moved with `Cargo.toml` — the root one and `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace crate's version and fails the Hub release build when it disagrees. No `2.68.8` string remains in any of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)