### PR TITLE
fix(discovery): resolve anthropic model lists from the models.dev catalog, not the endpoint

### DIFF
--- a/mur-core/src/model_discovery.rs
+++ b/mur-core/src/model_discovery.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::time::Duration;
 
 /// Response envelope shapes we support.
@@ -93,17 +94,30 @@ fn auth_headers(provider: &str, api_key: Option<&str>) -> Vec<(&'static str, Str
 
 /// Discover available models via HTTP GET to `{base}/v1/models`, assuming
 /// OpenAI-compatible Bearer auth. Use [`discover_models_for`] when the
-/// provider is known.
+/// provider is known. The empty provider never takes the catalog path, so no
+/// `mur_home` is needed here.
 #[allow(dead_code)]
 pub fn discover_models(
     base_url: &str,
     api_key: Option<&str>,
     timeout_secs: u64,
 ) -> Result<Vec<String>> {
-    discover_models_for("", base_url, api_key, timeout_secs)
+    discover_models_for("", Path::new(""), base_url, api_key, timeout_secs)
 }
 
-/// Discover available models for `provider` via HTTP GET to `{base}/v1/models`.
+/// Discover available models for `provider`.
+///
+/// Vendor-specific protocols (today: `anthropic`) resolve from the models.dev
+/// catalog cache instead of the endpoint: their registry base URL is often a
+/// chat-only proxy (e.g. the local cc-proxy gateway) that only rewrites
+/// `/v1/messages*` and forwards `GET /v1/models` untouched, so a live probe
+/// 401s no matter which key the caller holds. The catalog defines those
+/// vendors' model lists anyway.
+///
+/// Everything else — including the `openai` slug, which in this registry is a
+/// wire protocol, not a vendor (DeepSeek, local runtimes, and real OpenAI keys
+/// all use it) — keeps live HTTP GET to `{base}/v1/models`: only the endpoint
+/// knows which models it actually serves.
 ///
 /// Best-effort with timeout. A non-empty API key is sent with whichever auth
 /// header the provider expects (see [`auth_headers`]).
@@ -111,10 +125,18 @@ pub fn discover_models(
 #[allow(dead_code)]
 pub fn discover_models_for(
     provider: &str,
+    mur_home: &Path,
     base_url: &str,
     api_key: Option<&str>,
     timeout_secs: u64,
 ) -> Result<Vec<String>> {
+    if provider == ANTHROPIC_PROVIDER
+        && let Some(ids) = crate::model_prices::load_or_fetch(mur_home)
+            .and_then(|cat| cat.provider_models(provider))
+            .filter(|ids| !ids.is_empty())
+    {
+        return Ok(ids);
+    }
     let url = models_url(base_url);
     let url_for_err = url.clone();
     let headers = auth_headers(provider, api_key);
@@ -355,6 +377,53 @@ mod tests {
             }
         });
         format!("http://127.0.0.1:{port}/v1")
+    }
+
+    const CATALOG_FIXTURE: &str = r#"{
+      "anthropic": { "models": { "claude-a": {}, "claude-b": {} } },
+      "openai": { "models": { "gpt-x": {} } }
+    }"#;
+
+    fn seed_catalog(home: &Path, json: &str) {
+        let path = crate::model_prices::cache_path(home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, json).unwrap();
+    }
+
+    #[test]
+    fn anthropic_discovery_reads_catalog_and_never_probes_the_endpoint() {
+        let home = tempfile::TempDir::new().unwrap();
+        seed_catalog(home.path(), CATALOG_FIXTURE);
+        // Unroutable base: a regression back to live probing fails fast here
+        // with a connection error instead of returning the catalog list.
+        let ids = discover_models_for(
+            ANTHROPIC_PROVIDER,
+            home.path(),
+            "http://127.0.0.1:1/v1",
+            Some("irrelevant"),
+            1,
+        )
+        .unwrap();
+        assert_eq!(ids, vec!["claude-a", "claude-b"]);
+    }
+
+    #[test]
+    fn openai_slug_is_a_protocol_and_keeps_live_discovery() {
+        let home = tempfile::TempDir::new().unwrap();
+        // The catalog knows "openai" too — live discovery must still win.
+        seed_catalog(home.path(), CATALOG_FIXTURE);
+        let base = one_shot_server("200 OK", r#"{"data":[{"id":"deepseek-v4"}]}"#);
+        let ids = discover_models_for("openai", home.path(), &base, None, 5).unwrap();
+        assert_eq!(ids, vec!["deepseek-v4"]);
+    }
+
+    #[test]
+    fn anthropic_empty_catalog_entry_falls_back_to_live() {
+        let home = tempfile::TempDir::new().unwrap();
+        seed_catalog(home.path(), r#"{ "anthropic": { "models": {} } }"#);
+        let base = one_shot_server("200 OK", r#"{"data":[{"id":"claude-live"}]}"#);
+        let ids = discover_models_for(ANTHROPIC_PROVIDER, home.path(), &base, None, 5).unwrap();
+        assert_eq!(ids, vec!["claude-live"]);
     }
 
     #[test]

--- a/mur-core/src/model_prices.rs
+++ b/mur-core/src/model_prices.rs
@@ -113,6 +113,15 @@ impl Catalog {
             context_window: raw.limit.as_ref().and_then(|l| l.context),
         })
     }
+
+    /// All model ids the catalog lists under `provider`, sorted.
+    /// `None` when the catalog has no such provider.
+    pub fn provider_models(&self, provider: &str) -> Option<Vec<String>> {
+        let prov = self.providers.get(provider)?;
+        let mut ids: Vec<String> = prov.models.keys().cloned().collect();
+        ids.sort();
+        Some(ids)
+    }
 }
 
 /// Return the path where the catalog cache should be stored.
@@ -131,6 +140,15 @@ pub fn load_cached(mur_home: &Path, ttl_hours: u64) -> Option<Catalog> {
     }
     let body = std::fs::read_to_string(&path).ok()?;
     parse_catalog(&body).ok()
+}
+
+/// Best-effort catalog handle: fresh cache → network fetch (+cache) → stale
+/// cache. Unlike [`lookup`], the ladder stops at the first *catalog*, not the
+/// first hit — a fresh cache that lacks one model does not trigger a refetch.
+pub fn load_or_fetch(mur_home: &Path) -> Option<Catalog> {
+    load_cached(mur_home, TTL_HOURS)
+        .or_else(|| fetch_and_cache(mur_home))
+        .or_else(|| load_cached(mur_home, u64::MAX))
 }
 
 /// Fetch the catalog from the network and write it to the cache.

--- a/mur-hub-gui/src-tauri/src/models_admin.rs
+++ b/mur-hub-gui/src-tauri/src/models_admin.rs
@@ -207,11 +207,18 @@ pub async fn test_provider(
     }
 
     let home = mur_home();
+    let home_for_discovery = home.clone();
     let prov = provider.clone();
     let prov2 = provider.clone();
     // discover_models uses reqwest::blocking — run it off the async runtime.
     let ids = tokio::task::spawn_blocking(move || {
-        model_discovery::discover_models_for(&prov2, &base, key.as_deref(), DISCOVER_TIMEOUT_SECS)
+        model_discovery::discover_models_for(
+            &prov2,
+            &home_for_discovery,
+            &base,
+            key.as_deref(),
+            DISCOVER_TIMEOUT_SECS,
+        )
     })
     .await
     .map_err(|e| format!("discovery task failed: {e}"))?


### PR DESCRIPTION
## Problem

Hub Model Library "Re-explore models" for Anthropic always failed with `401 API key is invalid`. The registry's anthropic base URL points at the local cc-proxy gateway, whose disguise layer only covers `/v1/messages*` (`should_disguise()`); `GET /v1/models` is forwarded verbatim, and the machine holds no raw Anthropic API key — so live discovery is structurally impossible on that setup, regardless of the key entered.

## Fix

Vendor-specific protocols (today: `anthropic`) resolve their model list from the models.dev catalog cache (fresh cache → network fetch → stale cache) instead of probing the endpoint. An empty or missing catalog entry still falls back to the live probe.

**Deliberate exception:** the `openai` slug keeps live `/v1/models` discovery. In this registry that slug is a wire protocol, not a vendor — DeepSeek endpoints, local runtimes, and real OpenAI keys all use it, and only the endpoint knows which models it actually serves. Routing it through the catalog would list `gpt-*` for a DeepSeek endpoint.

## Changes

- `mur-core/src/model_prices.rs`: `Catalog::provider_models()` (sorted id list per provider), `load_or_fetch()` (catalog-level cache ladder; unlike `lookup`, stops at the first catalog rather than the first hit).
- `mur-core/src/model_discovery.rs`: catalog-first branch in `discover_models_for` for `ANTHROPIC_PROVIDER`; new `mur_home` param (the empty-provider wrapper never reads it). 3 new tests: catalog path never touches the endpoint (unroutable base), openai slug stays live, empty catalog entry falls back to live.
- `mur-hub-gui/src-tauri/src/models_admin.rs`: pass `mur_home` through.

## Verification

- `cargo check -p mur-core --all-targets` ✓
- `cargo nextest run -p mur-core -E 'test(/model_discovery|model_prices/)'` — 38/38 passed
- `cargo clippy -p mur-core --all-targets -- -D warnings` ✓ (after clearing a stale pre-#949 fingerprint for mur-common/mur-channel)
- `cargo fmt --check` ✓ (workspace + hub manifest)
- `cargo check --lib` on mur-hub-gui ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)