### PR TITLE
feat(murmur): /model slash command with runtime hot-switch (model/set)

### DIFF
--- a/docs/superpowers/specs/2026-08-17-murmur-model-slash-command-design.md
+++ b/docs/superpowers/specs/2026-08-17-murmur-model-slash-command-design.md
@@ -1,0 +1,105 @@
+# murmur `/model` Slash Command — Design
+
+**Status**: approved (conversation 2026-08-17); implementation in progress
+**Author**: david + Claude Fable 5
+
+## Problem
+
+Switching an agent's model today means editing `profile.yaml` and restarting
+the runtime (the profile is loaded once at boot). Pi/Claude Code users expect
+an in-session `/model` picker. murmur already has a slash-command surface
+(`/channels`, `/sessions`, …) but no model command, and the runtime has no way
+to change its LLM client after boot.
+
+## Decisions (grilled + approved)
+
+1. **Hot switch** — new A2A method `model/set`; the running supervisor swaps
+   its live LLM client. No restart (auto-restart stays forbidden).
+2. **Registry-only listing** — `/model` lists `~/.mur/models.yaml` entries.
+   No key entry, no unregistered catalog models in the TUI (that flow is the
+   CLI `mur model connect` project).
+3. **Persist to profile** — a successful switch rewrites `model_ref` in the
+   agent's `profile.yaml` so disk and process never disagree. The registry is
+   never modified.
+
+## UX (murmur TUI)
+
+- `/model` — numbered list of registry entries grouped by provider, current
+  model marked `●` (from `profile.yaml` `model_ref`), per-1k prices shown
+  when the entry carries them. Pure read; cancelling (not picking) leaves no
+  state anywhere.
+- `/model <n|name>` — switch by list number or registry alias
+  (case-insensitive alias match, same convention as agent names).
+- Success: `model → <ref> (effective next turn; saved to profile)`.
+- Old runtime without the method (JSON-RPC method-not-found): the TUI writes
+  `model_ref` to `profile.yaml` itself and prints a restart hint — graceful
+  degradation to the write-and-restart behaviour.
+- Agent not running: same profile write + restart hint (it had to restart
+  anyway).
+- Multiplexer panes are independent TUI processes; `/model` naturally targets
+  the focused pane's agent.
+
+## Protocol
+
+`model/set` params `{"model_ref": "<registry alias>"}` → result
+`{"model_ref": "...", "effective": "next-turn"}`.
+
+Trust surface = `message/send` (whoever can chat can already spend tokens);
+no HITL gate.
+
+## Runtime mechanics
+
+- `SwitchableLlmClient` — wrapper implementing `LlmClient`, holding
+  `std::sync::RwLock<Arc<dyn LlmClient>>`; each call clones the current inner
+  client (lock never held across await). `model_name()` returns the boot-time
+  name — same static-label precedent as `FallbackLlmClient::model_name`.
+- Boot (single-model path in `supervisor_runner`) wraps the built client in
+  `SwitchableLlmClient` and hands the handle + a client-builder closure
+  (registry ref → client, the same `build_client_from_entry` path) to the
+  dispatcher, which registers `ModelSetHandler`.
+- Switch order is strict: **validate ref → build new client → persist
+  profile.yaml → swap**. Any failure aborts with the old state fully intact —
+  disk and process can never disagree (the exact failure mode the
+  profile-staleness gotcha documents).
+- In-flight turns hold their cloned `Arc` and finish on the old model;
+  the swap is visible from the next turn.
+- Persistence edits `profile.yaml` as a YAML value tree (only the
+  `model_ref` key changes; the legacy `model:` block and unknown fields are
+  preserved byte-for-byte elsewhere) and writes temp+rename.
+
+## v1 limits (explicit)
+
+- **Fallback-chain / routing agents refuse the hot switch** with a clear
+  error (edit profile + restart instead). Rebuilding the routed
+  `FallbackLlmClient` stack live means extracting the whole boot construction
+  block; that is v2. The handler is only registered on the single-model path,
+  so chain/routing (and echo/misconfigured) agents surface method-not-found
+  and the TUI degrades to profile-write + restart hint.
+- The stale legacy `model:` block is left untouched; `mur model doctor` may
+  flag the disagreement until the block is refreshed by its own tooling.
+- The in-memory `Arc<Profile>` keeps the boot `model_ref` (used only for
+  boot resolution and card display); known, accepted staleness.
+
+## Testing
+
+- Runtime: `SwitchableLlmClient` delegates and a swap is visible to the next
+  request; `model/set` rejects an unknown ref (state unchanged); a builder
+  failure aborts without swapping (injected stub builder seam); persisted
+  profile parses back with the new `model_ref` and preserved fields.
+- TUI: `parse_slash` for `/model`, `/model 2`, `/model claude_opus`; list
+  formatting is a pure function with a unit test; dial-failure path falls
+  back to profile write + hint.
+
+## Non-goals
+
+- Provider connect / key entry in the TUI (CLI `mur model connect`, separate
+  design).
+- Editing fallback chains from the TUI.
+- Auto-restart of any kind.
+- `/login` naming — the command is `/model`, matching Pi and Claude Code.
+
+## Related
+
+- Discovery catalog-first fix (PR #950): known cloud vendors list models from
+  the models.dev catalog; the `openai` slug stays live because it is a wire
+  protocol, not a vendor.

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -9,6 +9,7 @@ pub mod fallback;
 pub mod ollama;
 pub mod openai;
 pub mod stub;
+pub mod switchable;
 
 /// Shared reqwest builder for the agent's LLM clients. Built with `.no_proxy()`
 /// so an LLM client NEVER inherits an ambient `HTTP_PROXY`/`HTTPS_PROXY` — its

--- a/mur-agent-runtime/src/llm/switchable.rs
+++ b/mur-agent-runtime/src/llm/switchable.rs
@@ -1,0 +1,131 @@
+//! Hot-swappable LLM client — the runtime half of the murmur `/model` slash
+//! command. Boot wraps the built client in this; the `model/set` A2A handler
+//! replaces the inner client between turns, so a switch never needs a
+//! supervisor restart.
+
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+
+use super::{LlmClient, LlmError, LlmRequest, LlmResponse, StreamDelta};
+
+pub struct SwitchableLlmClient {
+    inner: RwLock<Arc<dyn LlmClient>>,
+    /// Static label, same precedent as `FallbackLlmClient::model_name`: the
+    /// boot-time client's name, not the currently active one.
+    boot_name: String,
+}
+
+impl SwitchableLlmClient {
+    pub fn new(initial: Arc<dyn LlmClient>) -> Arc<Self> {
+        let boot_name = initial.model_name().to_string();
+        Arc::new(Self {
+            inner: RwLock::new(initial),
+            boot_name,
+        })
+    }
+
+    /// Replace the client used from the next request on. In-flight requests
+    /// hold their own `Arc` clone and finish on the old client.
+    pub fn swap(&self, next: Arc<dyn LlmClient>) {
+        *self.inner.write().expect("switchable client lock poisoned") = next;
+    }
+
+    /// Clone the current inner client. The lock is only held for the clone —
+    /// never across an await.
+    fn current(&self) -> Arc<dyn LlmClient> {
+        self.inner
+            .read()
+            .expect("switchable client lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl LlmClient for SwitchableLlmClient {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        self.current().generate(req).await
+    }
+
+    fn model_name(&self) -> &str {
+        &self.boot_name
+    }
+
+    async fn generate_stream(
+        &self,
+        req: LlmRequest,
+        sink: tokio::sync::mpsc::Sender<StreamDelta>,
+    ) -> Result<LlmResponse, LlmError> {
+        self.current().generate_stream(req, sink).await
+    }
+}
+
+/// Everything `model/set` needs: the live slot to swap plus a builder that
+/// turns a registry ref into a concrete client (the boot single-model path).
+/// Only produced on that path — chain/routing and echo agents get `None`, so
+/// the method is simply not registered for them.
+pub struct ModelSwitchHandle {
+    pub switchable: Arc<SwitchableLlmClient>,
+    pub build_client: super::fallback::ClientFactory,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{RequestIntent, StopReason};
+    use super::*;
+
+    struct FixedClient {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmClient for FixedClient {
+        async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            Ok(LlmResponse {
+                text: self.name.to_string(),
+                input_tokens: 0,
+                output_tokens: 0,
+                model: self.name.to_string(),
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+            })
+        }
+
+        fn model_name(&self) -> &str {
+            self.name
+        }
+    }
+
+    fn req() -> LlmRequest {
+        LlmRequest {
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            intent: RequestIntent::Interactive,
+            pin_model_ref: None,
+            task_id: None,
+            effort: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn swap_is_visible_to_the_next_request() {
+        let sw = SwitchableLlmClient::new(Arc::new(FixedClient { name: "before" }));
+        assert_eq!(sw.generate(req()).await.unwrap().text, "before");
+
+        sw.swap(Arc::new(FixedClient { name: "after" }));
+        assert_eq!(sw.generate(req()).await.unwrap().text, "after");
+        // Label stays the boot-time name by design (FallbackLlmClient precedent).
+        assert_eq!(sw.model_name(), "before");
+    }
+
+    #[tokio::test]
+    async fn in_flight_clone_keeps_the_old_client() {
+        let sw = SwitchableLlmClient::new(Arc::new(FixedClient { name: "old" }));
+        let held = sw.current();
+        sw.swap(Arc::new(FixedClient { name: "new" }));
+        assert_eq!(held.generate(req()).await.unwrap().text, "old");
+        assert_eq!(sw.generate(req()).await.unwrap().text, "new");
+    }
+}

--- a/mur-agent-runtime/src/protocol/methods/mod.rs
+++ b/mur-agent-runtime/src/protocol/methods/mod.rs
@@ -2,6 +2,7 @@
 pub mod card;
 pub mod channel_delegate;
 pub mod message_send;
+pub mod model_set;
 pub mod skills;
 pub mod tasks;
 pub mod turn;

--- a/mur-agent-runtime/src/protocol/methods/model_set.rs
+++ b/mur-agent-runtime/src/protocol/methods/model_set.rs
@@ -1,0 +1,184 @@
+//! A2A method: `model/set` — hot-switch the running agent to another registry
+//! model and persist the choice to `profile.yaml`.
+//!
+//! Registered only when boot produced a [`ModelSwitchHandle`] (single-model
+//! agents). Chain/routing and echo agents surface method-not-found, which the
+//! murmur TUI degrades to a profile write + restart hint.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::llm::switchable::ModelSwitchHandle;
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
+
+pub struct ModelSetHandler {
+    switch: Arc<ModelSwitchHandle>,
+    profile_path: PathBuf,
+}
+
+impl ModelSetHandler {
+    pub fn new(switch: Arc<ModelSwitchHandle>, profile_path: PathBuf) -> Self {
+        Self {
+            switch,
+            profile_path,
+        }
+    }
+}
+
+#[async_trait]
+impl MethodHandler for ModelSetHandler {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
+        let params = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
+        let model_ref = params
+            .get("model_ref")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| HandlerError::InvalidParams("missing 'model_ref' field".into()))?;
+
+        // Strict order: build → persist → swap. Any failure aborts with the
+        // old client AND the old profile intact — a switch can never leave
+        // "disk says new, process runs old" (or the reverse) behind.
+        let next = (self.switch.build_client)(model_ref)
+            .map_err(|e| HandlerError::InvalidParams(format!("model_ref {model_ref:?}: {e:#}")))?;
+        persist_model_ref(&self.profile_path, model_ref)
+            .map_err(|e| HandlerError::Internal(format!("persist model_ref: {e:#}")))?;
+        self.switch.switchable.swap(next);
+        tracing::info!(model_ref, "model/set: live client switched");
+        Ok(json!({ "model_ref": model_ref, "effective": "next-turn" }))
+    }
+}
+
+/// Rewrite `model_ref` in `profile.yaml` — typed round-trip + temp/rename,
+/// the same idiom as the rekey cleanup. The legacy `model:` block is a live
+/// read path and stays untouched; `model_ref` wins at resolution.
+fn persist_model_ref(path: &Path, model_ref: &str) -> anyhow::Result<()> {
+    let yaml = std::fs::read_to_string(path)?;
+    let mut p: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&yaml)?;
+    p.model_ref = Some(model_ref.to_string());
+    p.updated_at = chrono::Utc::now().to_rfc3339();
+    let out = serde_yaml_ng::to_string(&p)?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, out.as_bytes())?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::switchable::SwitchableLlmClient;
+    use crate::llm::{LlmClient, LlmError, LlmRequest, LlmResponse, StopReason};
+
+    struct FixedClient {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmClient for FixedClient {
+        async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            Ok(LlmResponse {
+                text: self.name.to_string(),
+                input_tokens: 0,
+                output_tokens: 0,
+                model: self.name.to_string(),
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+            })
+        }
+
+        fn model_name(&self) -> &str {
+            self.name
+        }
+    }
+
+    const MINIMAL_PROFILE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../mur-common/tests/fixtures/profile_p0a_minimal.yaml"
+    ));
+
+    fn seed_profile(dir: &Path) -> PathBuf {
+        let path = dir.join("profile.yaml");
+        let mut p: mur_common::agent::AgentProfile =
+            serde_yaml_ng::from_str(MINIMAL_PROFILE).unwrap();
+        p.model_ref = Some("old_ref".into());
+        std::fs::write(&path, serde_yaml_ng::to_string(&p).unwrap()).unwrap();
+        path
+    }
+
+    fn handle_with(
+        factory: crate::llm::fallback::ClientFactory,
+        profile_path: PathBuf,
+    ) -> ModelSetHandler {
+        ModelSetHandler::new(
+            Arc::new(ModelSwitchHandle {
+                switchable: SwitchableLlmClient::new(Arc::new(FixedClient { name: "boot" })),
+                build_client: factory,
+            }),
+            profile_path,
+        )
+    }
+
+    #[tokio::test]
+    async fn switches_persists_and_replies() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let profile_path = seed_profile(tmp.path());
+        let h = handle_with(
+            Box::new(|_ref| Ok(Arc::new(FixedClient { name: "switched" }) as _)),
+            profile_path.clone(),
+        );
+
+        let out = h
+            .handle(
+                Some(json!({"model_ref": "new_ref"})),
+                &RequestContext::none(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out["model_ref"], "new_ref");
+        assert_eq!(out["effective"], "next-turn");
+
+        let p: mur_common::agent::AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path).unwrap()).unwrap();
+        assert_eq!(p.model_ref.as_deref(), Some("new_ref"));
+    }
+
+    #[tokio::test]
+    async fn builder_failure_aborts_without_persisting_or_swapping() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let profile_path = seed_profile(tmp.path());
+        let h = handle_with(
+            Box::new(|r| anyhow::bail!("model_ref {r:?} not in registry")),
+            profile_path.clone(),
+        );
+
+        let err = h
+            .handle(Some(json!({"model_ref": "ghost"})), &RequestContext::none())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HandlerError::InvalidParams(_)));
+
+        let p: mur_common::agent::AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path).unwrap()).unwrap();
+        assert_eq!(p.model_ref.as_deref(), Some("old_ref"), "profile untouched");
+    }
+
+    #[tokio::test]
+    async fn missing_model_ref_param_is_invalid() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let h = handle_with(
+            Box::new(|_r| Ok(Arc::new(FixedClient { name: "x" }) as _)),
+            seed_profile(tmp.path()),
+        );
+        let err = h
+            .handle(Some(json!({})), &RequestContext::none())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HandlerError::InvalidParams(_)));
+    }
+}

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -385,25 +385,26 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     let hitl_timeout_secs = profile.inner.hitl.timeout_secs;
     let max_iterations = profile.inner.hitl.max_iterations;
     let max_tokens = profile.inner.hitl.max_tokens;
-    let (runner, llm_for_companion, mcp_pool) = crate::supervisor_runner::build_provider_runner(
-        force_echo,
-        &agent_home,
-        &profile,
-        egress_proxy,
-        runtime_skills.clone(),
-        skills_cfg.clone(),
-        &hook_chain,
-        &hook_ctx,
-        &hook_cancel,
-        Some(pending_approvals.clone()),
-        Some(sock_notif_tx.clone()),
-        hitl_timeout_secs,
-        max_iterations,
-        max_tokens,
-        Some(writer.sender()),
-        identity.clone(),
-    )
-    .await?;
+    let (runner, llm_for_companion, mcp_pool, model_switch) =
+        crate::supervisor_runner::build_provider_runner(
+            force_echo,
+            &agent_home,
+            &profile,
+            egress_proxy,
+            runtime_skills.clone(),
+            skills_cfg.clone(),
+            &hook_chain,
+            &hook_ctx,
+            &hook_cancel,
+            Some(pending_approvals.clone()),
+            Some(sock_notif_tx.clone()),
+            hitl_timeout_secs,
+            max_iterations,
+            max_tokens,
+            Some(writer.sender()),
+            identity.clone(),
+        )
+        .await?;
     let dispatcher = Arc::new(build_dispatcher(
         &profile_arc,
         &runner,
@@ -413,6 +414,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         &identity,
         &profile.inner.name,
         profile.inner.identity.key_version,
+        model_switch.map(|h| (h, agent_home.join("profile.yaml"))),
     ));
 
     // 7. Transports
@@ -873,6 +875,10 @@ fn build_dispatcher(
     identity: &Arc<AgentIdentity>,
     agent_name: &str,
     key_version: u32,
+    model_switch: Option<(
+        Arc<crate::llm::switchable::ModelSwitchHandle>,
+        std::path::PathBuf,
+    )>,
 ) -> Dispatcher {
     let mut d = Dispatcher::new();
     d.register("agent/card", Box::new(CardHandler::new(profile.clone())));
@@ -926,6 +932,18 @@ fn build_dispatcher(
             notifier,
         }),
     );
+    // murmur /model hot-switch. Only single-model agents get a handle;
+    // chain/routing and echo agents surface method-not-found and the TUI
+    // degrades to a profile write + restart hint.
+    if let Some((switch, profile_path)) = model_switch {
+        d.register(
+            "model/set",
+            Box::new(crate::protocol::methods::model_set::ModelSetHandler::new(
+                switch,
+                profile_path,
+            )),
+        );
+    }
     d
 }
 

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -221,9 +221,10 @@ pub async fn build_provider_runner(
     Arc<TaskRunner>,
     Option<Arc<dyn LlmClient>>,
     Option<Arc<McpPool>>,
+    Option<Arc<crate::llm::switchable::ModelSwitchHandle>>,
 )> {
     if force_echo {
-        return Ok((Arc::new(TaskRunner::new_stub_echo()), None, None));
+        return Ok((Arc::new(TaskRunner::new_stub_echo()), None, None, None));
     }
 
     let resolved = crate::supervisor::resolve_model_entry(&profile.inner);
@@ -427,7 +428,35 @@ pub async fn build_provider_runner(
         // FallbackLlmClient wrapper.
         return Ok(
             match crate::llm::client_builder::build_client_from_entry(&entry, profile, &mur_home) {
-                Ok(client) => build(client),
+                Ok(client) => {
+                    // Hot-switch seam (murmur /model): wrap the client so
+                    // `model/set` can replace it between turns, and hand the
+                    // dispatcher a per-ref builder that reuses the exact boot
+                    // construction path (fresh registry lookup + same profile).
+                    let switchable = crate::llm::switchable::SwitchableLlmClient::new(client);
+                    let profile_for_switch = profile.clone();
+                    let mur_home_for_switch = mur_home.clone();
+                    let build_client: crate::llm::fallback::ClientFactory =
+                        Box::new(move |model_ref: &str| {
+                            let reg = mur_common::model::ModelRegistry::load_from(
+                                &mur_common::model::ModelRegistry::default_path()?,
+                            )?;
+                            let entry = reg.models.get(model_ref).cloned().ok_or_else(|| {
+                                anyhow::anyhow!("model_ref {model_ref:?} not in registry")
+                            })?;
+                            crate::llm::client_builder::build_client_from_entry(
+                                &entry,
+                                &profile_for_switch,
+                                &mur_home_for_switch,
+                            )
+                        });
+                    let handle = Arc::new(crate::llm::switchable::ModelSwitchHandle {
+                        switchable: switchable.clone(),
+                        build_client,
+                    });
+                    let (r, c, p) = build(switchable as Arc<dyn LlmClient>);
+                    (r, c, p, Some(handle))
+                }
                 Err(e) => {
                     // A `guarded_http` build failure is a real error unrelated to
                     // provider support — pre-Task-7 this was a hard `?` straight
@@ -448,6 +477,7 @@ pub async fn build_provider_runner(
                                 Arc::new(TaskRunner::new_stub_echo()),
                                 None,
                                 Some(pool.clone()),
+                                None,
                             )
                         }
                         "openai" => {
@@ -456,6 +486,7 @@ pub async fn build_provider_runner(
                                 Arc::new(TaskRunner::new_stub_echo()),
                                 None,
                                 Some(pool.clone()),
+                                None,
                             )
                         }
                         "echo" => {
@@ -465,6 +496,7 @@ pub async fn build_provider_runner(
                                 Arc::new(TaskRunner::new_stub_echo()),
                                 None,
                                 Some(pool.clone()),
+                                None,
                             )
                         }
                         other => {
@@ -482,6 +514,7 @@ pub async fn build_provider_runner(
                                 Arc::new(TaskRunner::new_stub_misconfigured(msg)),
                                 None,
                                 Some(pool.clone()),
+                                None,
                             )
                         }
                     }
@@ -525,7 +558,8 @@ pub async fn build_provider_runner(
         }
         Arc::new(fb)
     };
-    Ok(build(fallback_client))
+    let (r, c, p) = build(fallback_client);
+    Ok((r, c, p, None))
 }
 
 /// Telemetry writer + notification routing + hook chain + skills loaded once at boot.

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -186,6 +186,8 @@ pub enum SlashCmd {
     Panel(Vec<String>),
     /// `/open` — what is still outstanding, observed and reported kept apart.
     Open,
+    /// `/model [N|name]` — list registry models, or hot-switch to one.
+    Model(Option<String>),
     Quit,
     Unknown(String),
 }
@@ -208,6 +210,7 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
                 follow: args.iter().any(|s| *s == "--follow" || *s == "-f"),
             }
         }
+        "model" => SlashCmd::Model(words.next().map(str::to_string)),
         "auto" => SlashCmd::Auto(match words.next() {
             Some("on") => Some(true),
             Some("off") => Some(false),
@@ -1794,6 +1797,19 @@ mod tests {
         a.start_new_session(s);
         assert!(a.context_task_id.is_none());
         assert_eq!(a.messages.last().unwrap().role, Role::System);
+    }
+
+    #[test]
+    fn parse_slash_model() {
+        assert_eq!(parse_slash("/model"), Some(SlashCmd::Model(None)));
+        assert_eq!(
+            parse_slash("/model 2"),
+            Some(SlashCmd::Model(Some("2".into())))
+        );
+        assert_eq!(
+            parse_slash("/model claude_opus"),
+            Some(SlashCmd::Model(Some("claude_opus".into())))
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/complete.rs
+++ b/mur-core/src/cmd/agent/cli/complete.rs
@@ -58,6 +58,7 @@ const COMMANDS: &[(&str, &str, &[&str])] = &[
             "registry-add",
         ],
     ),
+    ("model", "list or hot-switch the model", &[]),
     (
         "panel",
         "companion window (MUR Hub)",

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -18,6 +18,7 @@ mod footer;
 mod manage;
 mod markdown;
 mod memory_cmds;
+mod model_cmd;
 mod multiplex;
 mod panel;
 mod paste;
@@ -161,7 +162,7 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /open (outstanding items)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /open (outstanding items)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /model [N|name] (list/switch model)  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 #[allow(clippy::too_many_arguments)]
@@ -1822,6 +1823,60 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                 app.push_system("verbose OFF — tool cards collapse to a one-line summary");
             }
         }
+        SlashCmd::Model(arg) => {
+            let reg = mur_common::model::ModelRegistry::default_path()
+                .and_then(|p| mur_common::model::ModelRegistry::load_from(&p));
+            let reg = match reg {
+                Ok(r) => r,
+                Err(e) => {
+                    app.push_system(format!("model registry unavailable: {e:#}"));
+                    return;
+                }
+            };
+            let models = model_cmd::ordered_models(&reg);
+            match arg {
+                None => {
+                    let cur = model_cmd::current_model_ref(&app.home, &app.agent);
+                    app.push_system(model_cmd::render_list(&models, cur.as_deref()));
+                }
+                Some(a) => {
+                    let Some(target) = model_cmd::resolve_pick(&models, &a) else {
+                        app.push_system(format!("no such model: {a} — /model to list"));
+                        return;
+                    };
+                    let (h, ag, mref) = (app.home.clone(), app.agent.clone(), target.clone());
+                    let res = tokio::task::spawn_blocking(move || {
+                        dial_method(
+                            &h,
+                            &ag,
+                            "model/set",
+                            serde_json::json!({ "model_ref": mref }),
+                            DialMode::Auto,
+                        )
+                    })
+                    .await;
+                    match res {
+                        Ok(Ok(_)) => app.push_system(format!(
+                            "model → {target} (effective next turn; saved to profile)"
+                        )),
+                        // Runtime without model/set, or agent not running: save
+                        // the pick anyway so the operator's intent lands — a
+                        // restart applies it.
+                        Ok(Err(e)) => {
+                            match model_cmd::write_model_ref(&app.home, &app.agent, &target) {
+                                Ok(()) => app.push_system(format!(
+                                    "couldn't hot-switch ({e:#}); saved {target} to profile — restart the agent to apply"
+                                )),
+                                Err(w) => app.push_system(format!(
+                                    "model switch failed: {e:#}; profile write also failed: {w:#}"
+                                )),
+                            }
+                        }
+                        Err(e) => app.push_system(format!("model task failed: {e}")),
+                    }
+                }
+            }
+        }
         SlashCmd::Mcp(args) => run_manage(app, move |agent| manage::run_mcp(&agent, &args)).await,
         SlashCmd::Skill(args) => {
             run_manage(app, move |agent| manage::run_skill(&agent, &args)).await
@@ -2603,7 +2658,7 @@ mod help_coverage_tests {
     /// command that does not exist; `/help` then has to mention all of them.
     const COMMANDS: &[&str] = &[
         "help", "clear", "card", "sessions", "channels", "open", "auto", "verbose", "skin", "mcp",
-        "skill", "remember", "memories", "forget", "panel", "exit",
+        "skill", "model", "remember", "memories", "forget", "panel", "exit",
     ];
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/model_cmd.rs
+++ b/mur-core/src/cmd/agent/cli/model_cmd.rs
@@ -1,0 +1,190 @@
+//! `/model` — list registry models and hot-switch the agent's model.
+//!
+//! Listing is a pure read (provider groups, current model marked, per-1k
+//! rates when priced). Switching dials A2A `model/set`; when the dial fails
+//! (a runtime predating the method, or the agent not running) the pick is
+//! still saved to `profile.yaml` with a restart hint, so the operator's
+//! intent always lands and disk never trails what they asked for.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mur_common::agent::AgentProfile;
+use mur_common::model::{ModelEntry, ModelRegistry};
+
+/// Registry entries in display order: provider groups, aliases sorted inside.
+/// The same ordering backs both list numbering and number resolution, so
+/// `/model 2` picks exactly what the last `/model` printed.
+pub(crate) fn ordered_models(reg: &ModelRegistry) -> Vec<(String, ModelEntry)> {
+    let mut v: Vec<(String, ModelEntry)> = reg
+        .models
+        .iter()
+        .map(|(k, e)| (k.clone(), e.clone()))
+        .collect();
+    v.sort_by(|a, b| {
+        (a.1.provider.as_str(), a.0.as_str()).cmp(&(b.1.provider.as_str(), b.0.as_str()))
+    });
+    v
+}
+
+pub(crate) fn render_list(models: &[(String, ModelEntry)], current: Option<&str>) -> String {
+    if models.is_empty() {
+        return "no models in ~/.mur/models.yaml — add one with `mur model add`".to_string();
+    }
+    let mut out = String::new();
+    let mut last_provider = "";
+    for (i, (alias, entry)) in models.iter().enumerate() {
+        if entry.provider != last_provider {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&format!("{}:\n", entry.provider));
+            last_provider = &entry.provider;
+        }
+        let marker = if Some(alias.as_str()) == current {
+            "●"
+        } else {
+            " "
+        };
+        let (input, output) = entry.effective_costs();
+        let price = match (input, output) {
+            (Some(i), Some(o)) => format!("  in ${i}/1k · out ${o}/1k"),
+            _ => String::new(),
+        };
+        out.push_str(&format!(
+            "{marker} {:>2}. {alias}  {}{price}\n",
+            i + 1,
+            entry.model
+        ));
+    }
+    out.push_str("\nswitch: /model <number|name>");
+    out
+}
+
+/// Resolve `/model <arg>`: 1-based number from the printed list, exact alias,
+/// or case-insensitive alias (same convention as agent names).
+pub(crate) fn resolve_pick(models: &[(String, ModelEntry)], arg: &str) -> Option<String> {
+    if let Ok(n) = arg.parse::<usize>() {
+        return models.get(n.checked_sub(1)?).map(|(a, _)| a.clone());
+    }
+    if models.iter().any(|(a, _)| a == arg) {
+        return Some(arg.to_string());
+    }
+    models
+        .iter()
+        .find(|(a, _)| a.eq_ignore_ascii_case(arg))
+        .map(|(a, _)| a.clone())
+}
+
+fn profile_path(home: &Path, agent: &str) -> std::path::PathBuf {
+    home.join("agents").join(agent).join("profile.yaml")
+}
+
+/// Current `model_ref` from the agent's profile (best-effort).
+pub(crate) fn current_model_ref(home: &Path, agent: &str) -> Option<String> {
+    let yaml = std::fs::read_to_string(profile_path(home, agent)).ok()?;
+    serde_yaml_ng::from_str::<AgentProfile>(&yaml)
+        .ok()?
+        .model_ref
+}
+
+/// Fallback persistence when the dial can't reach a `model/set`-capable
+/// runtime: typed round-trip + temp/rename, mirroring the runtime handler.
+pub(crate) fn write_model_ref(home: &Path, agent: &str, model_ref: &str) -> Result<()> {
+    let path = profile_path(home, agent);
+    let yaml =
+        std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut p: AgentProfile = serde_yaml_ng::from_str(&yaml).context("parse profile.yaml")?;
+    p.model_ref = Some(model_ref.to_string());
+    p.updated_at = chrono::Utc::now().to_rfc3339();
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, serde_yaml_ng::to_string(&p)?.as_bytes())?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg(entries: &[(&str, &str, &str)]) -> ModelRegistry {
+        let mut reg = ModelRegistry::default();
+        for (alias, provider, model) in entries {
+            reg.models.insert(
+                alias.to_string(),
+                ModelEntry {
+                    provider: provider.to_string(),
+                    model: model.to_string(),
+                    ..Default::default()
+                },
+            );
+        }
+        reg
+    }
+
+    #[test]
+    fn ordering_groups_by_provider_then_alias() {
+        let reg = reg(&[
+            ("zeta", "openai", "z"),
+            ("claude_opus", "anthropic", "claude-opus-5"),
+            ("alpha", "openai", "a"),
+        ]);
+        let names: Vec<String> = ordered_models(&reg).into_iter().map(|(a, _)| a).collect();
+        assert_eq!(names, vec!["claude_opus", "alpha", "zeta"]);
+    }
+
+    #[test]
+    fn render_marks_current_and_numbers_globally() {
+        let reg = reg(&[
+            ("claude_opus", "anthropic", "claude-opus-5"),
+            ("dsv4", "openai", "deepseek-v4"),
+        ]);
+        let out = render_list(&ordered_models(&reg), Some("dsv4"));
+        assert!(out.contains("anthropic:"), "{out}");
+        assert!(out.contains("openai:"), "{out}");
+        assert!(out.contains("  1. claude_opus"), "{out}");
+        assert!(out.contains("●  2. dsv4"), "{out}");
+        assert!(out.contains("switch: /model"), "{out}");
+    }
+
+    #[test]
+    fn resolve_by_number_name_and_case() {
+        let reg = reg(&[
+            ("claude_opus", "anthropic", "claude-opus-5"),
+            ("dsv4", "openai", "deepseek-v4"),
+        ]);
+        let models = ordered_models(&reg);
+        assert_eq!(resolve_pick(&models, "2").as_deref(), Some("dsv4"));
+        assert_eq!(
+            resolve_pick(&models, "claude_opus").as_deref(),
+            Some("claude_opus")
+        );
+        assert_eq!(
+            resolve_pick(&models, "Claude_Opus").as_deref(),
+            Some("claude_opus")
+        );
+        assert_eq!(resolve_pick(&models, "0"), None);
+        assert_eq!(resolve_pick(&models, "3"), None);
+        assert_eq!(resolve_pick(&models, "ghost"), None);
+    }
+
+    #[test]
+    fn write_and_read_model_ref_round_trip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let adir = home.join("agents").join("t");
+        std::fs::create_dir_all(&adir).unwrap();
+        const MINIMAL: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../mur-common/tests/fixtures/profile_p0a_minimal.yaml"
+        ));
+        std::fs::write(adir.join("profile.yaml"), MINIMAL).unwrap();
+
+        assert_eq!(current_model_ref(home, "t"), None);
+        write_model_ref(home, "t", "claude_opus").unwrap();
+        assert_eq!(current_model_ref(home, "t").as_deref(), Some("claude_opus"));
+        // Legacy `model:` block survives the rewrite (live read path).
+        let text = std::fs::read_to_string(adir.join("profile.yaml")).unwrap();
+        assert!(text.contains("provider: ollama"), "{text}");
+    }
+}


### PR DESCRIPTION
## What

Pi-style in-session model switching for murmur, per the approved spec (`docs/superpowers/specs/2026-08-17-murmur-model-slash-command-design.md`):

- **`/model`** — numbered list of `~/.mur/models.yaml` entries, grouped by provider, current model marked `●` (read from `profile.yaml`), per-1k rates when priced. Pure read; cancelling leaves no state.
- **`/model <n|name>`** — switch by list number or registry alias (case-insensitive). The agent uses the new model from the next turn, no restart.

## How

- New A2A method **`model/set`**: validates the ref via a builder closure on the exact boot construction path (fresh registry lookup + `build_client_from_entry`), persists `model_ref` to `profile.yaml` (typed round-trip + temp/rename, `updated_at` bumped, legacy `model:` block preserved), then swaps a new **`SwitchableLlmClient`** slot. Strict **build → persist → swap** — any failure aborts with the old client and old profile intact, so disk and process can never disagree.
- `SwitchableLlmClient` wraps the boot client behind `RwLock<Arc<dyn LlmClient>>` (lock held only to clone, never across await). In-flight turns finish on the old client. `model_name()` keeps the boot label — same precedent as `FallbackLlmClient`.
- **v1 scope:** only single-model agents register `model/set`. Chain/routing and echo agents surface method-not-found, and the TUI degrades to a profile write + restart hint (same fallback when the agent isn't running or predates the method) — the operator's intent always lands.
- Completion menu, `/help` text, and the help-coverage test updated.

## Verification

- `cargo check --all-targets` on mur-core and mur-agent-runtime ✓
- mur-core: 18/18 (`model_cmd`, `parse_slash*` incl. new `/model` forms, `help_coverage`) ✓
- mur-agent-runtime: 5/5 (`switchable` swap semantics + in-flight isolation; `model_set` switch-persist-reply, builder-failure abort leaves profile untouched, missing-param rejection) ✓
- `cargo clippy --all-targets -- -D warnings` both crates ✓ · `cargo fmt --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)