### PR TITLE
docs(readme): list connect/import in the model command tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,8 @@ mur
 ├── sync         (16+ AI tools) · status · fleet pull/push/both
 ├── hook         unified hook entry for AI tools (prompt / tool / stop / session-start)
 ├── chat         conversations archive + ask
-├── model        add · list · show · remove · doctor · prices · role · route · default · fallback · migrate
+├── model        connect · import · add · list · show · remove · doctor · prices · role · route ·
+│                default · fallback · migrate   (connect = one key, many models)
 ├── source       external knowledge — Obsidian · Notion · Joplin
 ├── project      index · search   (semantic code search)
 ├── daemon       start · stop · restart · status · serve · sleep


### PR DESCRIPTION
The "Models & providers" section already leads with `mur model connect` after #952, but the `Full command tree` block still showed the pre-connect subcommand list for `model`.

Top-level command count is unchanged (28) — `connect` and `import` are subcommands.

`mur verify --file README.md` → 0 invalid claims.

Docs site and product page are covered by a companion PR in `mur-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)