### PR TITLE
fix(hub): write the wire protocol, not the vendor name, into models.yaml

### DIFF
--- a/mur-core/src/cmd/model_connect.rs
+++ b/mur-core/src/cmd/model_connect.rs
@@ -12,7 +12,7 @@ use mur_common::model::{ModelEntry, ModelRegistry};
 use mur_common::route::RouteTier;
 use mur_common::secret::SecretRef;
 
-use crate::model_discovery::{self, default_alias};
+use crate::model_discovery::{self, default_alias, wire_protocol_for};
 use crate::model_prices;
 
 /// Keychain service shared with the Hub Model Library — a key stored by
@@ -58,8 +58,10 @@ pub(crate) fn plan_connect(
     base_url: Option<String>,
     catalog_has_vendor: bool,
 ) -> Result<ConnectPlan> {
-    let native = vendor == "anthropic" || vendor == "openai";
-    if native {
+    // "Native" means the runtime has a client for this vendor by name, so the
+    // entry can carry the vendor in `provider:` and omit the endpoint.
+    let protocol = wire_protocol_for(vendor);
+    if protocol == vendor {
         return Ok(ConnectPlan {
             provider: vendor.to_string(),
             vendor: vendor.to_string(),
@@ -74,7 +76,7 @@ pub(crate) fn plan_connect(
         );
     };
     Ok(ConnectPlan {
-        provider: "openai".to_string(),
+        provider: protocol.to_string(),
         vendor: vendor.to_string(),
         base_url: Some(base),
         list: if catalog_has_vendor {
@@ -352,11 +354,7 @@ pub async fn cmd_connect(
             let picked = pick_from(&d.models, all, pick.clone())?;
             // Ollama has a native client; other local runtimes speak the
             // openai protocol. Local tier prices as zero.
-            let provider = if d.key == "ollama" {
-                "ollama"
-            } else {
-                "openai"
-            };
+            let provider = wire_protocol_for(&d.key);
             let (added, skipped) = add_entries(
                 &mut reg,
                 &mur_home,

--- a/mur-core/src/model_discovery.rs
+++ b/mur-core/src/model_discovery.rs
@@ -69,6 +69,29 @@ fn models_url(base_url: &str) -> String {
 
 /// Registry provider key whose API authenticates the non-OpenAI way.
 pub const ANTHROPIC_PROVIDER: &str = "anthropic";
+
+/// The wire protocol the runtime dials to reach `vendor` — which is not the
+/// same thing as the vendor's name.
+///
+/// `models.yaml`'s `provider:` field selects a client implementation, and the
+/// runtime ships exactly four: `local`, `ollama`, `anthropic`, `openai`
+/// (see `client_builder::build_client_from_entry`). Every other vendor —
+/// DeepSeek, Groq, Mistral, xAI, OpenRouter, Google, LM Studio, MLX — is
+/// reached over the OpenAI protocol at its own `base_url`. Writing the vendor
+/// name into `provider:` instead produces an entry the runtime cannot build a
+/// client for, and the agent then answers every message with a
+/// misconfiguration notice.
+///
+/// Keep the vendor name for anything that identifies WHO makes the model
+/// (catalog pricing, alias prefixes); use this for how MUR dials it.
+pub fn wire_protocol_for(vendor: &str) -> &'static str {
+    match vendor {
+        "anthropic" => "anthropic",
+        "ollama" => "ollama",
+        "local" => "local",
+        _ => "openai",
+    }
+}
 /// Anthropic requires a dated API version on every request. Pinned, not
 /// configurable: it selects a wire contract, so it moves with the code that
 /// parses the response, never with user config.
@@ -377,6 +400,29 @@ mod tests {
             }
         });
         format!("http://127.0.0.1:{port}/v1")
+    }
+
+    #[test]
+    fn wire_protocol_maps_vendors_to_the_four_clients_the_runtime_ships() {
+        // Native protocols keep their own client.
+        assert_eq!(wire_protocol_for("anthropic"), "anthropic");
+        assert_eq!(wire_protocol_for("openai"), "openai");
+        assert_eq!(wire_protocol_for("ollama"), "ollama");
+        assert_eq!(wire_protocol_for("local"), "local");
+        // Everything else is OpenAI-protocol-at-its-own-base-url. Writing the
+        // vendor name here is what made Hub-added entries unusable.
+        for vendor in [
+            "deepseek",
+            "groq",
+            "mistral",
+            "xai",
+            "openrouter",
+            "google",
+            "mlx",
+            "lmstudio",
+        ] {
+            assert_eq!(wire_protocol_for(vendor), "openai", "vendor {vendor}");
+        }
     }
 
     const CATALOG_FIXTURE: &str = r#"{

--- a/mur-hub-gui/src-tauri/src/models_admin.rs
+++ b/mur-hub-gui/src-tauri/src/models_admin.rs
@@ -6,7 +6,7 @@
 use mur_common::model::{ModelEntry, ModelRegistry};
 use mur_common::route::RouteTier;
 use mur_common::secret::SecretRef;
-use mur_core::model_discovery::{self, default_alias};
+use mur_core::model_discovery::{self, default_alias, wire_protocol_for};
 use mur_core::model_prices::{self, PriceInfo};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
@@ -233,6 +233,34 @@ pub async fn test_provider(
         .collect())
 }
 
+/// Resolve what an entry must carry to be dialable: the wire protocol for
+/// `provider:` and the endpoint for `base_url:`.
+///
+/// The UI names a **vendor** (its preset key: `deepseek`, `groq`, `google`,
+/// `mlx`, …), but `provider:` selects one of the four clients the runtime
+/// ships. Writing the vendor there yields an entry the runtime cannot build,
+/// and the agent answers every message with a misconfiguration notice — so
+/// the vendor is mapped through [`wire_protocol_for`] here, exactly as
+/// `mur model connect` does, and kept only for catalog pricing.
+///
+/// A vendor that maps onto the OpenAI protocol without an endpoint is
+/// rejected rather than written: `provider: openai` with no `base_url` dials
+/// api.openai.com, so a DeepSeek key would be sent to OpenAI and fail with an
+/// error naming the wrong service.
+pub fn resolve_wire_target(
+    vendor: &str,
+    base_url: Option<String>,
+) -> Result<(&'static str, Option<String>), String> {
+    let protocol = wire_protocol_for(vendor);
+    let base = base_url.filter(|u| !u.trim().is_empty());
+    if protocol == "openai" && vendor != "openai" && base.is_none() {
+        return Err(format!(
+            "{vendor} is reached over the OpenAI protocol, so it needs a base URL —              without one the request would go to api.openai.com"
+        ));
+    }
+    Ok((protocol, base))
+}
+
 #[tauri::command]
 pub fn add_models(
     provider: String,
@@ -258,10 +286,14 @@ pub fn add_models(
     let resolved_base_url = base_url
         .clone()
         .or_else(|| provider_base_url(&reg, &provider));
+    // `provider` from the UI is a vendor; the registry field is a protocol.
+    let (wire, resolved_base_url) = resolve_wire_target(&provider, resolved_base_url)?;
     for pick in picks {
+        // Pricing still keys off the VENDOR — models.dev files DeepSeek under
+        // `deepseek`, and knows nothing about the protocol used to reach it.
         let price = model_prices::lookup(&home, &provider, &pick.model, is_local);
         let entry = ModelEntry {
-            provider: provider.clone(),
+            provider: wire.to_string(),
             model: pick.model.clone(),
             base_url: resolved_base_url.clone(),
             secret: secret.clone(),
@@ -351,6 +383,51 @@ mod tests {
         assert_eq!(v.input_cost, Some(0.00125));
         assert_eq!(v.output_cost, Some(0.01));
         assert_eq!(v.context_window, Some(400_000));
+    }
+
+    #[test]
+    fn vendor_presets_are_written_as_the_protocol_the_runtime_can_dial() {
+        // Native: vendor name IS the client name, endpoint optional.
+        assert_eq!(
+            resolve_wire_target("anthropic", None).unwrap(),
+            ("anthropic", None)
+        );
+        assert_eq!(
+            resolve_wire_target("openai", None).unwrap(),
+            ("openai", None)
+        );
+        // Every other Model Library preset is OpenAI-protocol. Writing the
+        // vendor here produced entries the runtime refuses to build a client
+        // for, so the agent replied with a misconfiguration notice instead of
+        // answering.
+        for vendor in ["deepseek", "groq", "mistral", "xai", "openrouter", "google"] {
+            let (protocol, base) =
+                resolve_wire_target(vendor, Some(format!("https://api.{vendor}.test/v1"))).unwrap();
+            assert_eq!(protocol, "openai", "vendor {vendor}");
+            assert!(base.is_some(), "vendor {vendor} must keep its endpoint");
+        }
+        // Local runtimes: only Ollama has its own client.
+        assert_eq!(
+            resolve_wire_target("ollama", Some("http://localhost:11434/v1".into()))
+                .unwrap()
+                .0,
+            "ollama"
+        );
+        assert_eq!(
+            resolve_wire_target("mlx", Some("http://127.0.0.1:8000/v1".into()))
+                .unwrap()
+                .0,
+            "openai"
+        );
+    }
+
+    #[test]
+    fn openai_protocol_vendor_without_an_endpoint_is_refused() {
+        // Would otherwise send a DeepSeek key to api.openai.com.
+        let err = resolve_wire_target("deepseek", None).unwrap_err();
+        assert!(err.contains("base URL"), "{err}");
+        // Blank counts as absent.
+        assert!(resolve_wire_target("groq", Some("   ".into())).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## The bug

The Model Library passes its preset key through to `add_models` as `provider`, and `add_models` writes it verbatim into `models.yaml`. So picking **DeepSeek** in the Hub produces:

```yaml
deepseek_deepseek_chat:
  provider: deepseek        # ← a vendor name
  base_url: https://api.deepseek.com/v1
```

But `provider:` selects a *client implementation*, and the runtime ships exactly four (`client_builder.rs`):

```rust
"local" => …, "ollama" => …, "anthropic" => …, "openai" => …,
other => Err(anyhow!("unsupported model provider {other:?}")),
```

`supervisor_runner` turns that `Err` into `TaskRunner::new_stub_misconfigured`, so the agent answers **every message** with a misconfiguration warning instead of working.

That affects six of the eight cloud presets — `google`, `openrouter`, `xai`, `mistral`, `deepseek`, `groq` — plus the `mlx` and `lmstudio` local runtimes. Only `anthropic`, `openai` and `ollama` happen to be both a vendor name and a client name, which is why this went unnoticed.

## The fix

Vendors map through a new `mur_core::model_discovery::wire_protocol_for`, which `mur model connect` now also uses — the CLI already had this logic inline, and having the same policy in two places was going to drift. Anthropic / Ollama / local keep their own client; everything else is the OpenAI protocol dialed at its own `base_url`.

The vendor name is still what **pricing** looks up: models.dev files DeepSeek under `deepseek` and knows nothing about the protocol used to reach it. Vendor = who makes it; provider = how MUR dials it.

`resolve_wire_target` also refuses an OpenAI-protocol vendor with no endpoint instead of writing it — `provider: openai` with no `base_url` dials api.openai.com, so a DeepSeek key would be sent to OpenAI and fail with an error naming the wrong service. The UI always supplies a preset endpoint, so this is a backstop, and it surfaces through the panel's existing error path.

## Not fixed here

The Library groups connected providers by the stored `provider:` field, so all OpenAI-protocol vendors appear under one **OpenAI** heading. That is pre-existing — a registry with DeepSeek and MLX entries added by the CLI already displays them as "OpenAI 3" — and this change routes more entries into that group. Recovering the vendor for display means recording it on the entry (an additive `ModelEntry` field), which is its own change.

Existing `provider: <vendor>` entries are not rewritten. They are broken today and stay broken; `mur model doctor` is the read-only surface that reports registry inconsistency, and rewriting a model binding silently is exactly what that command is documented never to do.

## Verification

- `wire_protocol_for` unit test pins all four native names and eight non-native vendors.
- Hub: `vendor_presets_are_written_as_the_protocol_the_runtime_can_dial` covers the six cloud presets plus ollama/mlx; `openai_protocol_vendor_without_an_endpoint_is_refused` covers the backstop (including a blank string).
- `cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml --lib models_admin` → 12 passed.
- `cargo nextest run -p mur-core -E 'test(/model_connect|wire_protocol/)'` → 12 passed.
- `cargo clippy -p mur-core --all-targets -- -D warnings` ✓ · Hub clippy with CI's exact args (`--lib`) ✓ · `cargo fmt --check` both manifests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)