### PR TITLE
feat(model): record the vendor on registry entries

### DIFF
--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -22,6 +22,19 @@ use std::path::{Path, PathBuf};
 pub struct ModelEntry {
     #[serde(default)]
     pub provider: String,
+    /// Who makes this model — the models.dev catalog vendor (`deepseek`,
+    /// `groq`, `mistral`, …).
+    ///
+    /// Distinct from `provider`, which is the wire protocol MUR dials: a
+    /// DeepSeek entry is `provider: openai` + `vendor: deepseek`, because the
+    /// runtime reaches it over the OpenAI protocol while the catalog files it
+    /// under DeepSeek. Only recorded when the two differ — for Anthropic,
+    /// OpenAI and Ollama the protocol already names the vendor.
+    ///
+    /// `None` on entries written before this field existed; readers should go
+    /// through [`ModelEntry::vendor_candidates`] rather than reading it raw.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
     #[serde(default)]
     pub model: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61,6 +74,23 @@ pub struct ModelEntry {
     pub priced_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Vendor label implied by an endpoint host: `https://api.deepseek.com/v1` →
+/// `deepseek`. Best-effort — a host that does not carry the vendor's name
+/// (Google's `generativelanguage.googleapis.com`) yields the wrong label,
+/// which is why `vendor` is recorded explicitly on new entries.
+fn vendor_label_of_url(base_url: Option<&str>) -> Option<String> {
+    let host = base_url?
+        .split("//")
+        .nth(1)
+        .unwrap_or(base_url?)
+        .split(['/', ':'])
+        .next()
+        .unwrap_or("");
+    let label = host.strip_prefix("api.").unwrap_or(host);
+    let first = label.split('.').next().unwrap_or("");
+    (!first.is_empty()).then(|| first.to_string())
+}
+
 impl ModelEntry {
     /// Resolve effective per-1k rates as `(input, output)`.
     ///
@@ -70,6 +100,33 @@ impl ModelEntry {
         let output = self.output_cost_per_1k.or(self.cost_per_1k_tokens);
         let input = self.input_cost_per_1k.or(self.cost_per_1k_tokens);
         (input, output)
+    }
+
+    /// Catalog vendor names to try for this entry, most specific first.
+    ///
+    /// The recorded `vendor` wins. Failing that — legacy entries, or anything
+    /// written by hand — the host of `base_url` is tried
+    /// (`https://api.deepseek.com` → `deepseek`), then `provider`, which names
+    /// the vendor only when the vendor happens to have its own client.
+    ///
+    /// Every caller that asks an external catalog about an entry must go
+    /// through this. Asking with `provider` alone reports every
+    /// OpenAI-compatible third party as unknown.
+    pub fn vendor_candidates(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::with_capacity(3);
+        let mut push = |v: &str| {
+            if !v.is_empty() && !out.iter().any(|e| e == v) {
+                out.push(v.to_string());
+            }
+        };
+        if let Some(v) = self.vendor.as_deref() {
+            push(v);
+        }
+        if let Some(label) = vendor_label_of_url(self.base_url.as_deref()) {
+            push(&label);
+        }
+        push(&self.provider);
+        out
     }
 
     /// Whether this entry carries any rate at all.
@@ -255,6 +312,63 @@ pub fn pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>) -> Option<St
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn vendor_candidates_prefer_the_recorded_vendor_then_the_host_then_provider() {
+        // Recorded vendor wins — this is what new entries carry.
+        let e = ModelEntry {
+            provider: "openai".into(),
+            vendor: Some("deepseek".into()),
+            base_url: Some("https://api.deepseek.com/v1".into()),
+            ..Default::default()
+        };
+        assert_eq!(e.vendor_candidates(), vec!["deepseek", "openai"]);
+
+        // Legacy entry with no vendor: the endpoint host still identifies it,
+        // which is how registries written before the field keep working.
+        let legacy = ModelEntry {
+            provider: "openai".into(),
+            base_url: Some("https://api.deepseek.com/v1".into()),
+            ..Default::default()
+        };
+        assert_eq!(legacy.vendor_candidates(), vec!["deepseek", "openai"]);
+
+        // Nothing to infer: provider is all there is.
+        let bare = ModelEntry {
+            provider: "anthropic".into(),
+            ..Default::default()
+        };
+        assert_eq!(bare.vendor_candidates(), vec!["anthropic"]);
+
+        // No duplicate when host and provider agree.
+        let same = ModelEntry {
+            provider: "openai".into(),
+            base_url: Some("https://api.openai.com/v1".into()),
+            ..Default::default()
+        };
+        assert_eq!(same.vendor_candidates(), vec!["openai"]);
+    }
+
+    #[test]
+    fn vendor_is_omitted_from_yaml_when_absent_and_round_trips_when_set() {
+        let bare = ModelEntry {
+            provider: "anthropic".into(),
+            model: "claude-opus-5".into(),
+            ..Default::default()
+        };
+        let y = serde_yaml_ng::to_string(&bare).unwrap();
+        assert!(!y.contains("vendor"), "{y}");
+
+        let tagged = ModelEntry {
+            provider: "openai".into(),
+            vendor: Some("groq".into()),
+            model: "llama-3.3".into(),
+            ..Default::default()
+        };
+        let y = serde_yaml_ng::to_string(&tagged).unwrap();
+        let back: ModelEntry = serde_yaml_ng::from_str(&y).unwrap();
+        assert_eq!(back.vendor.as_deref(), Some("groq"));
+    }
     use super::*;
 
     #[test]
@@ -305,6 +419,7 @@ models:
                 output_cost_per_1k: None,
                 context_window: None,
                 priced_at: None,
+                ..Default::default()
             },
         );
         let s = serde_yaml_ng::to_string(&r).unwrap();
@@ -365,6 +480,7 @@ roles:
                 output_cost_per_1k: None,
                 context_window: None,
                 priced_at: None,
+                ..Default::default()
             },
         );
         reg.roles.insert(
@@ -396,6 +512,7 @@ roles:
                 output_cost_per_1k: None,
                 context_window: None,
                 priced_at: None,
+                ..Default::default()
             },
         );
         reg.roles.insert(
@@ -451,6 +568,7 @@ models:
                 output_cost_per_1k: None,
                 context_window: None,
                 priced_at: None,
+                ..Default::default()
             },
         );
         let yaml = serde_yaml_ng::to_string(&r2).unwrap();
@@ -596,6 +714,7 @@ mod io_tests {
                 output_cost_per_1k: None,
                 context_window: None,
                 priced_at: None,
+                ..Default::default()
             },
         );
         r.save_to(&p).unwrap();

--- a/mur-core/src/cmd/model.rs
+++ b/mur-core/src/cmd/model.rs
@@ -420,7 +420,10 @@ fn cmd_prices(
                 .get(&name)
                 .ok_or_else(|| anyhow::anyhow!("not found in registry: {name}"))?;
             let is_local = matches!(entry.tier, Some(RouteTier::Local));
-            match model_prices::lookup(mur_home, &entry.provider, &entry.model, is_local) {
+            // Ask under every vendor the entry implies — `provider` alone is a
+            // protocol, so a DeepSeek entry (`provider: openai`) would report
+            // "no pricing" while the catalog has it under `deepseek`.
+            match model_prices::lookup_entry(mur_home, entry, is_local) {
                 Some(p) => {
                     println!("Pricing for {name} ({}/{}):", entry.provider, entry.model);
                     println!("  input:   ${}/1k tokens", p.input_per_1k);

--- a/mur-core/src/cmd/model_connect.rs
+++ b/mur-core/src/cmd/model_connect.rs
@@ -250,6 +250,9 @@ fn add_entries(
         }
         let entry = ModelEntry {
             provider: provider.to_string(),
+            // Only when it adds information: for anthropic/openai/ollama the
+            // protocol already names the vendor.
+            vendor: (vendor != provider).then(|| vendor.to_string()),
             model: model_id.clone(),
             base_url: base_url.map(str::to_string),
             secret: secret.cloned(),

--- a/mur-core/src/cmd/model_doctor.rs
+++ b/mur-core/src/cmd/model_doctor.rs
@@ -21,8 +21,9 @@
 //! a typo, a copied-wrong id, or a `provider:` field used as a vendor name when
 //! it is really a protocol dialect. That last one is common — `deepseek` is
 //! reached over the OpenAI wire protocol, so its registry entry reads
-//! `provider: openai` while the catalog files it under vendor `deepseek`. The
-//! vendor is therefore inferred from `base_url` before falling back to
+//! `provider: openai` while the catalog files it under vendor `deepseek`. New
+//! entries record the vendor explicitly; for older ones it is inferred from
+//! `base_url` before falling back to
 //! `provider`, or every openai-compatible third party would be flagged.
 
 use std::path::Path;
@@ -35,25 +36,6 @@ use mur_common::model::ModelRegistry;
 /// answers "has this id ever existed" correctly for anything but the newest
 /// releases.
 const CATALOG_TTL_HOURS: u64 = 24 * 30;
-
-/// Catalog vendor names to try for a registry entry, most specific first.
-///
-/// `provider` is a protocol dialect as often as it is a vendor, so the host of
-/// `base_url` is tried too: `https://api.deepseek.com` → `deepseek`. Both are
-/// offered to the catalog and a hit on either clears the entry.
-fn vendor_candidates(provider: &str, base_url: Option<&str>) -> Vec<String> {
-    let mut out = vec![provider.to_string()];
-    if let Some(host) = host_of(base_url) {
-        let label = host.strip_prefix("api.").unwrap_or(&host);
-        if let Some(first) = label.split('.').next()
-            && !first.is_empty()
-            && !out.iter().any(|v| v == first)
-        {
-            out.push(first.to_string());
-        }
-    }
-    out
-}
 
 fn host_of(base_url: Option<&str>) -> Option<String> {
     let u = base_url?;
@@ -143,7 +125,7 @@ pub fn audit(
             if is_local_endpoint(e.base_url.as_deref()) {
                 continue;
             }
-            let vendors = vendor_candidates(&e.provider, e.base_url.as_deref());
+            let vendors = e.vendor_candidates();
             if vendors.iter().any(|v| knows(v, &e.model)) {
                 continue;
             }
@@ -332,20 +314,6 @@ mod tests {
         // The real catalog shape: filed under `deepseek`, absent from `openai`.
         let knows = |v: &str, m: &str| v == "deepseek" && m == "deepseek-v4-flash";
         assert!(audit(&reg, &[], Some(&knows)).is_empty());
-    }
-
-    #[test]
-    fn the_vendor_guess_prefers_provider_then_the_endpoint_host() {
-        assert_eq!(vendor_candidates("anthropic", None), vec!["anthropic"]);
-        assert_eq!(
-            vendor_candidates("openai", Some("https://api.deepseek.com/v1")),
-            vec!["openai", "deepseek"]
-        );
-        // No duplicate when the host already agrees with the provider.
-        assert_eq!(
-            vendor_candidates("openai", Some("https://api.openai.com/v1")),
-            vec!["openai"]
-        );
     }
 
     /// A local runtime is in no public catalog, so "unknown" is the normal case

--- a/mur-core/src/model_prices.rs
+++ b/mur-core/src/model_prices.rs
@@ -209,6 +209,23 @@ pub fn lookup(
     load_cached(mur_home, u64::MAX).and_then(|cat| cat.lookup(provider, model))
 }
 
+/// Resolve pricing for a registry entry, asking the catalog under every vendor
+/// name the entry implies (see [`ModelEntry::vendor_candidates`]).
+///
+/// Prefer this over [`lookup`] whenever you hold an entry: `provider` alone is
+/// a wire protocol as often as a vendor, so a DeepSeek entry
+/// (`provider: openai`) is priced only when `deepseek` is tried too.
+pub fn lookup_entry(
+    mur_home: &Path,
+    entry: &mur_common::model::ModelEntry,
+    tier_is_local: bool,
+) -> Option<PriceInfo> {
+    entry
+        .vendor_candidates()
+        .into_iter()
+        .find_map(|vendor| lookup(mur_home, &vendor, &entry.model, tier_is_local))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -43,6 +43,11 @@ pub struct AgentDetail {
 pub struct ModelOptionView {
     pub ref_name: String,
     pub provider: String,
+    /// Who makes the model, when that differs from the protocol in
+    /// `provider`. The Library groups by this so OpenAI-compatible vendors
+    /// (DeepSeek, Groq, a local MLX server) do not all collapse into one
+    /// "OpenAI" heading.
+    pub vendor: Option<String>,
     pub model: String,
     pub tier: Option<String>,
     pub input_cost: Option<f64>,
@@ -60,8 +65,15 @@ pub fn list_models() -> Result<Vec<ModelOptionView>, String> {
         .into_iter()
         .map(|(ref_name, entry)| {
             let (input_cost, output_cost) = entry.effective_costs();
+            // Resolve before moving the fields out of `entry`.
+            let vendor = entry
+                .vendor_candidates()
+                .into_iter()
+                .next()
+                .filter(|v| *v != entry.provider);
             ModelOptionView {
                 ref_name,
+                vendor,
                 provider: entry.provider,
                 model: entry.model,
                 tier: entry.tier.map(|t| format!("{t:?}").to_lowercase()),

--- a/mur-hub-gui/src-tauri/src/models_admin.rs
+++ b/mur-hub-gui/src-tauri/src/models_admin.rs
@@ -96,25 +96,32 @@ pub fn probe_local_providers() -> Result<Vec<DetectedLocalView>, String> {
 }
 
 /// Find the stored `SecretRef` to reuse when re-exploring an already-connected
-/// provider: the first registry entry for `provider` that carries a secret.
+/// provider: the first entry belonging to `vendor` that carries a secret.
+///
+/// Matched on vendor candidates, not `provider`: the Library's rail is keyed
+/// by vendor, while the entry records the protocol it is dialed with.
 /// Returns `None` for providers with no stored credential (e.g. local).
-pub fn provider_secret_ref(reg: &ModelRegistry, provider: &str) -> Option<SecretRef> {
+pub fn provider_secret_ref(reg: &ModelRegistry, vendor: &str) -> Option<SecretRef> {
     reg.models
         .values()
-        .find(|e| e.provider == provider && e.secret.is_some())
+        .find(|e| e.secret.is_some() && e.vendor_candidates().iter().any(|v| v == vendor))
         .and_then(|e| e.secret.clone())
 }
 
-/// Base URL already stored for `provider`, if any.
+/// Base URL already stored for `vendor`, if any.
+///
+/// Matched against the entry's vendor candidates, not its `provider` field:
+/// after a DeepSeek entry is written as `provider: openai`, only the recorded
+/// vendor (or its endpoint host) still identifies it as DeepSeek.
 ///
 /// A provider fronted by a proxy (mur-model-gateway, LiteLLM, a self-hosted
 /// relay) has its endpoint in the registry, not at the vendor's canonical
 /// host. Discovery must reuse it or it dials the vendor directly with a
 /// gateway token and gets a 401.
-pub fn provider_base_url(reg: &ModelRegistry, provider: &str) -> Option<String> {
+pub fn provider_base_url(reg: &ModelRegistry, vendor: &str) -> Option<String> {
     reg.models
         .values()
-        .find(|e| e.provider == provider && e.base_url.is_some())
+        .find(|e| e.base_url.is_some() && e.vendor_candidates().iter().any(|v| v == vendor))
         .and_then(|e| e.base_url.clone())
 }
 
@@ -294,6 +301,9 @@ pub fn add_models(
         let price = model_prices::lookup(&home, &provider, &pick.model, is_local);
         let entry = ModelEntry {
             provider: wire.to_string(),
+            // Keep who makes it; `wire` only says how MUR dials it. Recorded
+            // only when it adds information.
+            vendor: (provider != wire).then(|| provider.clone()),
             model: pick.model.clone(),
             base_url: resolved_base_url.clone(),
             secret: secret.clone(),
@@ -428,6 +438,31 @@ mod tests {
         assert!(err.contains("base URL"), "{err}");
         // Blank counts as absent.
         assert!(resolve_wire_target("groq", Some("   ".into())).is_err());
+    }
+
+    #[test]
+    fn stored_credential_and_endpoint_are_found_by_vendor_not_protocol() {
+        // A DeepSeek entry written the correct way: dialed as openai, but the
+        // Library's rail is keyed by vendor, so both lookups must match on it.
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "deepseek_chat".into(),
+            ModelEntry {
+                provider: "openai".into(),
+                vendor: Some("deepseek".into()),
+                model: "deepseek-chat".into(),
+                base_url: Some("https://api.deepseek.com/v1".into()),
+                secret: Some(SecretRef::Env("DEEPSEEK_KEY".into())),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            provider_base_url(&reg, "deepseek").as_deref(),
+            Some("https://api.deepseek.com/v1")
+        );
+        assert!(provider_secret_ref(&reg, "deepseek").is_some());
+        // And not attributed to OpenAI just because that is the protocol.
+        assert_eq!(provider_base_url(&reg, "anthropic"), None);
     }
 
     #[test]

--- a/mur-hub-gui/ui/src/components/ModelLibrary.tsx
+++ b/mur-hub-gui/ui/src/components/ModelLibrary.tsx
@@ -34,7 +34,10 @@ interface ConnectedProvider {
 function deriveConnected(models: ModelOption[]): ConnectedProvider[] {
   const map = new Map<string, number>();
   for (const m of models) {
-    map.set(m.provider, (map.get(m.provider) ?? 0) + 1);
+    // Group by who makes the model, not by the protocol used to reach it:
+    // DeepSeek, Groq and a local MLX server are all `provider: openai`.
+    const key = m.vendor || m.provider;
+    map.set(key, (map.get(key) ?? 0) + 1);
   }
   return Array.from(map.entries()).map(([key, count]) => ({
     key,

--- a/mur-hub-gui/ui/src/components/ModelLibraryPanels.tsx
+++ b/mur-hub-gui/ui/src/components/ModelLibraryPanels.tsx
@@ -407,7 +407,9 @@ export function ConnectedPanel({
     providerKey.charAt(0).toUpperCase() + providerKey.slice(1);
   const color = providerColor(providerKey);
 
-  const provModels = registryModels.filter((m) => m.provider === providerKey);
+  const provModels = registryModels.filter(
+    (m) => (m.vendor || m.provider) === providerKey,
+  );
   const suggested = useSuggestedBaseUrl(providerKey);
 
   const [baseUrlEdit, setBaseUrlEdit] = useState<string | null>(null);
@@ -555,7 +557,9 @@ export function LocalPanel({
 }) {
   const { t } = useT();
   const color = providerColor(detected.key);
-  const provModels = registryModels.filter((m) => m.provider === detected.key);
+  const provModels = registryModels.filter(
+    (m) => (m.vendor || m.provider) === detected.key,
+  );
   const [picks, setPicks] = useState<Set<string>>(
     new Set(
       detected.models.filter((m) => registrySet.has(m.model)).map((m) => m.model)

--- a/mur-hub-gui/ui/src/components/modelPicker.ts
+++ b/mur-hub-gui/ui/src/components/modelPicker.ts
@@ -6,6 +6,8 @@
 export interface ModelOption {
   ref_name: string;
   provider: string;
+  /** Who makes the model, when that differs from the wire protocol. */
+  vendor?: string | null;
   model: string;
   tier?: string;
   input_cost?: number;


### PR DESCRIPTION
Follow-up to #954, which established that `provider:` is a wire protocol. That fix routes DeepSeek, Groq, Mistral, xAI, OpenRouter, Google, MLX and LM Studio through `provider: openai` — correct for dialing, but it left the vendor recoverable only by guessing at the endpoint host.

## The field

`ModelEntry.vendor: Option<String>` — who makes the model, recorded only when it differs from the protocol (Anthropic, OpenAI and Ollama already name their vendor). Omitted from YAML when absent, so existing registries are byte-identical until they are next written.

One resolver answers "who makes this", and every reader that asks an external catalog about an entry goes through it:

```rust
ModelEntry::vendor_candidates() -> Vec<String>   // recorded vendor → host label → provider
```

Legacy entries keep working through the fallback — which is the point of ordering it that way.

## What it fixes

**Pricing.** `model_prices::lookup_entry` walks the candidates, so an entry named by protocol is priced under its vendor. On a registry written long before this branch:

```
$ mur model prices show deepseek_v4_flash        # before: "No pricing found"
Pricing for deepseek_v4_flash (openai/deepseek-v4-flash):
  input:   $0.00014/1k tokens
  output:  $0.00028/1k tokens
  context: 1000000 tokens
```

**Hub grouping.** The Model Library rail grouped by `provider`, so a registry with two DeepSeek entries and an MLX server displayed "OpenAI 3" — a heading that owns none of them. It now groups by vendor. Because the rail key changes from a protocol to a vendor, three lookups move with it: the panel's model filter, `provider_secret_ref`, and `provider_base_url`. Leaving any one of them on `provider` would have produced an empty panel or a lost API key.

**Duplication.** `mur model doctor` had its own copy of the host-guessing logic; it now calls the shared resolver. The guess had no notion of a recorded vendor, so keeping both would have meant the doctor disagreeing with pricing about the same entry.

## Not included

Existing entries are not rewritten to add `vendor:` — they resolve correctly through the host fallback, and rewriting model bindings is what `mur model doctor` is documented never to do.

## Verification

- `cargo check --workspace --all-targets` ✓, plus both workspace-excluded GUI crates (`mur-hub-gui`, `mur-agent-gui`) — the field is additive, and the compiler found the five exhaustive `ModelEntry` literals that needed a `..Default::default()`.
- `cargo nextest -p mur-common -p mur-core` on the affected filters → 80 passed. New: candidate ordering (recorded vendor wins, legacy falls back to host, no duplicate when host and provider agree), and YAML round-trip proving the field is omitted when absent.
- `cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml --lib` → 120 passed. New: endpoint and credential are found by vendor, and not attributed to another vendor that shares the protocol.
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ · Hub clippy with CI's args ✓ · `cargo fmt --check` both manifests ✓.
- Ran against a real `~/.mur`: the pricing output above, and `mur model doctor` reports the same single pre-existing finding as before.

Unrelated pre-existing breakage noticed while verifying: `mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs` no longer compiles (`install_muragent_file` gained an `AppHandle` parameter). CI runs `cargo check` and `cargo test --lib` for that crate, so nothing catches it. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)