### PR TITLE
fix(hub): make the .muragent roundtrip test compile, and let CI see it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,10 +351,13 @@ jobs:
         run: cd mur-hub-gui/ui && npm run build
       - name: cargo check
         run: cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml
-      - name: cargo test --lib
-        run: cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml --lib
+      # Not --lib: the integration test in tests/ went unnoticed for months
+      # after a signature change stopped it compiling, because nothing built
+      # that target.
+      - name: cargo test
+        run: cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml
       - name: cargo clippy
-        run: cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --lib -- -D warnings
+        run: cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings
 
   e2e_quick:
     name: E2E orchestration smoke (quick mode)

--- a/mur-hub-gui/src-tauri/src/import_muragent.rs
+++ b/mur-hub-gui/src-tauri/src/import_muragent.rs
@@ -153,7 +153,10 @@ fn inspect_inner(path: &Path) -> anyhow::Result<MuragentInspection> {
     }
 }
 
-fn install_inner(path: &Path, hub_version: &str) -> anyhow::Result<InstallReceipt> {
+/// The install itself, split out from the Tauri command so it is reachable
+/// from a test: the command exists only to read the Hub version off an
+/// `AppHandle`, which a test cannot construct.
+pub fn install_inner(path: &Path, hub_version: &str) -> anyhow::Result<InstallReceipt> {
     let archive =
         MuragentArchive::read(path).map_err(|e| anyhow::anyhow!("read .muragent: {e}"))?;
     let mur_home = trust::mur_home();

--- a/mur-hub-gui/src-tauri/src/model_switch.rs
+++ b/mur-hub-gui/src-tauri/src/model_switch.rs
@@ -121,9 +121,11 @@ mod tests {
         assert!(got.fallback_chain.is_empty());
 
         // Set a valid config → persisted + returned.
-        let mut next = ModelSwitchConfig::default();
-        next.default = Some("claude_sonnet".into());
-        next.fallback_chain = vec!["claude_sonnet".into(), "deepseek_v4_pro".into()];
+        let next = ModelSwitchConfig {
+            default: Some("claude_sonnet".into()),
+            fallback_chain: vec!["claude_sonnet".into(), "deepseek_v4_pro".into()],
+            ..Default::default()
+        };
         let saved = model_switch_set_impl(&home, next.clone()).unwrap();
         assert_eq!(saved.default.as_deref(), Some("claude_sonnet"));
         // Reloading from disk reflects it.
@@ -137,8 +139,10 @@ mod tests {
     #[test]
     fn set_rejects_unknown_ref_and_persists_nothing() {
         let (_d, home) = seed_home();
-        let mut bad = ModelSwitchConfig::default();
-        bad.default = Some("does_not_exist".into());
+        let bad = ModelSwitchConfig {
+            default: Some("does_not_exist".into()),
+            ..Default::default()
+        };
         assert!(model_switch_set_impl(&home, bad).is_err());
         // Nothing persisted.
         assert_eq!(model_switch_get_impl(&home).unwrap().default, None);
@@ -147,13 +151,15 @@ mod tests {
     #[test]
     fn set_validates_routing_and_chain_refs() {
         let (_d, home) = seed_home();
-        let mut cfg = ModelSwitchConfig::default();
-        cfg.routing = RoutingConfig {
-            enabled: true,
-            cheap: Some("claude_sonnet".into()),
-            frontier: Some("nope".into()), // unknown → reject
-            threshold_input_tokens: Some(1000),
-            smart: None,
+        let cfg = ModelSwitchConfig {
+            routing: RoutingConfig {
+                enabled: true,
+                cheap: Some("claude_sonnet".into()),
+                frontier: Some("nope".into()), // unknown → reject
+                threshold_input_tokens: Some(1000),
+                smart: None,
+            },
+            ..Default::default()
         };
         assert!(model_switch_set_impl(&home, cfg).is_err());
     }

--- a/mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs
+++ b/mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs
@@ -31,9 +31,11 @@ fn hub_gui_open_muragent_lands_prompt_and_skills() {
     // SAFETY: single-threaded test; trust::mur_home() reads MUR_HOME.
     unsafe { std::env::set_var("MUR_HOME", &home) }
 
-    let receipt =
-        mur_hub_gui_lib::import_muragent::install_muragent_file(pkg.to_string_lossy().into_owned())
-            .expect("Hub GUI install_muragent_file should succeed");
+    // The `install_muragent_file` command only reads the Hub version off an
+    // AppHandle before delegating here; a test has no AppHandle, so it calls
+    // the seam with an explicit version.
+    let receipt = mur_hub_gui_lib::import_muragent::install_inner(&pkg, "0.0.0-test")
+        .expect("Hub GUI install path should succeed");
 
     let agent_dir = home.join("agents").join(&receipt.slug);
     assert_eq!(


### PR DESCRIPTION
## What was broken

`mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs` calls `install_muragent_file`, which gained an `AppHandle` parameter in #335. The test was never updated, so the target has not compiled since — meaning the assertion it exists to make (a `.muragent` opened through the Hub keeps its system prompt and skills) has not been checked in months.

Nothing caught it because the Hub CI job runs:

```
cargo test  --manifest-path … --lib
cargo clippy --manifest-path … --lib -- -D warnings
```

Neither `--lib` invocation builds `tests/`. `cargo check` (no `--all-targets`) doesn't either.

## Fix

The test now calls `install_inner` — the function the Tauri command delegates to after reading the Hub version off the `AppHandle` — with an explicit version string. A test cannot construct an `AppHandle`, so the seam is the only reachable entry point; it's now `pub` with a doc comment saying why, matching how `apply_cost_update` is already split out of `update_model` in this crate.

Both CI commands drop `--lib` so the target stays built and linted. That surfaced three `field_reassign_with_default` lints in `model_switch` tests, fixed here.

## Verification

- `cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml` → 120 lib + **1 integration** passed. That integration test had not executed since #335.
- `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings` → clean.
- `cargo fmt --check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)