### PR TITLE
ci: give Clippy headroom to recover from a bad run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,18 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Headroom, because 45 proved too tight to recover from — NOT because a
+    # cold build costs 45 minutes (measured: a cold run takes ~11 min).
+    # Three runs in a row were killed at the 45m mark with "No cache found"
+    # (main @962ac841 and two on #968) while a fourth cold run of the SAME
+    # Rust code finished in 10m41s. Whatever slows a run down that far is
+    # unexplained — runner contention is the suspicion, not a finding. What
+    # made it stick was the feedback loop: a killed job never runs
+    # rust-cache's save step, so every retry starts cold too, and re-running
+    # can't clear it. The extra budget buys a bad run the chance to finish
+    # and leave a cache behind. Still far below the 6h default, so a
+    # genuinely hung build is still caught.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
**main is currently red and cannot recover on its own.** This unblocks it.

## What is established

Three Clippy runs in a row were killed at the 45-minute mark with
`No cache found` — main `962ac841`, and two on #968.

| Run | Clippy | Result |
|---|---|---|
| main `462e347b` (before) | 2m20s | ✅ warm |
| PR #963 `f3bdd866` | 2m28s | ✅ warm |
| main `962ac841` | ≥45m | ❌ killed, cold |
| #968 first run | ≥45m | ❌ killed, cold |
| #968 re-run | ≥45m | ❌ killed, cold |
| this branch (main + 1 YAML line) | **10m41s** | ✅ **cold** |

That last row is the important one, and it corrects the first version of this
PR: **a cold Clippy run costs ~11 minutes, not 45.** It ran the same Rust code
as the timing-out main commit, with the same empty cache, and finished in a
quarter of the budget.

So the three kills measure nothing except ">= 45". **Why those runs were that
slow is unexplained.** Runner contention is the suspicion — a `B0 Eval` run sat
queued for six hours across the same window — but that is a guess, not a
finding, and I am not going to dress it up as one.

## Why it stuck

A killed job never reaches `rust-cache`'s save step. So every retry starts cold
too, and `gh run rerun` cannot break out of it. Three retries reproduced the
kill exactly. That loop is the part this change actually addresses.

## What this is, and is not

**Is:** headroom. A bad run now has room to finish and leave a cache behind
instead of being killed and taking the recovery path down with it.

**Is not:** a root-cause fix. If runs start burning 90 minutes, the real cause
is still out there and this number is not the answer.

Clippy was the only job budgeted under 60. In the same cold run on main every
other job finished: Test 17–21 min across all three platforms, E2E smoke
10m35s, Hub GUI 3–7 min. E2E is also at 45 and is **deliberately left alone**
— it has headroom already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
