### PR TITLE
fix(sandbox): deny reads of sibling signing keys (macOS)

### DIFF
--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -153,11 +153,43 @@ impl LaunchChain {
     /// see docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md.
     pub fn sibling_signing_keys(&self) -> Vec<PathBuf> {
         let agents = self.mur_home.join("agents");
-        let Ok(entries) = std::fs::read_dir(&agents) else {
-            return Vec::new();
+        let entries = match std::fs::read_dir(&agents) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(error) => {
+                // Never silently: an unreadable agents dir means the profile
+                // is built WITHOUT these denies, i.e. weaker than intended,
+                // and nothing else would say so.
+                tracing::warn!(
+                    dir = %agents.display(),
+                    %error,
+                    "cannot enumerate sibling agents — their signing keys will \
+                     NOT be read-denied in this sandbox profile"
+                );
+                return Vec::new();
+            }
         };
         entries
             .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+            // Only well-formed agent names reach the profile text. Names are
+            // `[A-Za-z0-9_-]` by construction (`validate_agent_name`), so this
+            // is normally a no-op — but the profile is assembled by string
+            // concatenation and `fail_closed_on_sandbox_error` defaults to
+            // true, so one hand-made directory with an odd name could
+            // otherwise produce a profile that fails to compile and stop
+            // EVERY agent from starting. Skip it instead, loudly.
+            .filter(|e| match e.file_name().to_str() {
+                Some(n) if mur_common::validate_agent_name(n).is_ok() => true,
+                other => {
+                    tracing::warn!(
+                        entry = ?other,
+                        "skipping malformed entry under agents/ when building \
+                         the sibling-key deny list"
+                    );
+                    false
+                }
+            })
             .map(|e| e.path())
             .filter(|p| p != &self.agent_home)
             .map(|p| p.join("identity.key"))

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -136,6 +136,35 @@ impl LaunchChain {
     /// Symlinks present now. One created later is not listed, which is
     /// acceptable: a new symlink only matters if something starts it, and
     /// that needs a profile (denied) or an autostart entry (denied) or a human.
+    /// Sibling signing keys, as concrete paths for backends that need a list
+    /// rather than a predicate. The rule is `protects_read`'s; this is the
+    /// enforcement side of it, which until now had no caller — the predicate
+    /// was consulted at GRANT time (`mur agent perm`) and never emitted into a
+    /// sandbox profile, so the kernel never enforced it (#850).
+    ///
+    /// KNOWN GAP, deliberate: this enumerates the agents that exist when the
+    /// policy is sealed. An agent created afterwards is not in the list, and
+    /// stays readable to an already-running agent until that one restarts.
+    /// The write side avoids this by denying the whole `agents` subtree, which
+    /// the read side cannot do: verifying a peer's signed events must read
+    /// `identity.pub` and `rotations.jsonl` from that peer's home, so a
+    /// blanket read-deny would fail-close every multi-agent channel. Closing
+    /// the gap properly means moving private keys out of the agents tree —
+    /// see docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md.
+    pub fn sibling_signing_keys(&self) -> Vec<PathBuf> {
+        let agents = self.mur_home.join("agents");
+        let Ok(entries) = std::fs::read_dir(&agents) else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p != &self.agent_home)
+            .map(|p| p.join("identity.key"))
+            .filter(|p| self.protects_read(p).is_some())
+            .collect()
+    }
+
     fn existing_agent_symlinks(&self) -> Vec<PathBuf> {
         let Ok(entries) = std::fs::read_dir(&self.bin_dir) else {
             return Vec::new();

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -404,6 +404,44 @@ mod tests {
         }
     }
 
+    /// A directory under `agents/` that is not a valid agent name must never
+    /// reach the profile text. The profile is assembled by string
+    /// concatenation and `fail_closed_on_sandbox_error` defaults to TRUE, so a
+    /// name that broke SBPL would not brick one agent — it would stop every
+    /// agent on the machine from starting, because they all enumerate the same
+    /// directory.
+    #[test]
+    fn a_malformed_entry_under_agents_is_skipped_not_emitted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(agents.join("alice")).unwrap();
+        std::fs::create_dir_all(agents.join("bob")).unwrap();
+        // Hand-made junk: a quote would terminate the SBPL string literal.
+        std::fs::create_dir_all(agents.join("we\"ird")).unwrap();
+        // A plain file is not an agent either.
+        std::fs::write(agents.join("notes.txt"), b"x").unwrap();
+
+        let policy = policy_with_launch_chain(&agents.join("alice").to_string_lossy());
+        let sbpl = build_sbpl_profile(&policy);
+
+        assert!(
+            sbpl.contains("bob/identity.key"),
+            "the well-formed sibling should still be denied:\n{sbpl}"
+        );
+        // Assert on the tail, which escaping does not touch: `sbpl_escape`
+        // renders the quote as `we\\"ird`, so searching for the raw name
+        // passes whether or not the entry was skipped — a test that proves
+        // escaping works, not that the filter does.
+        assert!(
+            !sbpl.contains("ird/identity.key"),
+            "a malformed directory name reached the profile text:\n{sbpl}"
+        );
+        assert!(
+            !sbpl.contains("notes.txt"),
+            "a plain file was treated as an agent home:\n{sbpl}"
+        );
+    }
+
     /// The deny must NOT extend to a peer's verification material. Resolving a
     /// peer's pubkey reads `identity.pub` and `rotations.jsonl` from that
     /// peer's home, and verify-on-fold is per-actor — denying them would

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -214,6 +214,23 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
         lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
     }
 
+    // Sibling signing keys (#850). The launch chain denies WRITES on the agents
+    // tree and re-allows this agent's own home; neither is a read deny, so
+    // until this loop existed any agent could read any other agent's
+    // `identity.key` — enough to forge that agent's signed channel events with
+    // no write at all. `protects_read` had encoded the rule since the launch
+    // chain landed; nothing emitted it into a profile.
+    //
+    // Emitted LAST, so last-match-wins cannot let the own-home re-allow above
+    // reopen them. Deliberately NOT a subtree deny on `agents`: verifying a
+    // peer's events reads `identity.pub` and `rotations.jsonl` from that peer's
+    // home, and denying those fail-closes every multi-agent channel.
+    for key in policy.launch_chain.sibling_signing_keys() {
+        let p = sbpl_escape(&key.to_string_lossy());
+        lines.push(format!("(deny file-read* (subpath \"{p}\"))"));
+        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
+    }
+
     // Process-exec restrictions. Under `(allow default)` any binary is
     // spawnable unless explicitly denied. When spawn_mode is not `Any`
     // (i.e. Allowlist, None, or Strict), deny all exec by default and
@@ -357,6 +374,68 @@ mod tests {
             fs_deny: deny,
             ..Default::default()
         }
+    }
+
+    /// #850: a sibling's signing key must be read-denied. Before this, the
+    /// launch chain denied WRITES on the agents tree and read-denied only the
+    /// agent's OWN protected files — so alice could not read her own
+    /// `identity.key` and could read bob's, which is enough to forge bob's
+    /// signed channel events without writing anything.
+    #[test]
+    fn a_siblings_signing_key_is_read_denied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        for name in ["alice", "bob", "carol"] {
+            std::fs::create_dir_all(agents.join(name)).unwrap();
+            std::fs::write(agents.join(name).join("identity.key"), b"k").unwrap();
+        }
+        let policy = policy_with_launch_chain(&agents.join("alice").to_string_lossy());
+        let sbpl = build_sbpl_profile(&policy);
+
+        for sibling in ["bob", "carol"] {
+            let key = agents.join(sibling).join("identity.key");
+            assert!(
+                sbpl.contains(&format!(
+                    "(deny file-read* (subpath \"{}\"))",
+                    key.display()
+                )),
+                "{sibling}'s signing key is readable:\n{sbpl}"
+            );
+        }
+    }
+
+    /// The deny must NOT extend to a peer's verification material. Resolving a
+    /// peer's pubkey reads `identity.pub` and `rotations.jsonl` from that
+    /// peer's home, and verify-on-fold is per-actor — denying them would
+    /// fail-close every fleet, delegation and shared channel, silently. This
+    /// is the guard against "fix" it by denying the agents subtree.
+    #[test]
+    fn peer_verification_material_stays_readable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        for name in ["alice", "bob"] {
+            std::fs::create_dir_all(agents.join(name)).unwrap();
+            std::fs::write(agents.join(name).join("identity.key"), b"k").unwrap();
+        }
+        let policy = policy_with_launch_chain(&agents.join("alice").to_string_lossy());
+        let sbpl = build_sbpl_profile(&policy);
+
+        for public in ["identity.pub", "rotations.jsonl"] {
+            let p = agents.join("bob").join(public);
+            assert!(
+                !sbpl.contains(&format!("(deny file-read* (subpath \"{}\"))", p.display())),
+                "bob's {public} was read-denied — peer signature verification \
+                 will fail-close:\n{sbpl}"
+            );
+        }
+        // And the agents tree itself must not be read-denied wholesale.
+        assert!(
+            !sbpl.contains(&format!(
+                "(deny file-read* (subpath \"{}\"))",
+                agents.display()
+            )),
+            "the whole agents tree was read-denied, which breaks verification:\n{sbpl}"
+        );
     }
 
     fn policy_with_launch_chain(agent_home: &str) -> SandboxPolicy {


### PR DESCRIPTION
#850, option (a) from the audit in #974. **Read #974 first** — it is why this is
not a subtree deny.

## The rule already existed; nothing enforced it

`LaunchChain::protects_read` has encoded the rule since the launch chain landed:

> another agent's signing key — reading it is enough to forge that agent's
> signed channel events

Its only caller was the **grant-time** check in `mur agent perm`. No backend
emitted it into a sandbox profile, so the kernel never enforced it.

Proven from `build_sbpl_profile`'s actual output — every line it emitted for the
agents tree was a write deny, a write re-allow of the agent's own home, or a
read+write deny of that agent's **own** protected files. Net effect:

**alice could not read her own `identity.key`, and could read bob's.**

Under v3d signed events and `channel/delegate`, that key is enough to forge
events attributed to bob with no write at all.

## The fix

`sibling_signing_keys()` enumerates them; macOS emits a read+write deny per key,
**last**, so the own-home re-allow cannot reopen them under last-match-wins.

## Deliberately not a subtree deny

Verifying a peer's signed events reads, from that peer's home:

- `identity.pub` — `mur-channel/src/sign.rs:135`
- `rotations.jsonl` — `mur-channel/src/sign.rs:109`

and verify-on-fold is per-actor since v3d-2. Denying `agents/` wholesale
fail-closes every fleet, delegation and shared channel, silently.

`peer_verification_material_stays_readable` guards that direction. Note it
**passes with this fix removed** — it asserts the deny does not go too far, so
it is only red if someone "fixes" #850 by denying the tree. The two tests guard
opposite failure modes on purpose.

## Two limits, in the code and not only in the doc

- **macOS only.** Linux uses `deny_paths()` solely to filter write grants;
  Landlock read confinement does not exist here, and tier-3 self-protection was
  already macOS-only. This does not change that.
- **Seal-time enumeration.** An agent created after the policy is sealed is not
  in the list, and stays readable to an already-running agent until it
  restarts. The write side escapes this by denying the whole subtree; the read
  side cannot, per above. Option (c) in #974 — moving private keys out of the
  agents tree — is what actually closes it.

Both are written into the doc comment on `sibling_signing_keys`, so a reader of
the code learns them without finding the spec.

## Verification

```
cargo test -p mur-agent-runtime --lib          → 532 passed; 0 failed
cargo test -p mur-agent-runtime --lib sandbox  →  81 passed; 0 failed
cargo clippy -p mur-agent-runtime --all-targets → clean
cargo fmt --check → clean
```

Negative control: with the emission loop replaced by an empty iterator,
`a_siblings_signing_key_is_read_denied` fails and
`peer_verification_material_stays_readable` still passes — confirming each test
is anchored to its own direction.

## Does not close #850

Deliverable 1 (audit) is #974. This is deliverable 2 for the private-key case
plus its regression guard. Still open: the read audit of the central stores
(`skills/`, `channels/`, `index/`, `inbox/`, `compress/`, `fleets/`), Linux read
confinement, and option (c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
