### PR TITLE
fix(sandbox): agents cannot read the user's credential store

### DIFF
--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -145,6 +145,18 @@ impl LaunchChain {
         if path == self.mur_home.join("identity.key") {
             return Some("the host signing key");
         }
+        if path == self.mur_home.join("commander").join("signing.key") {
+            return Some("the commander's signing key — governance authority");
+        }
+        if path == self.mur_home.join("mobile").join("pair-token") {
+            return Some("the phone pairing token");
+        }
+        if path.starts_with(self.mur_home.join("actions-runner")) {
+            return Some(
+                "a self-hosted CI runner's credentials — they authenticate as \
+                 that runner against the whole repository host",
+            );
+        }
         None
     }
 
@@ -189,6 +201,9 @@ impl LaunchChain {
             self.mur_home.join("secrets"),
             self.mur_home.join("auth.json"),
             self.mur_home.join("identity.key"),
+            self.mur_home.join("commander").join("signing.key"),
+            self.mur_home.join("mobile").join("pair-token"),
+            self.mur_home.join("actions-runner"),
         ]
     }
 
@@ -344,6 +359,10 @@ mod tests {
             mur.join("secrets").join("anthropic.key"),
             mur.join("auth.json"),
             mur.join("identity.key"),
+            mur.join("commander").join("signing.key"),
+            mur.join("mobile").join("pair-token"),
+            mur.join("actions-runner"),
+            mur.join("actions-runner").join(".credentials"),
         ] {
             assert!(
                 chain.protects_read(&p).is_some(),
@@ -365,10 +384,17 @@ mod tests {
         let mur = tmp.path().to_path_buf();
         let chain =
             LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+        // Includes the non-secret NEIGHBOURS of the new denies: `commander/`
+        // holds the constitution and the audit log, `mobile/` holds the paired
+        // device list. Denying a whole directory to reach one credential
+        // inside it is the mistake this guards against.
         for p in [
             mur.join("skills"),
             mur.join("channels"),
             mur.join("workflows"),
+            mur.join("commander"),
+            mur.join("commander").join("constitution.toml"),
+            mur.join("mobile").join("paired.json"),
         ] {
             assert!(
                 chain.protects_read(&p).is_none(),

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -92,18 +92,58 @@ impl LaunchChain {
         if self.autostart.iter().any(|d| path.starts_with(d)) {
             return Some("an OS autostart directory — entries here run outside any sandbox");
         }
+        if let Some(reason) = self.protects_credential(path) {
+            return Some(reason);
+        }
         None
     }
 
-    /// Why `path` may never be read. Only sibling signing keys: whoever reads
-    /// one can forge that agent's channel events with no write at all, and
-    /// verify-on-fold accepts them because the key on disk is untouched.
+    /// Why `path` may never be read.
+    ///
+    /// Two families, both "reading this is equivalent to holding a credential":
+    /// a sibling's signing key, and the user's own credential store. Neither
+    /// is expressible as an entitlement — an agent that could be granted them
+    /// could impersonate another agent or the user, so no grant may authorise
+    /// it and the gate sits before the allow/deny lists.
     pub fn protects_read(&self, path: &Path) -> Option<&'static str> {
         if self.is_other_agent(path) && path.file_name().is_some_and(|n| n == "identity.key") {
             return Some(
                 "another agent's signing key — reading it is enough to forge \
                  that agent's signed channel events",
             );
+        }
+        if let Some(reason) = self.protects_credential(path) {
+            return Some(reason);
+        }
+        None
+    }
+
+    /// The user's credentials, which no agent has a reason to read.
+    ///
+    /// `secrets/` holds provider API keys and the commander token in plain
+    /// text; `auth.json` holds the account access + refresh tokens; the
+    /// top-level `identity.key` is the host key. An agent reaches its model
+    /// through the runtime's own client, which resolves credentials before the
+    /// sandbox is sealed — it never needs the files.
+    ///
+    /// This is deliberately BOTH read and write: writing `secrets/` swaps the
+    /// key an unrelated agent will use, and writing `auth.json` is a session
+    /// takeover.
+    fn protects_credential(&self, path: &Path) -> Option<&'static str> {
+        if path.starts_with(self.mur_home.join("secrets")) {
+            return Some(
+                "MUR's credential store — provider API keys and the commander \
+                 token, which no agent needs and any agent could exfiltrate",
+            );
+        }
+        if path == self.mur_home.join("auth.json") {
+            return Some(
+                "the account's access and refresh tokens — reading them is a \
+                 session takeover, not a file read",
+            );
+        }
+        if path == self.mur_home.join("identity.key") {
+            return Some("the host signing key");
         }
         None
     }
@@ -136,6 +176,22 @@ impl LaunchChain {
     /// Symlinks present now. One created later is not listed, which is
     /// acceptable: a new symlink only matters if something starts it, and
     /// that needs a profile (denied) or an autostart entry (denied) or a human.
+    /// The credential paths, as concrete paths for the SBPL emitter. Same set
+    /// `protects_credential` refuses at grant time; this is the kernel side,
+    /// so a read that never goes through the file tools (a spawned process, an
+    /// MCP server, a library doing raw I/O) is stopped too.
+    ///
+    /// Unlike sibling keys these are FIXED paths, so there is no enumeration
+    /// and no after-seal gap: a `secrets/` file created later is still under
+    /// the denied subtree.
+    pub fn credential_paths(&self) -> Vec<PathBuf> {
+        vec![
+            self.mur_home.join("secrets"),
+            self.mur_home.join("auth.json"),
+            self.mur_home.join("identity.key"),
+        ]
+    }
+
     /// Sibling signing keys, as concrete paths for backends that need a list
     /// rather than a predicate. The rule is `protects_read`'s; this is the
     /// enforcement side of it, which until now had no caller — the predicate
@@ -272,6 +328,55 @@ pub fn is_overbroad_grant_root(path: &Path, home: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The published docs say `mur agent perm allow-read` / `allow-write`
+    /// refuse these. Before #850 they did not — `protects_read` matched only a
+    /// sibling `identity.key`, so a grant covering the credential store was
+    /// accepted, and two live agents held one. This pins the claim.
+    #[test]
+    fn the_grant_gates_refuse_the_credential_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+        for p in [
+            mur.join("secrets"),
+            mur.join("secrets").join("anthropic.key"),
+            mur.join("auth.json"),
+            mur.join("identity.key"),
+        ] {
+            assert!(
+                chain.protects_read(&p).is_some(),
+                "read grant not refused: {}",
+                p.display()
+            );
+            assert!(
+                chain.protects_write(&p).is_some(),
+                "write grant not refused: {}",
+                p.display()
+            );
+        }
+    }
+
+    /// ...and must not swallow the ordinary stores an agent legitimately uses.
+    #[test]
+    fn the_grant_gates_still_allow_the_ordinary_stores() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+        for p in [
+            mur.join("skills"),
+            mur.join("channels"),
+            mur.join("workflows"),
+        ] {
+            assert!(
+                chain.protects_read(&p).is_none(),
+                "an ordinary store was refused: {}",
+                p.display()
+            );
+        }
+    }
 
     /// `<tmp>/agents/mur` as agent_home, so mur_home is `<tmp>`.
     fn chain(tmp: &Path) -> LaunchChain {

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -225,6 +225,15 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
     // reopen them. Deliberately NOT a subtree deny on `agents`: verifying a
     // peer's events reads `identity.pub` and `rotations.jsonl` from that peer's
     // home, and denying those fail-closes every multi-agent channel.
+    // The user's credential store (#850). Fixed subtrees, so unlike the
+    // sibling keys below there is no enumeration and no after-seal gap.
+    // Emitted with the same last-match-wins reasoning: after every allow.
+    for p in policy.launch_chain.credential_paths() {
+        let p = sbpl_escape(&p.to_string_lossy());
+        lines.push(format!("(deny file-read* (subpath \"{p}\"))"));
+        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
+    }
+
     for key in policy.launch_chain.sibling_signing_keys() {
         let p = sbpl_escape(&key.to_string_lossy());
         lines.push(format!("(deny file-read* (subpath \"{p}\"))"));
@@ -440,6 +449,30 @@ mod tests {
             !sbpl.contains("notes.txt"),
             "a plain file was treated as an agent home:\n{sbpl}"
         );
+    }
+
+    /// #850: the user's credential store is not an entitlement question. An
+    /// agent reaches its model through the runtime's own client, which
+    /// resolves credentials before the sandbox is sealed, so it never needs
+    /// these files — and reading them is exfiltrating the user's API keys or
+    /// taking over their account session.
+    #[test]
+    fn the_credential_store_is_denied_read_and_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(agents.join("alice")).unwrap();
+        let policy = policy_with_launch_chain(&agents.join("alice").to_string_lossy());
+        let sbpl = build_sbpl_profile(&policy);
+
+        for p in ["secrets", "auth.json", "identity.key"] {
+            let full = tmp.path().join(p);
+            for verb in ["file-read*", "file-write*"] {
+                assert!(
+                    sbpl.contains(&format!("(deny {verb} (subpath \"{}\"))", full.display())),
+                    "{p} is not {verb}-denied:\n{sbpl}"
+                );
+            }
+        }
     }
 
     /// The deny must NOT extend to a peer's verification material. Resolving a

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -464,7 +464,14 @@ mod tests {
         let policy = policy_with_launch_chain(&agents.join("alice").to_string_lossy());
         let sbpl = build_sbpl_profile(&policy);
 
-        for p in ["secrets", "auth.json", "identity.key"] {
+        for p in [
+            "secrets",
+            "auth.json",
+            "identity.key",
+            "commander/signing.key",
+            "mobile/pair-token",
+            "actions-runner",
+        ] {
             let full = tmp.path().join(p);
             for verb in ["file-read*", "file-write*"] {
                 assert!(


### PR DESCRIPTION
#850, found while doing deliverable 1 — the read audit of the central stores.
Larger than the sibling-key case #975 closed, and **live on my machine**.

## What I found

Verified with `sandbox-exec` against the real generated profile, not by
reasoning:

```
~/.mur/secrets/anthropic.key     READABLE
~/.mur/secrets/commander-token   READABLE
~/.mur/auth.json                 READABLE
~/.mur/identity.key              READABLE
```

`secrets/` holds provider API keys and the commander token **in plain text**;
`auth.json` holds the account access + refresh tokens. Nothing denied them at
either layer — `protects_read` matched only a sibling `identity.key`, and the
SBPL baseline is `(allow default)` for reads.

**Not hypothetical.** Two agents on this machine hold `fs.read` *and*
`fs.write` on `~/.mur` itself:

```
dataml    read+write /Users/david/.mur     deny: [~/.ssh, ~/.aws, ~/.gnupg]
frontend  read+write /Users/david/.mur     deny: [~/.ssh, ~/.aws, ~/.gnupg]
```

So their `read_file` tool served these files too — not just a non-tool path.
And `mur agent perm allow-read <agent> ~/.mur/secrets` was **accepted**:
`is_overbroad_grant_root` counts path components (three, so not overbroad) and
the launch chain did not cover it.

## The docs said otherwise

The published troubleshooting page states:

> You cannot grant `~/.mur` wholesale, and cannot grant `~/.mur/agents`:
> `mur agent perm allow-read` / `allow-write` refuse them

Probing the three gates directly:

| path | read refused | write refused |
|---|---|---|
| `~/.mur` | no | no |
| `~/.mur/agents` | no | **yes** |
| `~/.mur/secrets` | no | no |
| `~/.mur/auth.json` | no | no |

One of four claims held. A false claim in user-facing **security** docs is
worse than the gap itself, because it tells people they are covered. The doc
fix is a separate `mur-server` PR.

## The change

`protects_credential` refuses these paths for **both** read and write — writing
`secrets/` swaps the key another agent will use, and writing `auth.json` is a
session takeover.

It sits inside `protects_read` / `protects_write`, which run **before** the
allow/deny lists in `read_file.rs`, so an existing broad grant no longer
reaches them. `credential_paths()` emits the same set into the SBPL, so a read
that never touches the file tools — a spawned process, an MCP server, raw I/O —
is stopped as well.

Unlike sibling keys these are **fixed subtrees**: no enumeration, no after-seal
gap, and a `secrets/` file created later is still covered.

Nothing legitimate reads them: an agent reaches its model through the runtime's
own client, which resolves credentials before the sandbox is sealed.

## After, same real profile

```
secrets/anthropic.key    DENIED      agents/pm/identity.pub  READABLE
auth.json                DENIED      skills                  READABLE
identity.key             DENIED      channels                READABLE
```

Profile still compiles: `sandbox-exec -f <profile> /usr/bin/true` → exit 0.

## Verification

```
cargo test -p mur-agent-runtime --lib → 536 passed; 0 failed
cargo clippy -p mur-agent-runtime --all-targets → clean
cargo fmt --check → clean
```

Negative controls, run separately:

| removing | fails |
|---|---|
| the grant gate | `the_grant_gates_refuse_the_credential_store` |
| the SBPL emission | `the_credential_store_is_denied_read_and_write` |

`the_grant_gates_still_allow_the_ordinary_stores` guards the opposite direction
— `skills/`, `channels/`, `workflows/` must stay grantable.

## Does not fix the live exposure by itself

The runtime reads its profile and seals its sandbox **once**, at startup. The
two agents holding the broad grant stay exposed until they restart. The
immediate mitigation is additive and does not disturb their other access:

```bash
for a in dataml frontend pm; do
  mur agent perm deny-path $a ~/.mur/secrets
  mur agent perm deny-path $a ~/.mur/auth.json
done
mur agent restart dataml frontend pm
```

`fs.deny` is checked before `fs.read`/`fs.write` in the tool layer and emitted
after the allows in SBPL, so it overrides the broad grant either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
