### PR TITLE
fix(sandbox): agents cannot read the capture stores

### DIFF
--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -157,6 +157,41 @@ impl LaunchChain {
                  that runner against the whole repository host",
             );
         }
+        if let Some(reason) = self.protects_capture_store(path) {
+            return Some(reason);
+        }
+        None
+    }
+
+    /// The capture stores, which record what was DONE rather than what was
+    /// configured — and record it verbatim.
+    ///
+    /// `queue/events.jsonl` is the CLI hook pipeline's event log: every tool
+    /// call, including shell command lines as typed. It is not redacted —
+    /// `inject::queue::enqueue_to` serialises the event and appends it, and
+    /// nothing in `capture/` filters first. The redaction chokepoint that does
+    /// exist (`telemetry_writer::redact_envelope`, B0 rule 9) is a DIFFERENT
+    /// writer, on the runtime's own telemetry path, and never sees this file.
+    ///
+    /// So any credential that ever appeared on a command line is in here in
+    /// plain text. A 200 MB sample of a real 934 MB queue matched 21 lines of
+    /// `sk-ant-` shape, 12 of `ghp_`, 8 of `AKIA`, and 180 Authorization
+    /// headers.
+    ///
+    /// `session/`, `conversations/`, `telemetry/` and `traces/` are the same
+    /// class: a recording of the user's work, not state an agent operates on.
+    ///
+    /// Nothing in the agent runtime reads any of them.
+    fn protects_capture_store(&self, path: &Path) -> Option<&'static str> {
+        const STORES: [&str; 5] = ["queue", "session", "conversations", "telemetry", "traces"];
+        for s in STORES {
+            if path.starts_with(self.mur_home.join(s)) {
+                return Some(
+                    "a capture store — an unredacted verbatim record of every \
+                     command run, which no agent reads and any agent could mine",
+                );
+            }
+        }
         None
     }
 
@@ -204,6 +239,11 @@ impl LaunchChain {
             self.mur_home.join("commander").join("signing.key"),
             self.mur_home.join("mobile").join("pair-token"),
             self.mur_home.join("actions-runner"),
+            self.mur_home.join("queue"),
+            self.mur_home.join("session"),
+            self.mur_home.join("conversations"),
+            self.mur_home.join("telemetry"),
+            self.mur_home.join("traces"),
         ]
     }
 
@@ -363,6 +403,12 @@ mod tests {
             mur.join("mobile").join("pair-token"),
             mur.join("actions-runner"),
             mur.join("actions-runner").join(".credentials"),
+            mur.join("queue"),
+            mur.join("queue").join("events.jsonl"),
+            mur.join("session").join("recordings"),
+            mur.join("conversations"),
+            mur.join("telemetry"),
+            mur.join("traces"),
         ] {
             assert!(
                 chain.protects_read(&p).is_some(),

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -151,6 +151,17 @@ impl LaunchChain {
         if path == self.mur_home.join("mobile").join("pair-token") {
             return Some("the phone pairing token");
         }
+        // `.env` under `<mur_home>` is a credential file by convention, and
+        // `commander/.env` really does hold SLACK_BOT_TOKEN,
+        // SLACK_SIGNING_SECRET, SLACK_APP_TOKEN and ANTHROPIC_API_KEY. Denying
+        // `commander/signing.key` alone missed it — the third time this list
+        // proved incomplete.
+        if path.file_name().is_some_and(|n| n == ".env") && path.starts_with(&self.mur_home) {
+            return Some("a .env file under MUR's home — credentials by convention");
+        }
+        if path == self.mur_home.join("runtime").join("vlc.json") {
+            return Some("the VLC control password");
+        }
         if path.starts_with(self.mur_home.join("actions-runner")) {
             return Some(
                 "a self-hosted CI runner's credentials — they authenticate as \
@@ -244,6 +255,8 @@ impl LaunchChain {
             self.mur_home.join("conversations"),
             self.mur_home.join("telemetry"),
             self.mur_home.join("traces"),
+            self.mur_home.join("commander").join(".env"),
+            self.mur_home.join("runtime").join("vlc.json"),
         ]
     }
 
@@ -409,6 +422,8 @@ mod tests {
             mur.join("conversations"),
             mur.join("telemetry"),
             mur.join("traces"),
+            mur.join("commander").join(".env"),
+            mur.join("runtime").join("vlc.json"),
         ] {
             assert!(
                 chain.protects_read(&p).is_some(),

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -476,6 +476,8 @@ mod tests {
             "conversations",
             "telemetry",
             "traces",
+            "commander/.env",
+            "runtime/vlc.json",
         ] {
             let full = tmp.path().join(p);
             for verb in ["file-read*", "file-write*"] {

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -471,6 +471,11 @@ mod tests {
             "commander/signing.key",
             "mobile/pair-token",
             "actions-runner",
+            "queue",
+            "session",
+            "conversations",
+            "telemetry",
+            "traces",
         ] {
             let full = tmp.path().join(p);
             for verb in ["file-read*", "file-write*"] {


### PR DESCRIPTION
#850. Third class after sibling keys (#975) and the credential store (#976) —
and the one holding the most material.

## The finding

`~/.mur/queue/events.jsonl` is the CLI hook pipeline's event log: **every tool
call, including shell command lines verbatim.** On this machine it is **934 MB**
and was readable by every agent.

**It is not redacted.** `inject::queue::enqueue_to` serialises the event and
appends it; nothing in `capture/` filters first. The redaction chokepoint that
*does* exist — `telemetry_writer::redact_envelope`, B0 rule 9 — belongs to a
**different writer** on the runtime's own telemetry path and never sees this
file. Rule 9 is named "telemetry sink redaction", which is how I assumed the
queue was covered until I checked.

So any credential that ever appeared on a command line is here in plain text.
Scanning the first 200 MB (**counting only, never printing**):

| pattern | lines matching |
|---|---|
| `sk-ant-` shape | 21 |
| `ghp_` / `gho_` | 12 |
| `AKIA` | 8 |
| `Authorization` header | 180 |

Some will be documentation or examples. `AKIA[0-9A-Z]{16}` and a 20+ char
`sk-ant-` are specific enough that I would not assume so.

## The other four

`session/` (recordings), `conversations/`, `telemetry/`, `traces/` — same
class: a record of the user's work, not state an agent operates on.

**Nothing in `mur-agent-runtime` reads any of the five.** Verified by grep for
`join("queue")` / `join("session")` / `join("conversations")` — no hits.

## The change

Denied as subtrees, read and write, at the grant gate and in the SBPL — same
mechanism as #976, so a read that never touches the file tools is stopped too.

`skills/`, `channels/` and `artifacts/` stay readable, guarded by
`the_grant_gates_still_allow_the_ordinary_stores`.

## Verification

Against the real profile on this machine:

```
queue/events.jsonl  DENIED      skills     READABLE
session             DENIED      channels   READABLE
conversations       DENIED      artifacts  READABLE
telemetry           DENIED
traces              DENIED
```

```
cargo test -p mur-agent-runtime --lib → 536 passed; 0 failed
cargo clippy --all-targets → 0 errors     cargo fmt --check → clean
```

Negative control: removing the gate fails
`the_grant_gates_refuse_the_credential_store` on `queue`.

## What this does NOT fix

The underlying problem is that **the queue records credentials unredacted and
grows without bound** — 934 MB and rising. Denying agents is confinement, not a
fix for what gets written. That needs its own change: either redaction on the
capture path (making rule 9's promise true for this writer too) or rotation, or
both. Filing separately rather than folding it in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
