### PR TITLE
fix(capture): redact the queue before it reaches disk

### DIFF
--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -156,76 +156,20 @@ pub fn scan_for_secrets(body: &str) -> Option<&'static str> {
 ///
 /// Returns `Cow::Borrowed` when nothing matched so the common
 /// hot path (no secrets present) avoids any allocation.
+/// Replace credential-shaped substrings with `[REDACTED:<kind>]`.
+///
+/// Thin forwarder: the implementation moved to `mur_common::redact` so the
+/// CLI's capture queue writer can share it (#979). B0 rule 9 is named
+/// "telemetry sink redaction" and used to cover only this crate's writer.
 pub fn redact_secrets(input: &str) -> std::borrow::Cow<'_, str> {
-    // TODO(M1): collapse into mur-common::skill::scan::secrets
-    use regex::Regex;
-    use std::borrow::Cow;
-    use std::sync::OnceLock;
-
-    static REDACT_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
-    let patterns = REDACT_PATTERNS.get_or_init(|| {
-        vec![
-            // OpenAI / Anthropic API keys
-            (Regex::new(r"\bsk-[a-zA-Z0-9]{20,}\b").unwrap(), "openai_key"),
-            (Regex::new(r"\bsk-ant-[a-zA-Z0-9-]{20,}\b").unwrap(), "anthropic_key"),
-            // AWS access keys
-            (Regex::new(r"\bAKIA[0-9A-Z]{16}\b").unwrap(), "aws_access_key"),
-            (Regex::new(r"\baws_secret_access_key\s*[:=]\s*[A-Za-z0-9/+=]{40}\b").unwrap(), "aws_secret_key"),
-            // GitHub PAT
-            (Regex::new(r"\bghp_[A-Za-z0-9]{36}\b").unwrap(), "github_pat"),
-            (Regex::new(r"\bghs_[A-Za-z0-9]{36}\b").unwrap(), "github_app_token"),
-            // GCP service account / API key
-            (Regex::new(r"\bAIza[0-9A-Za-z_-]{35}\b").unwrap(), "gcp_api_key"),
-            // JWT (3 base64url segments separated by dots)
-            (Regex::new(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b").unwrap(), "jwt"),
-            // PEM private key
-            (Regex::new(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----").unwrap(), "pem_private_key"),
-            // Slack webhook
-            (Regex::new(r"\bhooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+\b").unwrap(), "slack_webhook"),
-            // Generic .env-style assignment with high-entropy value
-            (Regex::new(r"(?i)\b(api_key|api_secret|secret_key|access_token|password|token)\s*[:=]\s*[A-Za-z0-9_\-./+=]{20,}\b").unwrap(), "env_assignment"),
-        ]
-    });
-
-    let mut out: Cow<'_, str> = Cow::Borrowed(input);
-    for (rx, label) in patterns {
-        if rx.is_match(&out) {
-            let replacement = format!("[REDACTED:{label}]");
-            out = Cow::Owned(rx.replace_all(&out, replacement.as_str()).into_owned());
-        }
-    }
-    out
+    mur_common::redact::redact_secrets(input)
 }
 
-/// Replace home-directory-style absolute paths with `~/`. Catches
-/// macOS `/Users/<user>/`, Linux `/home/<user>/`, and Windows
-/// `C:\Users\<user>\` so error messages don't leak the OS user
-/// account name in telemetry. Conservative: only the username
-/// portion is collapsed; the trailing path is preserved so
-/// debugging context survives.
+/// Replace home-directory-style absolute paths with `~/`.
+///
+/// Thin forwarder — see `redact_secrets`.
 pub fn redact_home_path(input: &str) -> std::borrow::Cow<'_, str> {
-    use regex::Regex;
-    use std::borrow::Cow;
-    use std::sync::OnceLock;
-
-    static RE_UNIX: OnceLock<Regex> = OnceLock::new();
-    static RE_MAC: OnceLock<Regex> = OnceLock::new();
-    static RE_WIN: OnceLock<Regex> = OnceLock::new();
-
-    let unix = RE_UNIX.get_or_init(|| Regex::new(r"/home/[^/\s]+/").unwrap());
-    let mac = RE_MAC.get_or_init(|| Regex::new(r"/Users/[^/\s]+/").unwrap());
-    let win = RE_WIN.get_or_init(|| Regex::new(r"(?i)[A-Z]:\\Users\\[^\\\s]+\\").unwrap());
-
-    let mut out: Cow<'_, str> = Cow::Borrowed(input);
-    for rx in [unix, mac] {
-        if rx.is_match(&out) {
-            out = Cow::Owned(rx.replace_all(&out, "~/").into_owned());
-        }
-    }
-    if win.is_match(&out) {
-        out = Cow::Owned(win.replace_all(&out, "~\\").into_owned());
-    }
-    out
+    mur_common::redact::redact_home_path(input)
 }
 
 #[cfg(test)]

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -56,6 +56,7 @@ pub mod pattern;
 pub mod permissions;
 pub mod pipeline;
 pub mod project;
+pub mod redact;
 pub mod removable_volume;
 pub mod route;
 pub mod schedule;

--- a/mur-common/src/redact.rs
+++ b/mur-common/src/redact.rs
@@ -1,0 +1,117 @@
+//! One redaction chokepoint, shared by every writer that puts text on disk.
+//!
+//! This lived in `mur-agent-runtime::hooks::b0_helpers` and was reachable only
+//! from the runtime's own telemetry writer. B0 rule 9 is named "telemetry sink
+//! redaction", which reads like a guarantee about everything MUR writes — it
+//! was not. The CLI hook pipeline's capture queue
+//! (`mur-core::inject::queue`) went to disk unredacted, and on a real install
+//! accumulated 934 MB of verbatim command lines including API keys (#979).
+//!
+//! It sits in `mur-common` because both `mur-agent-runtime` and `mur-core`
+//! write text, and neither may depend on the other for it.
+//!
+//! `mur-common::skill::scan::secrets` DETECTS secrets and reports findings;
+//! this module REPLACES them. The two are deliberately separate: a scanner
+//! that silently rewrote its input would be a surprising scanner.
+
+pub fn redact_secrets(input: &str) -> std::borrow::Cow<'_, str> {
+    // TODO(M1): collapse into mur-common::skill::scan::secrets
+    use regex_lite::Regex;
+    use std::borrow::Cow;
+    use std::sync::OnceLock;
+
+    static REDACT_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+    let patterns = REDACT_PATTERNS.get_or_init(|| {
+        vec![
+            // OpenAI / Anthropic API keys
+            (Regex::new(r"\bsk-[a-zA-Z0-9]{20,}\b").unwrap(), "openai_key"),
+            (Regex::new(r"\bsk-ant-[a-zA-Z0-9-]{20,}\b").unwrap(), "anthropic_key"),
+            // AWS access keys
+            (Regex::new(r"\bAKIA[0-9A-Z]{16}\b").unwrap(), "aws_access_key"),
+            (Regex::new(r"\baws_secret_access_key\s*[:=]\s*[A-Za-z0-9/+=]{40}\b").unwrap(), "aws_secret_key"),
+            // GitHub PAT
+            (Regex::new(r"\bghp_[A-Za-z0-9]{36}\b").unwrap(), "github_pat"),
+            (Regex::new(r"\bghs_[A-Za-z0-9]{36}\b").unwrap(), "github_app_token"),
+            // GCP service account / API key
+            (Regex::new(r"\bAIza[0-9A-Za-z_-]{35}\b").unwrap(), "gcp_api_key"),
+            // JWT (3 base64url segments separated by dots)
+            (Regex::new(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b").unwrap(), "jwt"),
+            // PEM private key
+            (Regex::new(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----").unwrap(), "pem_private_key"),
+            // Slack webhook
+            (Regex::new(r"\bhooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+\b").unwrap(), "slack_webhook"),
+            // Generic .env-style assignment with high-entropy value
+            (Regex::new(r"(?i)\b(api_key|api_secret|secret_key|access_token|password|token)\s*[:=]\s*[A-Za-z0-9_\-./+=]{20,}\b").unwrap(), "env_assignment"),
+        ]
+    });
+
+    let mut out: Cow<'_, str> = Cow::Borrowed(input);
+    for (rx, label) in patterns {
+        if rx.is_match(&out) {
+            let replacement = format!("[REDACTED:{label}]");
+            out = Cow::Owned(rx.replace_all(&out, replacement.as_str()).into_owned());
+        }
+    }
+    out
+}
+
+/// Replace home-directory-style absolute paths with `~/`. Catches
+/// macOS `/Users/<user>/`, Linux `/home/<user>/`, and Windows
+/// `C:\Users\<user>\` so error messages don't leak the OS user
+/// account name in telemetry. Conservative: only the username
+/// portion is collapsed; the trailing path is preserved so
+/// debugging context survives.
+pub fn redact_home_path(input: &str) -> std::borrow::Cow<'_, str> {
+    use regex_lite::Regex;
+    use std::borrow::Cow;
+    use std::sync::OnceLock;
+
+    static RE_UNIX: OnceLock<Regex> = OnceLock::new();
+    static RE_MAC: OnceLock<Regex> = OnceLock::new();
+    static RE_WIN: OnceLock<Regex> = OnceLock::new();
+
+    let unix = RE_UNIX.get_or_init(|| Regex::new(r"/home/[^/\s]+/").unwrap());
+    let mac = RE_MAC.get_or_init(|| Regex::new(r"/Users/[^/\s]+/").unwrap());
+    let win = RE_WIN.get_or_init(|| Regex::new(r"(?i)[A-Z]:\\Users\\[^\\\s]+\\").unwrap());
+
+    let mut out: Cow<'_, str> = Cow::Borrowed(input);
+    for rx in [unix, mac] {
+        if rx.is_match(&out) {
+            out = Cow::Owned(rx.replace_all(&out, "~/").into_owned());
+        }
+    }
+    if win.is_match(&out) {
+        out = Cow::Owned(win.replace_all(&out, "~\\").into_owned());
+    }
+    out
+}
+
+/// Redact every string leaf of a JSON value in place.
+///
+/// The shape the telemetry writer already used, moved here so both writers
+/// share it. Walking the tree rather than regexing the serialised line is the
+/// safe form: a replacement lands inside a JSON string and cannot break the
+/// structure around it.
+pub fn redact_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => {
+            let stage1 = redact_secrets(s);
+            let stage2 = redact_home_path(&stage1);
+            // Only allocate-and-replace if something actually changed.
+            if stage2 != *s {
+                *s = stage2.into_owned();
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                redact_value(item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                redact_value(v);
+            }
+        }
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) | serde_json::Value::Null => {}
+    }
+}

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -13,7 +13,18 @@ pub fn enqueue(event: &NormalizedEvent) -> Result<()> {
 }
 
 pub fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
-    let line = serde_json::to_string(event)? + "\n";
+    // Redact before the line reaches disk (#979). This file records shell
+    // command lines verbatim, so anything ever typed on one — an API key in an
+    // argument, an Authorization header, a token in an env assignment — landed
+    // here in plain text. B0 rule 9's "telemetry sink redaction" covers the
+    // runtime's own writer and never saw this one.
+    //
+    // Walk the JSON rather than regexing the serialised line: a replacement
+    // then lands inside a string and cannot break the structure around it.
+    // Same shape the telemetry writer has always used, now shared.
+    let mut value = serde_json::to_value(event)?;
+    mur_common::redact::redact_value(&mut value);
+    let line = serde_json::to_string(&value)? + "\n";
     let mut f = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -64,6 +75,39 @@ mod tests {
             duration_ms: None,
             is_duration_record: false,
         }
+    }
+
+    /// #979: this file records shell command lines verbatim, so a credential
+    /// typed on one used to land here in plain text. The chokepoint is
+    /// `enqueue_to` — every producer goes through it, so nothing has to
+    /// remember to redact.
+    #[test]
+    fn a_secret_in_a_command_line_never_reaches_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+
+        let mut ev = make_event("hello");
+        ev.tool_called = Some("Bash".into());
+        ev.tool_input = Some(serde_json::json!({
+            "command": "curl -H 'Authorization: Bearer x' https://api.example.com",
+            "key": "sk-ant-abcdefghij0123456789klmnopqrst",
+        }));
+        enqueue_to(&ev, &path).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !written.contains("sk-ant-abcdefghij0123456789klmnopqrst"),
+            "the API key reached disk:\n{written}"
+        );
+        assert!(
+            written.contains("[REDACTED:"),
+            "nothing was redacted at all:\n{written}"
+        );
+        // Still a valid JSON line — redacting a string leaf must not break the
+        // structure around it, which is why this walks the value rather than
+        // regexing the serialised line.
+        let parsed: serde_json::Value = serde_json::from_str(written.trim()).unwrap();
+        assert_eq!(parsed["tool_called"], "Bash");
     }
 
     #[test]


### PR DESCRIPTION
#979, **first half**. Rotation is the other half and is not here.

## The gap

`~/.mur/queue/events.jsonl` records every tool call the CLI hooks see,
including **shell command lines verbatim**. `inject::queue::enqueue_to`
serialised the event and appended it with no filtering.

On a live install: **934 MB**, and a 200 MB sample matched 21 `sk-ant-` shapes,
12 GitHub tokens, 8 AWS key ids, 180 Authorization headers.

The redaction that exists — B0 rule 9, **"telemetry sink redaction"** — belongs
to `mur-agent-runtime`'s own telemetry writer and never saw this file. The name
reads like a guarantee about everything MUR writes. It is not, and that is what
made this easy to miss: I assumed the queue was covered until I read the writer.

## The change

The implementation moves **down** instead of being duplicated:

- `mur_common::redact` now holds `redact_secrets`, `redact_home_path` and
  `redact_value`.
- `b0_helpers` keeps its public functions as thin forwarders — every existing
  caller and the rule 7 / 8 / 9 tests are untouched.
- `mur-common` is where it belongs: both crates write text and neither may
  depend on the other. The old code even carried
  `TODO(M1): collapse into mur-common`.

`enqueue_to` walks the serialised JSON and redacts **string leaves** rather
than regexing the line — the shape the telemetry writer already used. A
replacement then lands inside a string and cannot break the structure around
it, which the test verifies by re-parsing what was written.

The chokepoint is `enqueue_to` itself, so no producer has to remember to call
anything.

`mur-common` uses `regex-lite` rather than `regex`; the patterns port
unchanged.

## Verification

```
mur-common          824 passed; 0 failed
mur-agent-runtime   536 passed; 0 failed
mur-core inject      88 passed; 0 failed
b0 rule7 / rule8 / telemetry integration tests — all ok
clippy --all-targets → clean     fmt --check → clean
```

Negative control: commenting out the `redact_value` call fails
`a_secret_in_a_command_line_never_reaches_disk`.

## One thing clippy caught that tests did not

My first insertion left a stray `#[test]` above my own function and stripped it
from `enqueue_to_writes_valid_json_line`. That test **silently stopped running**
— while the count stayed at 9, because mine had been registered twice. The
number looked identical and meant something different.

Repaired; all nine are distinct now. Worth saying because "9 passed" was true
both before and after.

## What this does not do

**Nothing about the 934 MB already on disk.** Redaction applies to what is
written from now on. The existing file still holds everything it held this
morning — #978 denies agents reading it, which is confinement, not cleanup.

Rotation, and what to do with the existing file, stay open in #979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
