### PR TITLE
fix(capture): stamp queue records, and make hook stats state its window

### DIFF
--- a/mur-core/src/cmd/hook.rs
+++ b/mur-core/src/cmd/hook.rs
@@ -517,8 +517,10 @@ pub(crate) async fn cmd_hook_session_start(tool: &str) -> Result<()> {
 pub(crate) fn cmd_hook_stats() -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
     let queue_path = home.join(".mur").join("queue").join("events.jsonl");
-    let events = crate::inject::queue::read_all_events(&queue_path);
-    let stats = crate::inject::stats::compute(&events);
+    // Records, not events: the write-time metadata is what lets the report say
+    // which window it covers (#979).
+    let records = crate::inject::queue::read_all_records(&queue_path);
+    let stats = crate::inject::stats::compute_records(&records);
     let output = crate::inject::stats::format_stats(&stats, &queue_path.display().to_string());
     print!("{output}");
     Ok(())

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -24,6 +24,20 @@ pub fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
     // Same shape the telemetry writer has always used, now shared.
     let mut value = serde_json::to_value(event)?;
     mur_common::redact::redact_value(&mut value);
+    // Stamp WHEN this was recorded (#979). Deliberately added here rather than
+    // as a `NormalizedEvent` field: the event models what the hook reported,
+    // the time models when the queue wrote it — different owners. Keeping it
+    // out of the struct also leaves the 23 literal constructions alone.
+    //
+    // Without it nothing in 454,874 records knows when it happened, so
+    // rotation cannot be age-based and `mur hook stats` cannot say what period
+    // it covers. Stamped after redaction, so it can never itself be redacted.
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "recorded_at".to_string(),
+            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+        );
+    }
     let line = serde_json::to_string(&value)? + "\n";
     let mut f = std::fs::OpenOptions::new()
         .create(true)
@@ -108,6 +122,36 @@ mod tests {
         // regexing the serialised line.
         let parsed: serde_json::Value = serde_json::from_str(written.trim()).unwrap();
         assert_eq!(parsed["tool_called"], "Bash");
+    }
+
+    /// #979: an append-only log whose records do not know when they happened
+    /// cannot be rotated by age, and its stats command cannot say what period
+    /// it covers. Stamped by the WRITER, after redaction so the timestamp
+    /// itself can never be redacted away.
+    #[test]
+    fn every_written_record_carries_when_it_was_recorded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        enqueue_to(&make_event("hello"), &path).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(written.trim()).unwrap();
+        let ts = v["recorded_at"].as_str().expect("no recorded_at");
+        chrono::DateTime::parse_from_rfc3339(ts)
+            .unwrap_or_else(|e| panic!("recorded_at is not RFC3339: {ts} ({e})"));
+    }
+
+    /// The reader must not care that the writer adds a field it does not model
+    /// — otherwise stamping the record would break every existing consumer.
+    #[test]
+    fn the_reader_still_parses_a_stamped_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        enqueue_to(&make_event("hi"), &path).unwrap();
+
+        let back = read_all_events(&path);
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].query.as_deref(), Some("hi"));
     }
 
     #[test]

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -47,6 +47,42 @@ pub fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// One line of the queue: the event the hook reported, plus the metadata the
+/// queue itself added when it wrote the line.
+///
+/// `recorded_at` is `None` for records written before stamping existed (#982).
+/// Absence means "before stamping", never "error" — treating it as an error
+/// would make the first report after that change cover nothing.
+#[derive(Debug, Clone)]
+pub struct QueueRecord {
+    pub recorded_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub event: NormalizedEvent,
+}
+
+/// Read the queue as records, keeping the write-time metadata that
+/// `read_all_events` drops. Malformed lines are skipped, as there.
+pub fn read_all_records(path: &Path) -> Vec<QueueRecord> {
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| {
+            let value: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+            let recorded_at = value
+                .get("recorded_at")
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&chrono::Utc));
+            let event: NormalizedEvent = serde_json::from_value(value).ok()?;
+            Some(QueueRecord { recorded_at, event })
+        })
+        .collect()
+}
+
 /// Read all events from the queue file. Returns an empty Vec if the file
 /// does not exist or cannot be read. Malformed JSON lines are silently skipped
 /// so a corrupt line never crashes the stats command.

--- a/mur-core/src/inject/stats.rs
+++ b/mur-core/src/inject/stats.rs
@@ -14,9 +14,29 @@ pub struct HookStats {
     pub latency_p50_ms: Option<u64>,
     pub latency_p95_ms: Option<u64>,
     pub latency_p99_ms: Option<u64>,
+    /// The window these numbers actually describe. `None` when no record in
+    /// the file carries a timestamp — which is every record written before
+    /// #982, and is why this is reported rather than assumed.
+    pub window_start: Option<chrono::DateTime<chrono::Utc>>,
+    pub window_end: Option<chrono::DateTime<chrono::Utc>>,
+    /// Records with no `recorded_at`. They still count toward every other
+    /// number here; they simply cannot say when they happened.
+    pub undated: usize,
 }
 
 #[allow(dead_code)] // called from cmd::hook_stats in Task 3
+/// Compute over records, keeping the write-time window. `compute` is retained
+/// for callers that have only events and therefore cannot describe a window.
+pub fn compute_records(records: &[crate::inject::queue::QueueRecord]) -> HookStats {
+    let events: Vec<NormalizedEvent> = records.iter().map(|r| r.event.clone()).collect();
+    let mut stats = compute(&events);
+    let dated: Vec<_> = records.iter().filter_map(|r| r.recorded_at).collect();
+    stats.undated = records.len() - dated.len();
+    stats.window_start = dated.iter().min().copied();
+    stats.window_end = dated.iter().max().copied();
+    stats
+}
+
 pub fn compute(events: &[NormalizedEvent]) -> HookStats {
     let mut by_kind: HashMap<String, usize> = HashMap::new();
     let mut by_provider: HashMap<String, usize> = HashMap::new();
@@ -66,6 +86,11 @@ pub fn compute(events: &[NormalizedEvent]) -> HookStats {
         latency_p50_ms: percentile(&durations, 50.0),
         latency_p95_ms: percentile(&durations, 95.0),
         latency_p99_ms: percentile(&durations, 99.0),
+        // `compute` sees events only, so it cannot know the window. Filled in
+        // by `compute_records`, which has the write-time metadata.
+        window_start: None,
+        window_end: None,
+        undated: 0,
     }
 }
 
@@ -74,6 +99,25 @@ pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
     if stats.total == 0 {
         return format!("No hook events recorded yet.\nQueue: {queue_path}\n");
     }
+
+    // Say what these numbers cover. Without this the totals are "since
+    // whenever this file started", which the file cannot tell you — and after
+    // rotation they would silently describe a different, also-unstated window.
+    let window = match (stats.window_start, stats.window_end) {
+        (Some(a), Some(b)) if stats.undated == 0 => {
+            format!("Window: {} .. {}\n", a.to_rfc3339(), b.to_rfc3339())
+        }
+        (Some(a), Some(b)) => format!(
+            "Window: {} .. {} (+{} undated record(s) written before timestamping)\n",
+            a.to_rfc3339(),
+            b.to_rfc3339(),
+            stats.undated
+        ),
+        _ => format!(
+            "Window: unknown — none of the {} record(s) carries a timestamp\n",
+            stats.undated
+        ),
+    };
 
     // Compute column width from the widest label we'll print
     let kinds = ["Prompt", "Tool", "Stop", "SessionStart"];
@@ -89,6 +133,7 @@ pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
 
     let mut out = String::new();
     out.push_str(&format!("Hook events  ({})\n", queue_path));
+    out.push_str(&format!("  {window}"));
     out.push_str(&format!("  Total:     {}\n", stats.total));
     out.push_str(&format!("  Sessions:  {}\n", stats.unique_sessions));
 
@@ -137,6 +182,88 @@ pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #979: the totals used to be "since whenever this file started", which
+    /// the file could not tell you — and after rotation they would describe a
+    /// different, equally unstated window. The report has to say what it
+    /// covers, including when it cannot.
+    #[test]
+    fn the_report_states_the_window_it_covers() {
+        use crate::inject::queue::QueueRecord;
+        let t0 = chrono::Utc::now() - chrono::Duration::hours(3);
+        let t1 = chrono::Utc::now();
+        let recs = vec![
+            QueueRecord {
+                recorded_at: Some(t0),
+                event: prompt_ev("a"),
+            },
+            QueueRecord {
+                recorded_at: Some(t1),
+                event: prompt_ev("b"),
+            },
+        ];
+        let out = format_stats(&compute_records(&recs), "/tmp/q.jsonl");
+        assert!(out.contains("Window:"), "{out}");
+        assert!(out.contains(&t0.to_rfc3339()), "start missing:\n{out}");
+        assert!(!out.contains("undated"), "nothing is undated here:\n{out}");
+    }
+
+    /// Records written before stamping existed carry no time. They must be
+    /// counted and named, not quietly folded into a window they are not in.
+    #[test]
+    fn undated_records_are_named_not_hidden() {
+        use crate::inject::queue::QueueRecord;
+        let recs = vec![
+            QueueRecord {
+                recorded_at: Some(chrono::Utc::now()),
+                event: prompt_ev("a"),
+            },
+            QueueRecord {
+                recorded_at: None,
+                event: prompt_ev("b"),
+            },
+        ];
+        let out = format_stats(&compute_records(&recs), "/tmp/q.jsonl");
+        assert!(out.contains("1 undated record"), "{out}");
+    }
+
+    /// And when NOTHING is dated — the shape of every queue that predates
+    /// #982 — the report says the window is unknown rather than printing a
+    /// number that looks like a measurement.
+    #[test]
+    fn a_wholly_undated_queue_reports_an_unknown_window() {
+        use crate::inject::queue::QueueRecord;
+        let recs = vec![
+            QueueRecord {
+                recorded_at: None,
+                event: prompt_ev("a"),
+            },
+            QueueRecord {
+                recorded_at: None,
+                event: prompt_ev("b"),
+            },
+        ];
+        let out = format_stats(&compute_records(&recs), "/tmp/q.jsonl");
+        assert!(out.contains("Window: unknown"), "{out}");
+        assert!(out.contains("2 record(s)"), "{out}");
+    }
+
+    fn prompt_ev(q: &str) -> NormalizedEvent {
+        NormalizedEvent {
+            kind: EventKind::Prompt,
+            tool_provider: "claude".into(),
+            query: Some(q.into()),
+            tool_called: None,
+            tool_input: None,
+            stop_reason: None,
+            session_id: Some("s".into()),
+            transcript_path: None,
+            tool_response: None,
+            cwd: None,
+            duration_ms: None,
+            is_duration_record: false,
+        }
+    }
     use crate::inject::event::{EventKind, NormalizedEvent};
 
     fn ev(


### PR DESCRIPTION
#979. **Prerequisite for rotation, not rotation itself.**

## Why this comes first

`NormalizedEvent` has no time field:

```
kind, tool_provider, query, tool_called, tool_input, stop_reason,
session_id, transcript_path, tool_response, cwd, duration_ms, is_duration_record
```

None of the 454,874 records in a real queue knows when it happened. Two things
follow:

1. Rotation cannot be age-based — only size or count.
2. **`mur hook stats` cannot say what period it covers**, and after rotation it
   would report a *different* unknowable window with nothing saying so. The
   number would look identical and mean something else.

(2) is why the stamp lands before rotation rather than with it. Rotating a log
whose only consumer cannot describe its own window turns a slightly-wrong
number into a silently-changing one.

## Where it goes, and why not in the struct

Stamped at the **write boundary**, not as a `NormalizedEvent` field.

The event models what the hook reported; the time models when the queue wrote
it. Different owners, and the queue is the one that knows.

It also matters practically: `NormalizedEvent` has **23 literal
constructions** and **none** uses `..Default::default()`, so adding a field
would have broken all 23 compile sites in order to record something none of
them is responsible for.

Inserted **after** redaction (#981), so the timestamp can never itself be
redacted away.

## The compatibility question, pinned

`read_all_events` is unaffected: the struct carries no `deny_unknown_fields`,
so the extra key parses as before. There is a test for that
(`the_reader_still_parses_a_stamped_record`) because "the writer adds a field
the reader does not model" is only safe while that stays true, and nothing else
would notice if it stopped being true.

## Verification

```
cargo test -p mur-core --lib inject → 90 passed; 0 failed
cargo clippy -p mur-core --all-targets → clean
cargo fmt --check → clean
```

Negative control: disabling the insert fails
`every_written_record_carries_when_it_was_recorded` with `no recorded_at`.

## Note for whoever builds rotation

Existing records have **no** `recorded_at`. A consumer must treat absence as
"recorded before stamping existed", not as an error — otherwise the first
stats run after this lands reports on nothing.

Next in #979: `mur hook stats` reporting its own window, then rotation. The
934 MB already on disk is still untouched by any of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
