### PR TITLE
feat(capture): rotate the queue, newsyslog-style

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -217,6 +217,46 @@ pub struct Config {
     /// Job/fleet/workflow run-status heartbeat tuning (`runs:`).
     #[serde(default)]
     pub runs: RunsConfig,
+
+    /// Capture-queue rotation (`capture:`).
+    #[serde(default)]
+    pub capture: CaptureConfig,
+}
+
+/// Rotation for `~/.mur/queue/events.jsonl`, in the shape FreeBSD's
+/// `newsyslog(8)` uses: rotate past a size, keep a bounded number of
+/// generations, compress all but the newest, drop the oldest.
+///
+/// The point of generations is that nobody has to decide to delete anything.
+/// A 934 MB queue becomes `.0`, then `.1.gz`, and ages out on a policy the
+/// user set rather than on a judgement call someone makes once.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CaptureConfig {
+    /// Rotate once the live file passes this. 64 MB keeps `mur hook stats`
+    /// responsive — parsing is O(file), and 934 MB took minutes.
+    #[serde(default = "default_rotate_at_mb")]
+    pub rotate_at_mb: u64,
+    /// How many rotated generations to keep. `.0` stays uncompressed like
+    /// newsyslog's, the rest are gzipped.
+    #[serde(default = "default_keep_generations")]
+    pub keep_generations: u32,
+}
+
+fn default_rotate_at_mb() -> u64 {
+    64
+}
+
+fn default_keep_generations() -> u32 {
+    5
+}
+
+impl Default for CaptureConfig {
+    fn default() -> Self {
+        Self {
+            rotate_at_mb: default_rotate_at_mb(),
+            keep_generations: default_keep_generations(),
+        }
+    }
 }
 
 /// Post-upgrade settings for `mur update`. Stored under `update:` in
@@ -497,6 +537,10 @@ impl Config {
         // on a zero period — both from one user-edited line.
         if self.runs.heartbeat_interval_secs == 0 {
             self.runs.heartbeat_interval_secs = default_heartbeat_interval_secs();
+        }
+        // A zero rotate size would rotate on every single append.
+        if self.capture.rotate_at_mb == 0 {
+            self.capture.rotate_at_mb = default_rotate_at_mb();
         }
         if self.runs.heartbeat_stale_after_intervals == 0 {
             self.runs.heartbeat_stale_after_intervals = default_heartbeat_stale_after_intervals();

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -7,9 +7,104 @@ use super::event::NormalizedEvent;
 #[allow(dead_code)] // called from cmd::hook in Task 4
 pub fn enqueue(event: &NormalizedEvent) -> Result<()> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    let queue_dir = home.join(".mur").join("queue");
+    let mur_home = home.join(".mur");
+    let queue_dir = mur_home.join("queue");
     std::fs::create_dir_all(&queue_dir)?;
-    enqueue_to(event, &queue_dir.join("events.jsonl"))
+    let path = queue_dir.join("events.jsonl");
+
+    // Checked here rather than inside `enqueue_to` so the pure write path stays
+    // testable without a config, and so rotation reads config exactly once per
+    // append instead of once per test fixture.
+    let cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml"));
+    // A failed rotation must not lose the event that triggered it: warn and
+    // append anyway. The file being too large is a worse day than the file
+    // being too large AND missing this record.
+    if let Err(error) = rotate_if_needed(
+        &path,
+        cfg.capture.rotate_at_mb,
+        cfg.capture.keep_generations,
+    ) {
+        tracing::warn!(%error, "capture queue rotation failed; appending anyway");
+    }
+
+    enqueue_to(event, &path)
+}
+
+/// Rotate the queue when it outgrows its budget, in the shape `newsyslog(8)`
+/// uses: `events.jsonl` → `.0`, `.0` → `.1.gz`, oldest dropped.
+///
+/// No signal to any writer is needed, and that is not an accident of this
+/// implementation — `enqueue_to` opens with `O_APPEND`, writes, and closes
+/// within the call, so nothing holds a descriptor across a rename. A process
+/// that is mid-append keeps writing to the renamed inode, so its line lands in
+/// `.0` rather than being lost.
+///
+/// Two processes deciding to rotate at once WOULD race, so the decision is
+/// taken under a sidecar lock — the same idiom `mur-channel` uses for its
+/// event log, and for the same reason.
+///
+/// Compression does not make the old records safe, only smaller: a rotated
+/// generation still holds whatever was written before redaction existed.
+/// `~/.mur/queue` is denied to agents wholesale (#978), which covers the
+/// generations too — but a backup of `~/.mur` carries them.
+fn rotate_if_needed(path: &Path, rotate_at_mb: u64, keep: u32) -> Result<()> {
+    use std::io::Write as _;
+
+    let len = match std::fs::metadata(path) {
+        Ok(m) => m.len(),
+        Err(_) => return Ok(()),
+    };
+    if len < rotate_at_mb.saturating_mul(1024 * 1024) {
+        return Ok(());
+    }
+
+    let dir = path.parent().unwrap_or(Path::new("."));
+    std::fs::create_dir_all(dir)?;
+    let lock_path = dir.join("rotate.lock");
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    fs2::FileExt::lock_exclusive(&lock)?;
+
+    // Re-check under the lock: another process may have rotated while we
+    // waited, and rotating twice would throw away a generation for nothing.
+    let still_big = std::fs::metadata(path)
+        .map(|m| m.len() >= rotate_at_mb.saturating_mul(1024 * 1024))
+        .unwrap_or(false);
+    if !still_big {
+        fs2::FileExt::unlock(&lock).ok();
+        return Ok(());
+    }
+
+    let gen_path = |n: u32| -> std::path::PathBuf {
+        if n == 0 {
+            path.with_extension("jsonl.0")
+        } else {
+            path.with_extension(format!("jsonl.{n}.gz"))
+        }
+    };
+
+    // Drop the oldest, then shift each generation up one.
+    let _ = std::fs::remove_file(gen_path(keep));
+    for n in (1..keep).rev() {
+        let _ = std::fs::rename(gen_path(n), gen_path(n + 1));
+    }
+    // `.0` is uncompressed (newsyslog keeps the newest that way); compress it
+    // as it becomes `.1.gz`.
+    if gen_path(0).exists() && keep >= 1 {
+        let raw = std::fs::read(gen_path(0))?;
+        let f = std::fs::File::create(gen_path(1))?;
+        let mut enc = flate2::write::GzEncoder::new(f, flate2::Compression::default());
+        enc.write_all(&raw)?;
+        enc.finish()?;
+        let _ = std::fs::remove_file(gen_path(0));
+    }
+    std::fs::rename(path, gen_path(0))?;
+
+    fs2::FileExt::unlock(&lock).ok();
+    Ok(())
 }
 
 pub fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
@@ -188,6 +283,96 @@ mod tests {
         let back = read_all_events(&path);
         assert_eq!(back.len(), 1);
         assert_eq!(back[0].query.as_deref(), Some("hi"));
+    }
+
+    /// The newsyslog shape: past the threshold the live file becomes `.0` and
+    /// a fresh one starts. Nothing is signalled, because nothing holds a
+    /// descriptor across the rename.
+    #[test]
+    fn rotation_moves_the_live_file_aside_and_starts_a_new_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        std::fs::write(&path, vec![b'x'; 2 * 1024 * 1024]).unwrap();
+
+        rotate_if_needed(&path, 1, 5).unwrap();
+
+        assert!(!path.exists(), "the live file should have been moved aside");
+        assert!(path.with_extension("jsonl.0").exists(), "no .0 generation");
+
+        // And the writer just carries on, creating a fresh file.
+        enqueue_to(&make_event("after"), &path).unwrap();
+        assert_eq!(read_all_events(&path).len(), 1);
+    }
+
+    /// Under the threshold nothing happens — rotation must not be a surprise
+    /// that fires on an ordinary append.
+    #[test]
+    fn a_small_queue_is_left_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        enqueue_to(&make_event("small"), &path).unwrap();
+
+        rotate_if_needed(&path, 64, 5).unwrap();
+
+        assert!(path.exists());
+        assert!(!path.with_extension("jsonl.0").exists());
+    }
+
+    /// Generations shift up and the oldest is dropped, so total disk is
+    /// bounded by `keep` — the property that makes "when do we delete the
+    /// 934 MB" a policy rather than a decision.
+    #[test]
+    fn generations_shift_up_and_the_oldest_is_dropped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        let big = vec![b'x'; 2 * 1024 * 1024];
+
+        for _ in 0..4 {
+            std::fs::write(&path, &big).unwrap();
+            rotate_if_needed(&path, 1, 2).unwrap();
+        }
+
+        assert!(path.with_extension("jsonl.0").exists(), "no .0");
+        assert!(
+            path.with_extension("jsonl.1.gz").exists(),
+            ".1 should be gzipped"
+        );
+        assert!(
+            !path.with_extension("jsonl.3.gz").exists(),
+            "kept more generations than configured"
+        );
+    }
+
+    /// `.1` onward is gzipped, and the bytes must survive the round trip —
+    /// a rotated generation nobody can read back is just a slower delete.
+    #[test]
+    fn a_compressed_generation_still_holds_its_records() {
+        use std::io::Read as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("events.jsonl");
+
+        enqueue_to(&make_event("keep-me"), &path).unwrap();
+        let pad = vec![b'\n'; 2 * 1024 * 1024];
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(&pad)
+            .unwrap();
+
+        rotate_if_needed(&path, 1, 3).unwrap(); // live -> .0
+        std::fs::write(&path, vec![b'y'; 2 * 1024 * 1024]).unwrap();
+        rotate_if_needed(&path, 1, 3).unwrap(); // .0 -> .1.gz
+
+        let gz = std::fs::File::open(path.with_extension("jsonl.1.gz")).unwrap();
+        let mut text = String::new();
+        flate2::read::GzDecoder::new(gz)
+            .read_to_string(&mut text)
+            .unwrap();
+        assert!(
+            text.contains("keep-me"),
+            "the record did not survive compression"
+        );
     }
 
     #[test]


### PR DESCRIPTION
#979, the last piece. Redaction (#981) and stamping (#982) are in; this bounds
the file.

## Why newsyslog's shape

It dissolves the question nobody wanted to answer. "Do we delete the 934 MB?"
becomes **"it is `.0`, then `.1.gz`, and it ages out at the generation count you
set"** — a policy, not a judgement someone makes once on somebody else's data.

```
events.jsonl        live
events.jsonl.0      most recent, uncompressed (as newsyslog keeps it)
events.jsonl.1.gz   .. up to keep_generations, oldest dropped
```

## Two things made this cheap, and neither is luck

- **`enqueue_to` opens with `O_APPEND`, writes, and closes inside the call**, so
  nothing holds a descriptor across a rename and **no writer has to be
  signalled**. That is newsyslog's `N` case, for free.
- **`flate2` is already a mur-core dependency**, so `Z` costs nothing either.

## Concurrency, stated

A process mid-append keeps writing to the **renamed inode**, so its line lands
in `.0` rather than being lost.

Two processes deciding to rotate at once *would* race, so the decision is taken
under a sidecar lock and **re-checked inside it** — the idiom `mur-channel`
already uses for its event log. Rotating twice would throw away a generation
for nothing.

A failed rotation **warns and appends anyway**: the file being too large is a
worse day than the file being too large *and* missing the record that noticed.

## Config

`rotate_at_mb` (64) and `keep_generations` (5) under `capture:` in
`config.yaml`. A zero size is clamped at load — it would rotate on every append.

64 MB is chosen **for the consumer, not the disk**: `mur hook stats` parses the
whole file on every run, and 934 MB took minutes.

## What compression does not do

It makes the old records **smaller, not safe**. A rotated generation still holds
whatever was written before redaction existed. #978 denies agents the whole
`queue/` subtree so generations are covered — but a backup of `~/.mur` carries
them.

## Verification

Four tests guarding **both** directions:

| test | guards |
|---|---|
| `rotation_moves_the_live_file_aside_and_starts_a_new_one` | it happens |
| `a_small_queue_is_left_alone` | it does **not** happen under the threshold |
| `generations_shift_up_and_the_oldest_is_dropped` | disk stays bounded |
| `a_compressed_generation_still_holds_its_records` | a generation nobody can read is just a slower delete |

Negative control: disabling the rename fails three of them.
`a_small_queue_is_left_alone` correctly stays green — it guards the other
direction, so a broken rotation should not make it red.

```
cargo nextest run -p mur-core --lib → 2509 passed
cargo test -p mur-common --lib      →  824 passed
clippy --all-targets → clean        fmt --check → clean
```

Note: plain `cargo test` false-reds ~5 shared-state tests in this crate. That is
a known property of this repo (it uses nextest), not this change — I hit it and
checked rather than assuming either way.

## Closes #979?

The three pieces are done: redact, stamp, rotate. Leaving the issue open until
you have seen a rotation happen on a real queue — the 934 MB will rotate on the
next hook event after this ships, and that is the first time any of this meets
a file that big.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
