### PR TITLE
feat(model): doctor names secrets that are plaintext on disk

### DIFF
--- a/mur-core/src/cmd/model_doctor.rs
+++ b/mur-core/src/cmd/model_doctor.rs
@@ -117,6 +117,49 @@ pub fn audit(
 ) -> Vec<Finding> {
     let mut out = Vec::new();
 
+    // 0. Secrets that live on disk as plaintext.
+    //
+    //    Reported, never blocking (design decision, 2026-08-18): `file:` is the
+    //    only backend that works on a headless Linux box with no Secret
+    //    Service daemon, it is what `mur model import` carries between
+    //    machines, and containers materialise secrets as files on purpose. A
+    //    check that failed those would be a gate for something the user cannot
+    //    fix — and this repo already learned where that ends, in eval.yml: a
+    //    gate that fires for things you cannot fix is a gate that gets switched
+    //    off.
+    //
+    //    So the defect this addresses is not that `file:` exists. It is that
+    //    nothing said a plaintext ref was plaintext, which made it look like a
+    //    choice rather than a default nobody revisited.
+    for (key, e) in &reg.models {
+        if let Some(mur_common::secret::SecretRef::File(path)) = &e.secret {
+            // Only name a `connect` target when the candidate actually looks
+            // like a vendor. `vendor_candidates` falls back to the endpoint
+            // host, so an entry pointed at a local gateway yields "127" and
+            // the suggestion becomes `mur model connect 127` — a command that
+            // does nothing, printed with the authority of advice. Caught by
+            // running this against a real registry rather than a fixture.
+            let vendor = e
+                .vendor_candidates()
+                .into_iter()
+                .find(|v| v.chars().all(|c| c.is_ascii_alphabetic() || c == '-'));
+            let fix = match vendor {
+                Some(v) => format!(
+                    "`mur model connect {v}`, or set `secret: keychain:<service>/<account>`"
+                ),
+                None => "set `secret: keychain:<service>/<account>`".to_string(),
+            };
+            out.push(Finding::warn(
+                key.clone(),
+                format!(
+                    "secret is plaintext on disk at {} — readable by anything that can read the path. \
+                     Move it to the keychain: {fix}",
+                    path.display(),
+                ),
+            ));
+        }
+    }
+
     // 1. Registry entries whose model id the catalog has never carried under
     //    any vendor we can name for them. See the module doc for what this does
     //    and does not prove.
@@ -268,6 +311,62 @@ mod tests {
             );
         }
         reg
+    }
+
+    /// A `file:` ref is plaintext on disk. Nothing said so before, which made
+    /// six of them on a real machine look like a choice rather than a default
+    /// nobody revisited.
+    #[test]
+    fn a_plaintext_secret_is_named_with_the_path_and_the_fix() {
+        let mut reg = reg_with(&[("anth", "anthropic", "claude-sonnet-5", None)]);
+        reg.models.get_mut("anth").unwrap().secret = Some(mur_common::secret::SecretRef::File(
+            "/Users/x/.mur/secrets/anthropic.key".into(),
+        ));
+
+        let f = audit(&reg, &[], None);
+        let hit = f
+            .iter()
+            .find(|f| f.subject == "anth")
+            .expect("no finding for the plaintext secret");
+        assert_eq!(
+            hit.level,
+            Level::Warn,
+            "must warn, never error — see the comment in audit"
+        );
+        assert!(
+            hit.detail.contains("/Users/x/.mur/secrets/anthropic.key"),
+            "{}",
+            hit.detail
+        );
+        assert!(
+            hit.detail.contains("mur model connect"),
+            "no fix offered: {}",
+            hit.detail
+        );
+    }
+
+    /// Keychain and env refs are not on disk and must not be flagged —
+    /// otherwise the warning appears on a correctly-configured machine and
+    /// stops meaning anything.
+    #[test]
+    fn a_keychain_or_env_secret_is_not_flagged() {
+        let mut reg = reg_with(&[
+            ("kc", "anthropic", "claude-sonnet-5", None),
+            ("ev", "anthropic", "claude-sonnet-5", None),
+        ]);
+        reg.models.get_mut("kc").unwrap().secret = Some(mur_common::secret::SecretRef::Keychain {
+            service: "mur".into(),
+            account: "anthropic".into(),
+        });
+        reg.models.get_mut("ev").unwrap().secret = Some(mur_common::secret::SecretRef::Env(
+            "ANTHROPIC_API_KEY".into(),
+        ));
+
+        let f = audit(&reg, &[], None);
+        assert!(
+            !f.iter().any(|f| f.detail.contains("plaintext")),
+            "flagged a secret that is not on disk: {f:?}"
+        );
     }
 
     fn agent(name: &str, r: Option<&str>, provider: &str, model: &str) -> AgentModel {


### PR DESCRIPTION
Implements the check settled in #980 — the piece worth building whether or not
either migration happens.

## What it says

```
warn  claude_sonnet: secret is plaintext on disk at
      /Users/david/.mur/secrets/anthropic.key — readable by anything that can
      read the path. Move it to the keychain: `mur model connect anthropic`,
      or set `secret: keychain:<service>/<account>`

6 finding(s): 0 error, 6 warning — nothing was changed
```

Six on this machine, matching the six `file:` refs the #980 audit found.
Nothing said they were plaintext, which is why they looked like a choice rather
than a default nobody revisited.

## Warn, never error — settled in #980

The exit code is unchanged. `file:` is the only backend that works on a
headless Linux box with no Secret Service daemon, it is what `mur model import`
carries between machines, and containers materialise secrets as files on
purpose.

A check that failed those would be a gate for something the user cannot fix,
and `eval.yml` already records where that ends:

> A gate that fires for things you cannot fix is a gate that gets switched off,
> and then the replacement never gets built.

## Running it for real caught a bug in the advice

Against a fixture it looked fine. Against the actual registry it printed:

```
Move it to the keychain: `mur model connect 127`
```

`vendor_candidates` falls back to the **endpoint host**, and those entries point
at the local model gateway on `127.0.0.1`. So the fix line was a command that
does nothing, printed with the authority of advice — worse than no advice.

It now names a vendor only when the candidate looks like one, and otherwise
gives the `keychain:` form alone. All three suggestions on this machine are now
real commands: `anthropic`, `deepseek`, `openai`.

## Tests, both directions

| test | guards |
|---|---|
| `a_plaintext_secret_is_named_with_the_path_and_the_fix` | it fires, with a usable fix |
| `a_keychain_or_env_secret_is_not_flagged` | it does **not** fire on a correctly-configured machine |

The second matters as much as the first: a warning that appears when nothing is
wrong stops meaning anything.

Negative control: disabling the finding fails the first, and correctly leaves
the second green.

```
cargo nextest run -p mur-core --lib → 2507 passed
clippy --all-targets → clean        fmt --check → clean
```

## Not the migration

#980 settled (B)-then-(A): move plaintext off disk, then a private root for
what must stay. This is neither — it is the thing that makes the exposure
visible while those are decided and built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
