### PR TITLE
fix(doctor): report grants the sandbox drops for overlapping the launch chain

### DIFF
--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -260,6 +260,33 @@ impl LaunchChain {
         ]
     }
 
+    /// Split write grants into those the sandbox can install and those it must
+    /// drop whole.
+    ///
+    /// Lives here rather than in `sandbox::linux` because it is pure launch-chain
+    /// path logic that every platform needs — the module comment there already
+    /// said as much ("shared with policy.rs on every platform; only the apply
+    /// path inside is linux-gated"). Being private to that module is also why
+    /// `mur agent doctor` could not report what it computes.
+    ///
+    /// The agent's own home is exempt: on macOS the SBPL deny of the agents tree
+    /// is followed by a re-allow of exactly this directory, and Landlock installs
+    /// it as-is (it contains nothing protected — the own profile/identity
+    /// self-protection is macOS tier 3 only). Without the exemption the symmetric
+    /// overlap test below would also catch the `<mur_home>/agents/<self>`
+    /// force-grant and Linux agents would lose their own home.
+    pub fn partition_grants(&self, grants: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let protected = self.deny_paths();
+        grants.iter().cloned().partition(|g| {
+            if g.starts_with(self.agent_self_home()) {
+                return true;
+            }
+            !protected
+                .iter()
+                .any(|p| p.starts_with(g) || g.starts_with(p))
+        })
+    }
+
     /// Sibling signing keys, as concrete paths for backends that need a list
     /// rather than a predicate. The rule is `protects_read`'s; this is the
     /// enforcement side of it, which until now had no caller — the predicate

--- a/mur-agent-runtime/src/sandbox/linux.rs
+++ b/mur-agent-runtime/src/sandbox/linux.rs
@@ -147,25 +147,11 @@ fn apply_seccomp_denylist() -> anyhow::Result<()> {
 /// path cannot be carved — it is dropped whole. Fail-closed on purpose: the
 /// alternative is installing a rule that hands over the launch chain.
 ///
-/// The agent's own home is exempt: on macOS the SBPL deny of the agents tree
-/// is followed by a re-allow of exactly this directory, and Landlock installs
-/// it as-is (it contains nothing protected — the own profile/identity
-/// self-protection is macOS tier 3 only). Without the exemption the symmetric
-/// overlap test below would also catch the `<mur_home>/agents/<self>`
-/// force-grant and Linux agents would lose their own home.
 pub(crate) fn partition_write_grants(
     grants: &[PathBuf],
     chain: &LaunchChain,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
-    let protected = chain.deny_paths();
-    grants.iter().cloned().partition(|g| {
-        if g.starts_with(chain.agent_self_home()) {
-            return true;
-        }
-        !protected
-            .iter()
-            .any(|p| p.starts_with(g) || g.starts_with(p))
-    })
+    chain.partition_grants(grants)
 }
 
 #[cfg(test)]

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -417,6 +417,52 @@ impl Check {
 ///
 /// `deny` entries are not checked: denying a path that does not exist costs
 /// nothing and is a reasonable thing to write ahead of time.
+/// Report write grants the sandbox drops WHOLE for overlapping the launch chain.
+///
+/// Distinct from `check_filesystem_entitlements`, which reports grants dropped
+/// because their path does not exist. This one is about grants whose path is
+/// fine but whose SCOPE is not: Landlock is a pure allow-list, so a protected
+/// path inside a grant cannot be carved out — the grant is dropped entire,
+/// fail-closed.
+///
+/// `SandboxPolicy::dropped_grants` has recorded exactly this since the launch
+/// chain landed, with a comment saying it is "recorded for the runtime-doctor".
+/// Nothing ever read it. So an agent could be granted a directory, silently
+/// lose the whole grant on Linux, and find out from an errno.
+fn check_dropped_launch_chain_grants(
+    fs: &mur_common::agent::FilesystemEntitlement,
+    agent_home: &std::path::Path,
+) -> Check {
+    let chain = mur_agent_runtime::sandbox::launch_chain::LaunchChain::new(agent_home);
+    let expanded: Vec<std::path::PathBuf> = fs
+        .write
+        .iter()
+        .map(|s| mur_agent_runtime::sandbox::policy::expand_entitlement_path(s))
+        .collect();
+    let (_kept, dropped) = chain.partition_grants(&expanded);
+
+    if dropped.is_empty() {
+        return Check::new(
+            "grant_scope",
+            true,
+            format!(
+                "{} write grant(s), none overlap the launch chain",
+                expanded.len()
+            ),
+        );
+    }
+    let names: Vec<String> = dropped.iter().map(|p| p.display().to_string()).collect();
+    Check::new(
+        "grant_scope",
+        false,
+        format!(
+            "{} write grant(s) contain a launch-chain path and are DROPPED WHOLE by the sandbox (Landlock cannot carve one out): {}. Grant the specific subdirectory instead.",
+            dropped.len(),
+            names.join(", ")
+        ),
+    )
+}
+
 fn check_filesystem_entitlements(fs: &mur_common::agent::FilesystemEntitlement) -> Check {
     let mut missing: Vec<String> = Vec::new();
     let mut granted = 0usize;
@@ -488,6 +534,11 @@ pub fn agent_doctor(mur_home: &std::path::Path, name: &str) -> Result<Vec<Check>
             Err(e) => out.push(Check::new(check_name, false, e.to_string())),
         }
     }
+
+    out.push(check_dropped_launch_chain_grants(
+        &profile.entitlements.filesystem,
+        &mur_home.join("agents").join(name),
+    ));
 
     out.push(check_filesystem_entitlements(
         &profile.entitlements.filesystem,
@@ -564,6 +615,54 @@ mod tests {
             arch.status,
             CheckStatus::Ok | CheckStatus::Skipped
         ));
+    }
+
+    /// `SandboxPolicy::dropped_grants` recorded this from the day the launch
+    /// chain landed, with a comment saying it was "recorded for the
+    /// runtime-doctor". Nothing ever read it. A grant whose SCOPE overlaps the
+    /// launch chain is dropped WHOLE — Landlock has no deny rule to carve one
+    /// out — so an agent could lose an entire grant and learn about it from an
+    /// errno.
+    #[test]
+    fn a_grant_that_swallows_the_launch_chain_is_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("alice");
+        std::fs::create_dir_all(&agent_home).unwrap();
+
+        let fs = mur_common::agent::FilesystemEntitlement {
+            read: vec![],
+            // Contains <mur_home>/agents, which is launch-chain protected.
+            write: vec![mur_home.display().to_string()],
+            deny: vec![],
+        };
+        let c = check_dropped_launch_chain_grants(&fs, &agent_home);
+        assert!(
+            !c.ok,
+            "a swallowing grant must fail the check: {}",
+            c.detail
+        );
+        assert!(c.detail.contains("DROPPED WHOLE"), "{}", c.detail);
+    }
+
+    /// A grant that does not reach the launch chain is installed as written,
+    /// and must not be reported — a check that fires on a correct setup is a
+    /// check people stop reading.
+    #[test]
+    fn an_ordinary_project_grant_is_not_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_home = tmp.path().join("agents").join("alice");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let proj = tmp.path().join("code").join("proj");
+        std::fs::create_dir_all(&proj).unwrap();
+
+        let fs = mur_common::agent::FilesystemEntitlement {
+            read: vec![],
+            write: vec![proj.display().to_string()],
+            deny: vec![],
+        };
+        let c = check_dropped_launch_chain_grants(&fs, &agent_home);
+        assert!(c.ok, "an ordinary grant was reported: {}", c.detail);
     }
 
     /// The check that used to be `Check::new("entitlements", true, "parsed")`


### PR DESCRIPTION
#850. A second silent drop, distinct from the one #972 fixed — and it comes
with a correction to something I wrote in #975/#976.

## First, the correction

I wrote in #975 and repeated in #976 that **"Linux has no read confinement"**.
That is wrong. Reading `sandbox/linux.rs`:

```rust
.handle_access(AccessFs::from_all(abi))   // handles ALL fs access, reads included
...
let read_rules = path_beneath_rules(policy.fs_read.iter(), AccessFs::from_read(abi));
```

Landlock **handles reads and is deny-by-default**: only `fs_read` / `fs_write` /
`fs_exec` paths are permitted. Linux is *structurally more confined* than macOS,
which is `(allow default)` plus denies.

The real asymmetry is the opposite of what I claimed: on Linux the denies I
added in #976/#978 **cannot be expressed at all** — there is no deny rule to
carve a protected path out of a grant. The code comment says so directly:

> Landlock is a pure allow-list, so a grant that contains a protected
> launch-chain path cannot be carved — it is dropped whole, fail-closed.

## The gap this fixes

`SandboxPolicy::dropped_grants` has recorded whole-grant drops since the launch
chain landed, with a comment saying it is *"recorded for the runtime-doctor"*.

Grepping the workspace: **nothing ever read it.** Computed, stored, never shown.
So an agent could lose an entire write grant and find out from an errno.

That is a different failure from #972, which reports grants whose **path does
not exist**. This one is about grants whose path is fine and whose **scope** is
not.

## On this machine

Both checks run, and `pm` fails each for a different reason — which is why they
are two checks:

```
dataml  grant_scope   ~/.mur contains the launch chain -> dropped whole
pm      grant_scope   same
pm      entitlements  2 of 9 paths do not exist -> dropped at seal
qa      both clean
```

## The refactor, and why it is a move rather than a `pub`

`partition_write_grants` moved from `sandbox::linux` to
`LaunchChain::partition_grants`. It is pure launch-chain path logic every
platform needs — linux.rs's own module comment already said so:

> shared with policy.rs on every platform; only the apply path inside is
> linux-gated

Being private to a platform module is exactly why the doctor could not report
what it computes. linux.rs now delegates, so there is still **one**
implementation.

Moving it also avoids making a `linux`-named module public on macOS and
Windows, and the per-cfg visibility edits that would need — a trap this repo
has hit before.

## Verification

```
cargo nextest run -p mur-core -p mur-agent-runtime --lib → 3049 passed
clippy --all-targets → clean     fmt --check → clean
```

Two tests, both directions: a grant that swallows the launch chain is reported;
an ordinary project grant is not — a check that fires on a correct setup is a
check people stop reading.

Negative control: stubbing the partition to drop nothing fails the first and
correctly leaves the second green.

## Still open in #850

Whether `fs_read` should be partitioned the same way. It is **not** today, so on
Linux a read grant covering `~/.mur` exposes the credential store and no deny
can re-close it. Dropping such a grant whole would be consistent — and could
brick an agent that legitimately needs a broad read path. That is a decision
with a canary requirement, not something to slip into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
