### PR TITLE
fix(doctor): surface the silent echo-stub fallback (secret + model resolution)

### DIFF
--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -481,6 +481,36 @@ pub fn agent_doctor(mur_home: &std::path::Path, name: &str) -> Result<Vec<Check>
         None => out.push(Check::new("model_ref", true, "inline model (no ref)")),
     }
 
+    // The runtime resolves model + secret at start and silently degrades to
+    // an echo stub when either fails (`client_builder` logs a warning nobody
+    // sees and carries on) — a dead keychain entry produces a "working" agent
+    // that parrots its input back. Run the exact same resolution here, where
+    // a human is watching. NOTE: on macOS a `keychain:` ref may pop the
+    // authorization prompt; doctor is interactive, which is the right place
+    // for that prompt to happen.
+    match mur_agent_runtime::supervisor::resolve_model_entry(&profile) {
+        Ok(entry) => match &entry.secret {
+            Some(sref) => match sref.resolve_blocking() {
+                Ok(_) => out.push(Check::new("secret", true, format!("'{sref}' resolves"))),
+                Err(e) => out.push(Check::new(
+                    "secret",
+                    false,
+                    format!(
+                        "'{sref}' does NOT resolve ({e}) — at start the runtime silently \
+                         falls back to an echo stub. Fix the secret (`mur agent secret \
+                         {name} set …` or `mur model connect`), then restart the agent."
+                    ),
+                )),
+            },
+            None => out.push(Check::new("secret", true, "model needs no secret")),
+        },
+        Err(e) => out.push(Check::new(
+            "model",
+            false,
+            format!("model resolution failed ({e:#}) — the runtime will start as an echo stub"),
+        )),
+    }
+
     for server in &profile.mcp_servers {
         let check_name = format!("mcp:{}", server.name);
         match crate::cmd::agent_mcp_pin::resolve_command(&server.command) {
@@ -672,6 +702,14 @@ mod tests {
         assert!(
             report.iter().any(|c| c.name == "model_ref" && !c.ok),
             "expected a failing model_ref check, got: {report:?}"
+        );
+        // The dangling ref also fails model resolution, which at runtime
+        // silently becomes an echo stub — doctor must say so.
+        assert!(
+            report
+                .iter()
+                .any(|c| c.name == "model" && !c.ok && c.detail.contains("echo stub")),
+            "expected a failing model-resolution check naming the echo fallback, got: {report:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

When the runtime starts, `client_builder`/`supervisor_runner` resolve the agent's model entry and secret. On any failure — keychain entry missing, dangling `model_ref` — they log a `tracing::warn!` nobody sees and **silently degrade to an echo stub**. The agent starts "successfully" and parrots input back. Field report: "an agent with no secret doesn't error — how do I even debug this?" There was no check anywhere that would say so: `mur agent doctor <name>` validated that `model_ref` exists in `models.yaml` and that MCP commands resolve, but never touched secret resolution.

## Fix

`mur agent doctor <name>` now runs the exact resolution the runtime runs at start (`supervisor::resolve_model_entry`, then `SecretRef::resolve_blocking`) and reports:

- model resolution failed → failing `model` check: "the runtime will start as an echo stub"
- secret does not resolve → failing `secret` check with the remedy (`mur agent secret <name> set …` / `mur model connect`) and the echo-stub consequence spelled out
- healthy states get passing checks, so "secret resolves" is visible too

On macOS a `keychain:` ref can pop the authorization prompt during this check — doctor is interactive, which is exactly where that prompt belongs (vs. dying silently under launchd).

## Verification

- `cargo fmt`, `cargo clippy -p mur-core --all-targets -- -D warnings` clean
- `cargo nextest run -p mur-core agent_doctor`: 2/2 — the existing dangling-`model_ref` test now also asserts the failing `model` check naming the echo fallback

Part 3 of the system-audit fix series. Part 1: #986 (merged), part 2: #987 (start confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)