### PR TITLE
fix(runtime): resolve MCP commands against an augmented PATH, same for checks and spawn

### DIFF
--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -209,20 +209,35 @@ impl StdioMcpClient {
     ) -> Result<Self, McpError> {
         // Resolve a bare `mur-mcp-server` command to the bundled absolute path
         // (ensured under ~/.mur/mcp-servers by the supervisor's self-heal) so it
-        // launches on installs where only `mur` is on PATH. Falls back to the
-        // command as-written when there is no bundled copy to point at.
+        // launches on installs where only `mur` is on PATH. Every other bare
+        // command resolves against the AUGMENTED PATH — the ambient one plus
+        // the standard install dirs a GUI/launchd parent omits — so which
+        // binary `command: node` names does not depend on who spawned the
+        // runtime (terminal vs service vs Hub sidecar), and matches what the
+        // B0 admission checks hashed (`supervisor_runner::mcp_server_binaries`
+        // resolves against the same augmented PATH). Falls back to the
+        // command as-written when nothing resolves, preserving the
+        // add-before-install workflow: the spawn then fails with the OS error.
         let bundled = mur_common::exec::bundled_mcp_server_path();
+        let aug_path = mur_common::exec::augmented_path_var();
         let resolved: std::borrow::Cow<'_, str> =
             if std::path::Path::new(&entry.command).file_name() == bundled.file_name()
                 && bundled.is_file()
             {
                 bundled.to_string_lossy().into_owned().into()
             } else {
-                std::borrow::Cow::Borrowed(entry.command.as_str())
+                match mur_common::exec::resolve_command_in(&aug_path, &entry.command) {
+                    Ok(p) => p.to_string_lossy().into_owned().into(),
+                    Err(_) => std::borrow::Cow::Borrowed(entry.command.as_str()),
+                }
             };
         let mut std_cmd = std::process::Command::new(resolved.as_ref());
         std_cmd
             .args(&entry.args)
+            // The server's own subprocesses (`npx` re-execing node, a shell
+            // step) must resolve identically, so the child gets the augmented
+            // PATH too — ambient entries keep priority.
+            .env("PATH", &aug_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -640,20 +640,26 @@ pub(crate) async fn prepare_runtime(
     let telemetry_emitter: Arc<dyn TelemetryEmitter> =
         Arc::new(WriterTelemetryEmitter::new(writer.sender()));
     let hook_chain = crate::hooks::builder::build_chain(&profile.inner, agent_home, &mur_home);
-    let mcp_server_binaries: Vec<std::path::PathBuf> = profile
-        .inner
-        .mcp_servers
-        .iter()
-        .filter_map(|s| {
-            // PATH-resolve so the B0 signature/pin checks (rules 6 & 11) inspect
-            // the same binary `Command::new` will spawn. A bare `node`/`npx`
-            // taken verbatim is a CWD-relative path that doesn't exist, which
-            // silently skips both checks. Unresolvable → drop (treated as
-            // "uninstalled", matching the soft-fail behaviour in rule 6).
-            let prog = s.command.split_whitespace().next().unwrap_or(&s.command);
-            mur_common::exec::resolve_command(prog).ok()
-        })
-        .collect();
+    let mcp_server_binaries: Vec<std::path::PathBuf> = {
+        // Resolve against the same AUGMENTED PATH the spawn uses
+        // (`mcp_client::spawn`), so the B0 signature/pin checks (rules 6 & 11)
+        // inspect the same binary `Command::new` will exec — including under a
+        // Hub-spawned sidecar whose ambient GUI PATH lacks the standard
+        // install dirs. A bare `node`/`npx` taken verbatim is a CWD-relative
+        // path that doesn't exist, which silently skips both checks.
+        // Unresolvable → drop (treated as "uninstalled", matching the
+        // soft-fail behaviour in rule 6).
+        let aug_path = mur_common::exec::augmented_path_var();
+        profile
+            .inner
+            .mcp_servers
+            .iter()
+            .filter_map(|s| {
+                let prog = s.command.split_whitespace().next().unwrap_or(&s.command);
+                mur_common::exec::resolve_command_in(&aug_path, prog).ok()
+            })
+            .collect()
+    };
 
     // B0 rules 11 + 6: MCP supply-chain admission control. Runs BEFORE the
     // hook chain because it must be able to abort startup — `on_startup` is an

--- a/mur-common/src/exec.rs
+++ b/mur-common/src/exec.rs
@@ -150,15 +150,23 @@ pub fn is_interpreter_command(command: &str) -> bool {
 ///
 /// Returns an error if the binary can't be located.
 pub fn resolve_command(command: &str) -> Result<PathBuf> {
+    let path_var = std::env::var_os("PATH")
+        .ok_or_else(|| anyhow::anyhow!("PATH env var unset; cannot resolve `{command}`"))?;
+    resolve_command_in(&path_var, command)
+}
+
+/// [`resolve_command`] against an explicit PATH value instead of the ambient
+/// env. The runtime resolves MCP commands against [`augmented_path_var`] for
+/// BOTH the B0 admission checks and the actual spawn, so the file that gets
+/// hashed is provably the file that gets exec'd.
+pub fn resolve_command_in(path_var: &std::ffi::OsStr, command: &str) -> Result<PathBuf> {
     let p = Path::new(command);
     if p.is_absolute() || command.contains('/') || command.contains('\\') {
         return p
             .canonicalize()
             .with_context(|| format!("canonicalize {command}"));
     }
-    let path_var = std::env::var_os("PATH")
-        .ok_or_else(|| anyhow::anyhow!("PATH env var unset; cannot resolve `{command}`"))?;
-    for dir in std::env::split_paths(&path_var) {
+    for dir in std::env::split_paths(path_var) {
         let candidate = dir.join(command);
         if candidate.is_file() {
             return candidate
@@ -176,6 +184,35 @@ pub fn resolve_command(command: &str) -> Result<PathBuf> {
         }
     }
     bail!("could not find `{command}` on PATH");
+}
+
+/// The ambient PATH plus the well-known install dirs that GUI/launchd parents
+/// omit (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`).
+///
+/// MCP entries store the command as the user typed it (`node`, `uvx`,
+/// `python3`); which binary that names must not depend on WHO spawned the
+/// runtime. A terminal hands it the user's full PATH and
+/// `mur agent install-service` derives a rich one into the unit file — but a
+/// Hub-spawned sidecar inherits the GUI's minimal PATH, which is how
+/// `command: node` works in a shell and dies under the Hub with nothing
+/// pointing here. Ambient entries keep priority; only missing standard dirs
+/// are appended, so an explicit PATH override still wins.
+pub fn augmented_path_var() -> std::ffi::OsString {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut dirs_list: Vec<PathBuf> = std::env::split_paths(&current).collect();
+    let mut extras: Vec<PathBuf> = vec![
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/usr/local/bin"),
+    ];
+    if let Some(home) = dirs::home_dir() {
+        extras.push(home.join(".local/bin"));
+    }
+    for e in extras {
+        if !dirs_list.contains(&e) {
+            dirs_list.push(e);
+        }
+    }
+    std::env::join_paths(dirs_list).unwrap_or(current)
 }
 
 #[cfg(test)]
@@ -240,6 +277,45 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let resolved = resolve_command(tmp.path().to_str().unwrap()).unwrap();
         assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn augmented_path_appends_standard_dirs_without_reordering_ambient() {
+        // Read-only against the ambient env (other tests resolve on PATH in
+        // parallel, so no set_var here).
+        let ambient: Vec<PathBuf> =
+            std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
+        let aug: Vec<PathBuf> = std::env::split_paths(&augmented_path_var()).collect();
+        assert!(
+            aug.starts_with(&ambient),
+            "ambient PATH must keep priority: {aug:?}"
+        );
+        for d in ["/opt/homebrew/bin", "/usr/local/bin"] {
+            let d = PathBuf::from(d);
+            let in_ambient = ambient.iter().filter(|x| **x == d).count();
+            let in_aug = aug.iter().filter(|x| **x == d).count();
+            // Appended when absent; an ambient PATH that already lists it
+            // (even more than once) is passed through untouched.
+            assert_eq!(
+                in_aug,
+                in_ambient.max(1),
+                "{d:?}: expected append-only-when-absent"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_command_in_uses_the_given_path_not_the_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("fake-mcp");
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        let var = std::env::join_paths([dir.path().to_path_buf()]).unwrap();
+        let found = resolve_command_in(&var, "fake-mcp").unwrap();
+        assert_eq!(found, exe.canonicalize().unwrap());
+        assert!(
+            resolve_command_in(std::ffi::OsStr::new(""), "fake-mcp").is_err(),
+            "an empty path var must not fall back to the ambient PATH"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Field report: adding an MCP server in the Hub required typing `/opt/homebrew/bin/node` as the command — bare `node` (what every other MCP host accepts) failed, with no error pointing at the cause.

Root cause: the runtime spawns MCP children with whatever PATH its own parent had. Three spawn contexts, three PATHs:
- terminal (`mur agent start` detached): the user's full shell PATH — bare `node` works;
- launchd service: the rich PATH `install-service` derives into the plist — works;
- **Hub-spawned sidecar: the GUI's minimal PATH — bare `node` dies.**

A second, quieter defect: the B0 supply-chain admission checks (rules 6/11) resolve commands via `mur_common::exec::resolve_command` (ambient PATH) while the actual spawn used execvp semantics. Under a divergent PATH they can hash a *different* binary than the one exec'd; under a minimal PATH they silently soft-skip while the spawn fails with an unexplained exit. (Read `docs/architecture/mcp-supply-chain.md` first — this PR narrows the gap between "inspected" and "executed"; it does not change what is pinned or enforced.)

## Fix

One PATH, used by both the checks and the spawn:

- **mur-common**: `augmented_path_var()` — the ambient PATH with priority kept, plus the standard install dirs GUI/launchd parents omit (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`), appended only when absent. `resolve_command_in(path, cmd)` resolves against an explicit PATH value; `resolve_command` now delegates to it.
- **mcp_client::spawn**: resolves the entry command against the augmented PATH (the bundled `mur-mcp-server` special case is unchanged; unresolvable commands fall back to as-written, preserving the documented add-before-install workflow), and hands the child the same augmented PATH so the server's own subprocesses (`npx` re-execing node, shell steps) resolve identically.
- **supervisor_runner**: the B0 binary list resolves against the same augmented PATH — what gets hashed is provably what gets exec'd, in every spawn context.

`command: node` now behaves the same under terminal, launchd, and Hub. The Hub form's file-picker UX is a separate (frontend) follow-up; with this change, typing plain `node` simply works.

## Verification

- `cargo fmt`, `cargo check --workspace`, `cargo clippy -p mur-common -p mur-agent-runtime --all-targets -- -D warnings` clean
- `cargo nextest run -p mur-common exec::`: 8/8 — new tests for append-only-when-absent PATH augmentation (read-only against ambient env) and explicit-PATH resolution

Part 5 of the system-audit fix series. Parts: #986, #987 (merged), #988, #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)