### PR TITLE
fix(agent): restart falls back to `launchctl load -w` when kickstart can't see the job

### DIFF
--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -535,6 +535,31 @@ pub(super) fn kickstart_service(name: &str) -> Result<bool> {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
+    if ok {
+        return Ok(true);
+    }
+    // kickstart can only kick a job launchd is tracking. After a manual
+    // `launchctl bootout` (or an unload that outlived a login) the plist is
+    // still on disk but not loaded — returning Ok(false) here sent the caller
+    // to an UNSUPERVISED direct respawn, the exact state a service install
+    // exists to prevent, and the operator's only way back was
+    // `mur agent install-service`. Mirror `mur agent start`: `load -w`
+    // re-registers the job and RunAtLoad brings it up by itself.
+    let Some(home) = dirs::home_dir() else {
+        return Ok(false);
+    };
+    let plist = super::service::service_file_in(&home, name);
+    if !plist.exists() {
+        return Ok(false);
+    }
+    let ok = Command::new("launchctl")
+        .args(["load", "-w"])
+        .arg(&plist)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
     Ok(ok)
 }
 


### PR DESCRIPTION
## Problem

`launchctl kickstart` only works on a job launchd is currently tracking. After a manual `launchctl bootout` (or an unload that survived a login), the plist is still on disk but not loaded: `kickstart_service` returned `Ok(false)` and every restart path (`mur agent restart`, `restart --stale`, `mur update --restart-agents`) silently degraded to an **unsupervised** direct respawn — no `KeepAlive`, no start at login. The only recovery was knowing to run `mur agent install-service <name>` by hand. This is half of the field report "after `mur update` I had to run `install-service mur` and nothing told me why".

## Fix

Mirror what `mur agent start` already does: when kickstart fails and the plist exists, `launchctl load -w` re-registers the job and `RunAtLoad` brings it up. The plist path comes from `service_file_in()` (the module's single source, per its own doc comment) instead of a third inline copy. When the plist is gone entirely, behavior is unchanged (`Ok(false)` → direct respawn with its unsupervised warning).

## Verification

`cargo fmt`, `cargo clippy -p mur-core --all-targets -- -D warnings` clean. This is launchctl orchestration with no unit seam; the fallback mirrors the already-shipped start path.

Part 6 of the system-audit fix series. Parts: #986, #987 (merged), #988, #989, #990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)