### PR TITLE
feat(hitl): park unattended approvals instead of timing them out (P0)

### DIFF
--- a/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
+++ b/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
@@ -1,0 +1,214 @@
+# Unattended HITL: Defer, Don't Time Out
+
+**Status**: P0 in progress (this PR series). P1–P3 designed, not started.
+**Issue thread**: system-audit follow-on (PR series #986–#991); field report: unattended fleet runs burn the 300 s HITL window and fail, and the request dies with the run.
+
+## Problem
+
+MUR's HITL gates are correct in direction (fail-closed, hash-pinned, signed) but
+modeled on an attended operator. Two layers, same assumption:
+
+1. **DAG executor gate** (`mur-core/src/hitl/gate.rs`): writes a `HitlRequest`
+   channel event, then **polls for a `HitlResponse` for 300 s** and denies on
+   timeout. The step fails, the run fails, and — because `hitl_id` is minted
+   fresh per call — the request the human eventually sees is already dead. A
+   later approval has nothing to attach to; the only recovery is a full re-run
+   that mints yet another request.
+2. **Member-runtime tool gate** (`mur-agent-runtime/src/task_runner.rs`): the
+   fleet delegation path passes an empty HITL callback
+   (`loop_run.rs`: `|_hitl| {}`), so the request is discarded and auto-denied
+   after `hitl.timeout_secs`.
+
+The unattended consequences: every gate burns its full window before failing;
+`--loop` re-burns it every iteration; approvals cannot arrive late; and the
+operator learns about all of it the next morning from a failed run. The
+second-order cost is worse: a gate this painful teaches users to run
+`set-mode unrestricted` or demand a blanket `--yes` — the pressure to bypass
+is itself a security cost.
+
+There is also a latent truthfulness bug in the no-channel path
+(`executor/dag.rs`): `needs_approval` + non-TTY + no `--yes` **skips the step
+and reports it successful** (`exit_code: 0`, `StepEventKind::Done`).
+
+## Prior art (checked 2026-08-19)
+
+- **LangGraph** `interrupt()` / `Command(resume)`: a pause is checkpointed
+  state, indefinite, survives process death.
+- **Temporal** signal + durable timer: the official pattern is an escalation
+  ladder (notify → remind → escalate → expiry default), i.e. timeout is a
+  business decision, not an infrastructure constant.
+- **OpenAI Agents SDK** `needsApproval` (optionally a dynamic predicate):
+  run pauses, state serializes for days, `approve()`/`reject()` then resume.
+- **AWS Bedrock** Return of Control: the pending call is handed back up the
+  delegation chain with an invocation id.
+- **A2A v0.3**: `input-required` is a standard **non-terminal** task state; the
+  client re-engages the same task later. MUR's channel already models exactly
+  this (`ChannelState::InputRequired`), so defer is protocol-aligned.
+- **OWASP Agentic (ASI06)**: least privilege, tiered autonomy, HITL only for
+  consequential actions, and explicit warnings about approval fatigue.
+
+Convergent shape everywhere: **a pending approval is durable state, not a
+countdown**, and the human's attention is the scarce resource the architecture
+must budget.
+
+## Design: a three-layer funnel
+
+Every risk-tiered action flows through three layers; each layer exists to
+spend less of the next layer's budget. Consent is never removed — it moves to
+the time and granularity where a human can actually give it.
+
+### Layer 1 — Policy first (consent given earlier) [P1]
+
+Named standing grants in `fleet.yaml`, signed with the fleet bundle:
+
+```yaml
+hitl:
+  mode: defer            # defer | deny | wait   (unattended default: defer)
+  approval_ttl_days: 7
+  grants:
+    - tools: ["write_file", "edit_file"]
+      paths: ["./sandbox/**"]
+      max_uses_per_run: 20
+      expires: 2026-09-19
+```
+
+Evaluation is pure code (scope + counter checks). A model may **narrow or
+escalate** a decision, never widen it. Routine actions die here; this layer is
+the approval-fatigue answer.
+
+### Layer 2 — Divert, don't block (structure) [P0 park; P2 divert]
+
+For `ask` outcomes:
+
+- **Isolatable actions** (file writes) → P2: execute speculatively in an
+  isolated git worktree (the `MUR_PARALLEL_EXEC` machinery); the
+  `HitlRequest` carries the **resulting diff**; approval = merge. The human
+  reviews bytes, not intentions — and pin drift is impossible because the
+  approved artifact is the change itself.
+- **Irreversible actions** (external POST, spend, non-compensable deletes) →
+  P0: park immediately. The step is `blocked`, independent branches continue,
+  and the run terminates as `blocked(waiting_approval)` — a first-class,
+  non-failed outcome that `--loop` treats as "stop, don't burn budget".
+
+### Layer 3 — The human, asynchronously (escalation ladder) [P0 surfaces; P1 ladder]
+
+`HitlRequest` events already reach the Hub "Needs You" inbox
+(`hitl_pending_list`) and phones (the daemon's `watch_channels` broadcasts
+`channel.updated` on every event append). P0 adds precise CLI hints
+(`mur channel approve <cid> <hitl_id>`) at the point of deferral and in
+`mur job/fleet status`. P1 adds the Temporal-style ladder: push (companion /
+mobile / Slack) → remind at T+x → per-fleet expiry action (`deny` default,
+`escalate` optional).
+
+### The learning loop [P3]
+
+Approval history is training data. When a class of action is approved N
+consecutive times, the harvest pipeline **proposes** a standing grant into the
+`mur out` inbox. A human review turns repeated Layer-3 labor into Layer-1
+policy. Proposals are never auto-activated.
+
+## P0 mechanics (this implementation)
+
+### Gate: `Deferred` outcome + durable matching
+
+`gate()` gains a defer mode and, in **both** modes, a resume scan:
+
+1. Compute `action_hash` (tool, input, channel, step, agent — deterministic).
+2. **Resume scan**: newest valid `HitlResponse` whose *payload*
+   `action_hash` matches, signature verifies per-actor, and age ≤ TTL
+   (7 days, `HITL_APPROVAL_TTL`) → return its allow/deny immediately. No new
+   request. This is what lets a re-run (or the next loop iteration) pass a
+   gate approved overnight — and what stops a denied action from re-asking
+   every iteration.
+3. **Dedup scan** (defer mode): an unanswered `HitlRequest` with the same
+   `action_hash` → return `Deferred` with the *existing* `hitl_id`; do not
+   write a duplicate. (Fixes the pile-of-duplicates bug: `hitl_id` is minted
+   per call, so matching must be by `action_hash`, never by `hitl_id`.)
+4. Otherwise write the `HitlRequest` + `InputRequired` transition (existing
+   code) and either poll (wait mode, unchanged 300 s semantics) or return
+   `Deferred` (defer mode).
+
+`GateDecision` gains `deferred: bool` (invariant: `deferred ⇒ !allow`).
+Mode selection: `DagExecOptions.hitl_defer: Option<bool>`; `None` = auto —
+defer when stdin is not a TTY (unattended by definition: daemon ticks,
+schedules, cron), wait when interactive. Explicit config lands in P1's
+`fleet.yaml` `hitl.mode`.
+
+Security invariants preserved: responses verify per-actor signatures
+(v3d-2); the execute boundary still re-verifies the pin (`hitl_drift`
+fail-closed); a resumed approval only ever matches the **exact** action bytes
+it approved; TTL bounds temporal staleness; `--yes` remains unreachable from
+unattended fleet paths.
+
+### Executor: blocked is a first-class outcome
+
+- A `Deferred` gate returns a `StepResult` marked `blocked` — **not** a
+  failure: `on_failure` handling does not fire, and the abort path is not
+  taken.
+- Dependents of a blocked step are transitively marked blocked without
+  executing (rank-order makes a direct-dependency check sufficient).
+  Independent branches run to completion.
+- Terminal accounting: any blocked step and no failed step → the run record
+  is `State::Blocked` (which already exists, renders as "blocked", and is
+  non-terminal), and the channel **stays** `InputRequired` (the gate's own
+  transition; the `Completed`/`Failed` finalizer is skipped).
+- The no-channel `needs_approval` skip-as-success path now reports the step
+  as skipped-not-approved instead of silently succeeding.
+
+### Loop: stop on blocked
+
+A `--loop` iteration whose run ends blocked stops the loop with the pending
+approval ids and the approve command. Rationale: with defer the gate itself is
+nearly free, but each iteration still burns router/member LLM calls; looping
+against an unanswered gate converts budget into nothing. The human approves,
+then re-runs (`mur fleet run` / next schedule tick); the v3c resume cursor
+skips completed steps and the resume scan releases the gate.
+
+### Runtime tool gate (fleet members)
+
+Unchanged in P0 (a mid-turn LLM pause is a checkpointing problem — P2 at the
+earliest). P0 relies on: requests remain visible via the A2A stream to any
+attached surface, and `hitl.timeout_secs` is per-profile tunable. The P1
+ladder gives these requests a push surface within their window.
+
+## Rejected
+
+- **Blanket `--yes` reachable from unattended paths** — stays rejected
+  (`fleet/run.rs` fail-closed comment; OWASP ASI06).
+- **LLM as final approver** — re-introduces the failure class it gates; models
+  may deny or escalate only.
+- **Adopting an external workflow engine** (Temporal et al.) — the signed
+  channel event log already is the durable state; local-first stays.
+- **Timeout-deny as the only mechanism** — burns the window, kills the
+  request, and teaches users to disable the gate entirely.
+
+## Where this lives in code (P0)
+
+| Concern | Location |
+|---|---|
+| Defer mode, resume/dedup scans, TTL | `mur-core/src/hitl/gate.rs` — `gate(.., defer, ..)`, `scan_prior`, `within_approval_ttl` |
+| Blocked propagation, terminal accounting | `mur-core/src/executor/dag.rs` — `RunOutcome`, `StepResult.blocked`, `StepEventKind::Blocked` |
+| Auto mode selection (TTY) | `mur-core/src/executor/dag.rs` — `unattended()`, `DagExecOptions.hitl_defer` |
+| Job status truthfulness | `mur-common/src/fleet.rs` — `JobStatus::Blocked` (non-terminal); `cmd/fleet/run.rs` |
+| Loop stop-on-blocked | `mur-core/src/cmd/fleet/loop_run.rs` — `LoopStop::AwaitingApproval` |
+| Status rendering | `run_status::State::Blocked` (pre-existing), `cmd/job.rs` |
+
+## P0 implementation notes (deviations worth knowing)
+
+- **`PipelineStatus` gained no variant.** A blocked run reports `Skipped` —
+  it does not claim success, and no serialized enum changed. The precise state
+  lives in the run record (`State::Blocked`), the channel (`InputRequired`),
+  and the job (`JobStatus::Blocked`). Add a `Blocked` variant only if a
+  consumer needs to tell "skipped" from "blocked" through that type.
+- **`JobStatus::Blocked` IS new** and deliberately non-terminal
+  (`is_terminal() == false`), because an approval resumes the job. Without it
+  a blocked fleet run fell through to the `Ok(_)` arm in `cmd/fleet/run.rs`
+  and was recorded `done` — claiming work that never ran.
+- **Blocked-ness is inherited per rank**, by checking each step's direct
+  `depends_on` against the blocked set before the rank spawns. Ranks execute
+  in dependency order, so this transitively covers the subgraph without a
+  separate closure pass.
+- **`unattended()` is resolved once per rank**, not per step: every step in a
+  run must agree on whether a human is watching.
+- **The runtime tool gate is unchanged in P0** — see above.
+

--- a/mur-common/src/fleet.rs
+++ b/mur-common/src/fleet.rs
@@ -88,12 +88,17 @@ pub fn fleet_name_from_channel_id(channel_id: &str) -> Option<&str> {
     valid_fleet_name(name).then_some(name)
 }
 
-/// Job status lifecycle: queued → running → {done, failed, canceled}.
+/// Job status lifecycle: queued → running → {done, failed, canceled}, with
+/// `blocked` as a non-terminal detour: the run reached an action that needs a
+/// human and stopped there. An approval resumes it, so it is deliberately NOT
+/// terminal — reporting it as done would claim work nobody did, and reporting
+/// it as failed would claim a fault that did not occur.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum JobStatus {
     Queued,
     Running,
+    Blocked,
     Done,
     Failed,
     Canceled,
@@ -115,6 +120,7 @@ impl JobStatus {
         match self {
             JobStatus::Queued => "queued",
             JobStatus::Running => "running",
+            JobStatus::Blocked => "blocked",
             JobStatus::Done => "done",
             JobStatus::Failed => "failed",
             JobStatus::Canceled => "canceled",

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -57,6 +57,11 @@ pub enum LoopStop {
     /// `done_when: queue-empty` and an iteration found no queued job — the
     /// fleet's work is done because there is none left.
     QueueDrained,
+    /// An iteration stopped at an action awaiting human approval. Looping past
+    /// it would re-spend router and member LLM calls every iteration to arrive
+    /// at the same unanswered question, so the loop stops and hands the
+    /// decision back to a person.
+    AwaitingApproval,
 }
 
 /// Parse a humantime-ish duration: `30s`, `5m`, `2h`, `1d`, or a bare integer
@@ -310,6 +315,7 @@ fn outcome_label(stop: LoopStop) -> &'static str {
         LoopStop::Stopped => "stopped",
         LoopStop::CommanderKilled => "commander-killed",
         LoopStop::QueueDrained => "queue-drained",
+        LoopStop::AwaitingApproval => "awaiting-approval",
     }
 }
 
@@ -538,6 +544,15 @@ pub async fn run_guarded(
                     sp.state = StepState::Running;
                     sp.started_at = Some(now);
                 }
+                StepEventKind::Blocked => {
+                    // Waiting on a human. Not Running (nothing is executing)
+                    // and not Failed (nothing went wrong): park it back at
+                    // Pending, which is what it is — work still to do — and
+                    // say so on its own line so the rail is not silent about
+                    // why the fleet stopped short.
+                    sp.state = StepState::Pending;
+                    println!("⏸ {} awaiting approval", sp.id);
+                }
                 StepEventKind::Done | StepEventKind::Failed => {
                     let done = e.kind == StepEventKind::Done;
                     sp.state = if done {
@@ -589,6 +604,22 @@ pub async fn run_guarded(
             crate::executor::dag::execute_dag(mur_home, &format!("fleet:{name}"), &proc, &opts)
                 .await?;
         iteration += 1;
+        // A blocked iteration reached an action that needs a human and stopped
+        // there. Mark the job blocked (not Done — nothing finished) and leave
+        // the loop: the next iteration would re-run the same steps, re-spend
+        // the same tokens, and arrive at the same unanswered question. The
+        // parked request stays in the channel, so approving it and re-running
+        // picks up where this left off.
+        let blocked = out.status == mur_common::pipeline::PipelineStatus::Skipped;
+        if blocked && let Some(job) = active_job.as_mut() {
+            job.run_id = Some(opts.run_id.clone());
+            job.status = JobStatus::Blocked;
+            job.error = Some("awaiting approval".to_string());
+            let _ = super::jobs::save_job(mur_home, name, job);
+        }
+        if blocked {
+            break LoopStop::AwaitingApproval;
+        }
         // Terminal stamp: mark the queued job Done with the result of this iteration.
         if let Some(job) = active_job.as_mut() {
             job.run_id = Some(opts.run_id.clone());

--- a/mur-core/src/cmd/fleet/run.rs
+++ b/mur-core/src/cmd/fleet/run.rs
@@ -438,6 +438,19 @@ pub async fn cmd_fleet_run(
             }
             // Channel said nothing terminal (empty DAG, no channel routing, or a
             // hard crash before emit): fall back to the exec_result.
+            //
+            // A blocked run lands here BY DESIGN: it deliberately writes no
+            // terminal StateChange, leaving the channel `input-required` so
+            // every surface keeps showing that a human still owes it an
+            // answer. Without this arm it would fall into the `Ok` case below
+            // and be recorded as `done` — claiming work that never ran.
+            (_, Ok(out)) if out.status == mur_common::pipeline::PipelineStatus::Skipped => {
+                job.status = JobStatus::Blocked;
+                job.error = Some(
+                    "awaiting approval — approve the pending request(s), then re-run this fleet"
+                        .to_string(),
+                );
+            }
             (_, Ok(out)) => {
                 job.status = JobStatus::Done;
                 job.result = out.output_text.clone().filter(|t| !t.is_empty());

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -87,6 +87,13 @@ pub struct DagExecOptions<'a> {
     pub input: Option<PipelineOutput>,
     /// `--yes` flag: auto-approve all `needs_approval` steps.
     pub yes: bool,
+    /// What an unanswered risk-tiered gate does. `Some(true)` parks the request
+    /// and marks the step blocked; `Some(false)` waits (polling) for the gate
+    /// timeout. `None` = auto: defer when stdin is not a TTY, because an
+    /// unattended run (daemon tick, schedule, cron, fleet loop) has nobody to
+    /// answer inside the wait window — waiting there only converts the whole
+    /// window into a denial, and kills a request a human could still answer.
+    pub hitl_defer: Option<bool>,
     /// Explicit override of the env classification (P4-ready).
     pub env_class_override: Option<&'a str>,
     /// Variable substitutions: `(name, value)` pairs for `{{name}}` in commands.
@@ -138,6 +145,7 @@ impl<'a> Default for DagExecOptions<'a> {
         Self {
             input: None,
             yes: false,
+            hitl_defer: None,
             env_class_override: None,
             variables: vec![],
             device_id: "cli".to_string(),
@@ -152,12 +160,32 @@ impl<'a> Default for DagExecOptions<'a> {
     }
 }
 
+/// How a DAG run ended. `Blocked` is deliberately not a failure: nothing went
+/// wrong, the run simply reached an action that needs a human and stopped
+/// there. It is also not terminal — an approval resumes it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum RunOutcome {
+    Done,
+    Failed,
+    Blocked,
+}
+
 /// Step-lifecycle event kind for `DagExecOptions.on_step`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StepEventKind {
     Started,
     Done,
     Failed,
+    /// Waiting on a human: the step did not run, and it did not fail.
+    Blocked,
+}
+
+/// True when nothing can answer an approval prompt in the next few minutes:
+/// no TTY on stdin. Daemon ticks, schedules, cron and the fleet loop all land
+/// here, which is exactly where waiting out a gate timeout converts the whole
+/// window into an automatic denial.
+fn unattended() -> bool {
+    !std::io::IsTerminal::is_terminal(&std::io::stdin())
 }
 
 /// Display-only step lifecycle event for progress observers. The callback
@@ -187,6 +215,9 @@ fn apply_step_event(record: &mut crate::run_status::RunState, event: &StepEvent)
         StepEventKind::Started => (crate::run_status::State::Running, Some(now), None),
         StepEventKind::Done => (crate::run_status::State::Done, None, Some(now)),
         StepEventKind::Failed => (crate::run_status::State::Failed, None, Some(now)),
+        // Not ended: a blocked step is expected to run once approved, so it
+        // keeps no end stamp (`mur job status` shows it as still outstanding).
+        StepEventKind::Blocked => (crate::run_status::State::Blocked, None, None),
     };
     if let Some(step) = record.steps.iter_mut().find(|s| s.id == event.id) {
         step.state = state;
@@ -390,6 +421,10 @@ struct StepResult {
     duration_ms: u64,
     failed_step: Option<String>,
     success: bool,
+    /// The step did not run and did not fail: it is waiting on a human. Kept
+    /// distinct from `success` because a blocked step must neither trigger
+    /// `on_failure` handling nor let dependents proceed as if it had run.
+    blocked: bool,
     /// Real LLM tokens (input + output) this step consumed — non-zero only for
     /// delegate steps, read from the specialist's `Task.usage`. Summed into the
     /// run's `PipelineOutput.tokens_used` for real fleet budget accounting.
@@ -450,6 +485,7 @@ async fn execute_step_inner(
                             duration_ms: start.elapsed().as_millis() as u64,
                             failed_step: Some(step.description.clone()),
                             success: false,
+                            blocked: false,
                             tokens_used: 0,
                         };
                     }
@@ -464,6 +500,7 @@ async fn execute_step_inner(
                             duration_ms: start.elapsed().as_millis() as u64,
                             failed_step: Some(step.description.clone()),
                             success: false,
+                            blocked: false,
                             tokens_used: 0,
                         };
                     }
@@ -482,6 +519,7 @@ async fn execute_step_inner(
                             duration_ms: start.elapsed().as_millis() as u64,
                             failed_step: Some(step.description.clone()),
                             success: false,
+                            blocked: false,
                             tokens_used: 0,
                         };
                     }
@@ -513,6 +551,7 @@ async fn execute_step_inner(
                 None
             },
             success: exit_code == 0,
+            blocked: false,
             tokens_used: 0,
         }
     } else {
@@ -532,6 +571,7 @@ async fn execute_step_inner(
             duration_ms: start.elapsed().as_millis() as u64,
             failed_step: None,
             success: true,
+            blocked: false,
             tokens_used: 0,
         }
     }
@@ -618,6 +658,7 @@ async fn execute_step(
                 duration_ms: 0,
                 failed_step: None,
                 success: true,
+                blocked: false,
                 tokens_used: 0,
             };
         }
@@ -701,6 +742,7 @@ async fn execute_step(
                         None
                     },
                     success: !empty,
+                    blocked: false,
                     // Real tokens the specialist's turn consumed, from Task.usage.
                     tokens_used: extract_usage_tokens(&task),
                 }
@@ -727,6 +769,7 @@ async fn execute_step(
                     duration_ms: start.elapsed().as_millis() as u64,
                     failed_step: Some(step.description.clone()),
                     success: false,
+                    blocked: false,
                     tokens_used: 0,
                 }
             }
@@ -771,15 +814,37 @@ async fn execute_step(
             cid,
             &req,
             opts.yes,
+            opts.hitl_defer.unwrap_or_else(unattended),
             None,
             Some(opts.run_id.as_str()),
         )
         .await
         .unwrap_or(crate::hitl::gate::GateDecision {
             allow: false,
+            deferred: false,
             reason: "gate error".into(),
             action_hash: String::new(),
         });
+        if decision.deferred {
+            // Parked, not refused: the request is durable in the channel and
+            // any surface can answer it later. Report blocked so the run stops
+            // here without burning the wait window or failing work a human
+            // never got to see.
+            eprintln!(
+                "  Step {sid}: awaiting approval — {} (approve: mur channel approve {cid} <hitl_id>)",
+                decision.reason
+            );
+            emit(StepEventKind::Blocked, 0);
+            return StepResult {
+                exit_code: 0,
+                output_text: decision.reason.clone(),
+                duration_ms: start.elapsed().as_millis() as u64,
+                failed_step: None,
+                success: false,
+                blocked: true,
+                tokens_used: 0,
+            };
+        }
         if !decision.allow {
             eprintln!("  Step {sid}: gate denied ({})", decision.reason);
             emit(StepEventKind::Failed, 0);
@@ -789,6 +854,7 @@ async fn execute_step(
                 duration_ms: start.elapsed().as_millis() as u64,
                 failed_step: Some(step.description.clone()),
                 success: false,
+                blocked: false,
                 tokens_used: 0,
             };
         }
@@ -803,6 +869,7 @@ async fn execute_step(
                 duration_ms: start.elapsed().as_millis() as u64,
                 failed_step: Some(step.description.clone()),
                 success: false,
+                blocked: false,
                 tokens_used: 0,
             };
         }
@@ -825,16 +892,31 @@ async fn execute_step(
             false
         };
         if !approved {
+            // NOT success. Reporting an unapproved step as done let every
+            // dependent run on a prerequisite that never happened, and the run
+            // as a whole reported success — the same silent-skip-as-success
+            // shape the audit found elsewhere. Unattended (no TTY) it is
+            // blocked; interactively it is a refusal the human just gave.
+            let refused = std::io::IsTerminal::is_terminal(&std::io::stdin());
             eprintln!(
-                "  Step {sid}: needs_approval, skipped (yields true) — use `--yes` to auto-approve"
+                "  Step {sid}: needs_approval and {} — not run. Re-run interactively, or with `--yes` to auto-approve.",
+                if refused { "declined" } else { "nobody to ask" }
             );
-            emit(StepEventKind::Done, 0);
+            emit(
+                if refused {
+                    StepEventKind::Failed
+                } else {
+                    StepEventKind::Blocked
+                },
+                0,
+            );
             return StepResult {
-                exit_code: 0,
-                output_text: String::new(),
+                exit_code: if refused { 1 } else { 0 },
+                output_text: "needs_approval: not approved".into(),
                 duration_ms: 0,
-                failed_step: None,
-                success: true,
+                failed_step: refused.then(|| step.description.clone()),
+                success: false,
+                blocked: !refused,
                 tokens_used: 0,
             };
         }
@@ -1076,13 +1158,17 @@ pub async fn execute_dag(
         };
 
     // Closure for terminal StateChange — call before each PipelineOutput return.
-    let emit_final = |failed: bool| {
+    let emit_final = |outcome: RunOutcome| {
+        // Blocked is NOT terminal: the channel is already `InputRequired`
+        // (the gate put it there) and must stay that way, or the surfaces that
+        // read channel state would show a finished run while a human still
+        // owes it an answer.
+        let st = match outcome {
+            RunOutcome::Blocked => return,
+            RunOutcome::Failed => ChannelState::Failed,
+            RunOutcome::Done => ChannelState::Completed,
+        };
         if let Some(cid) = opts.channel_id.as_deref() {
-            let st = if failed {
-                ChannelState::Failed
-            } else {
-                ChannelState::Completed
-            };
             let _ = ChannelService::open(mur_home)
                 .and_then(|svc| svc.transition(cid, st, ChannelActor::System, opts.event_run_id()));
         }
@@ -1105,6 +1191,12 @@ pub async fn execute_dag(
     // step id → output_text of successfully completed steps, so later ranks
     // can thread dependency outputs into their delegated sub-goals.
     let mut completed_outputs: HashMap<String, String> = HashMap::new();
+    // Step ids waiting on a human, plus everything downstream of them. A
+    // dependent must not run on a prerequisite that has not happened yet —
+    // but unlike a failure this is not an abort: independent branches in the
+    // same and later ranks still run to completion, so an unattended run gets
+    // as far as it legitimately can before it needs someone.
+    let mut blocked_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for rank in 0..=max_rank {
         let indices: Vec<usize> = (0..graph.nodes.len())
@@ -1115,9 +1207,42 @@ pub async fn execute_dag(
             continue;
         }
 
+        // Inherit blocked-ness before spawning: a step whose dependency is
+        // waiting on a human cannot run. Ranks execute in dependency order, so
+        // checking direct `depends_on` here transitively covers the subgraph —
+        // each rank marks the next.
+        let (indices, deferred_indices): (Vec<usize>, Vec<usize>) =
+            indices.into_iter().partition(|i| {
+                !graph.nodes[*i]
+                    .step
+                    .depends_on
+                    .iter()
+                    .any(|d| blocked_ids.contains(d))
+            });
+        for i in deferred_indices {
+            let step = &graph.nodes[i].step;
+            let sid = step.id.clone().unwrap_or_else(|| format!("step{i}"));
+            eprintln!("  Step {sid}: not run — depends on a step awaiting approval");
+            if let Some(cb) = composed_on_step.as_ref() {
+                cb(StepEvent {
+                    id: sid.clone(),
+                    agent: step.delegate_to.clone(),
+                    kind: StepEventKind::Blocked,
+                    tokens_used: 0,
+                });
+            }
+            blocked_ids.insert(sid);
+        }
+        if indices.is_empty() {
+            continue;
+        }
+
         // Concurrent: spawn each step in this rank.
         // Extract owned values from opts for the spawned tasks.
         let opt_yes = opts.yes;
+        // Resolve once per rank, not per step: `unattended()` probes the TTY,
+        // and every step in a run must agree on whether a human is watching.
+        let opt_hitl_defer = Some(opts.hitl_defer.unwrap_or_else(unattended));
         let opt_input = opts.input.clone();
         let opt_env_override = opts.env_class_override.map(|s| s.to_string());
         let opt_vars = opts.variables.clone();
@@ -1150,6 +1275,7 @@ pub async fn execute_dag(
                 };
                 let opts_clone = DagExecOptions {
                     yes: opt_yes,
+                    hitl_defer: opt_hitl_defer,
                     input: inp,
                     env_class_override: env_override.as_deref(),
                     variables: vars,
@@ -1183,6 +1309,7 @@ pub async fn execute_dag(
                         duration_ms: 0,
                         failed_step: Some("(task)".to_string()),
                         success: false,
+                        blocked: false,
                         tokens_used: 0,
                     });
                 }
@@ -1194,6 +1321,19 @@ pub async fn execute_dag(
             let result = &results[ri];
             let step = &graph.nodes[indices[ri]].step;
             overall_tokens = overall_tokens.saturating_add(result.tokens_used);
+
+            // A blocked step is neither a success to record nor a failure to
+            // act on: register it so dependents inherit, and skip the ledger +
+            // on_failure handling entirely. It never happened; the run will
+            // simply end short of it.
+            if result.blocked {
+                blocked_ids.insert(
+                    step.id
+                        .clone()
+                        .unwrap_or_else(|| format!("step{}", indices[ri])),
+                );
+                continue;
+            }
 
             // Write run-ledger record.
             let stderr_for_ledger = if !result.success && result.output_text.is_empty() {
@@ -1235,13 +1375,13 @@ pub async fn execute_dag(
                             "  Step {sid} failed (exit {}), aborting workflow",
                             result.exit_code
                         );
-                        emit_final(true);
+                        emit_final(RunOutcome::Failed);
                         finalize_run(
                             mur_home,
                             &opts.run_id,
                             recorded.is_some(),
                             &mut heartbeat,
-                            true,
+                            RunOutcome::Failed,
                         )
                         .await;
                         return Ok(PipelineOutput {
@@ -1289,13 +1429,13 @@ pub async fn execute_dag(
                             } else if attempt + 1 == max_retries {
                                 let _retry_code = retry_result.exit_code;
                                 eprintln!("  Step {sid} retry exhausted, aborting workflow");
-                                emit_final(true);
+                                emit_final(RunOutcome::Failed);
                                 finalize_run(
                                     mur_home,
                                     &opts.run_id,
                                     recorded.is_some(),
                                     &mut heartbeat,
-                                    true,
+                                    RunOutcome::Failed,
                                 )
                                 .await;
                                 return Ok(PipelineOutput {
@@ -1326,19 +1466,46 @@ pub async fn execute_dag(
     }
 
     let duration_ms = start.elapsed().as_millis() as u64;
-    let status = if overall_exit_code == 0 {
-        PipelineStatus::Success
+    // Blocked outranks a clean exit code: every blocked step exits 0 (nothing
+    // ran, nothing failed), so reading the exit code alone would report a run
+    // waiting on a human as a success.
+    let outcome = if overall_exit_code != 0 {
+        RunOutcome::Failed
+    } else if !blocked_ids.is_empty() {
+        RunOutcome::Blocked
     } else {
-        PipelineStatus::Failed
+        RunOutcome::Done
     };
+    let status = match outcome {
+        RunOutcome::Done => PipelineStatus::Success,
+        RunOutcome::Failed => PipelineStatus::Failed,
+        // ponytail: `Skipped` is the closest existing variant — it does not
+        // claim success and needs no change to a serialized enum. Add a
+        // `Blocked` variant if a consumer ever needs to tell the two apart;
+        // the run record (State::Blocked) and the channel (InputRequired)
+        // already carry the precise state.
+        RunOutcome::Blocked => PipelineStatus::Skipped,
+    };
+    if outcome == RunOutcome::Blocked {
+        let mut ids: Vec<&String> = blocked_ids.iter().collect();
+        ids.sort();
+        eprintln!(
+            "\n⏸ Run stopped: {} step(s) awaiting approval ({}).\n   Approve with `mur channel approve <channel_id> <hitl_id>` (or the Hub's Needs You card), then re-run — completed steps are skipped.",
+            ids.len(),
+            ids.iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
 
-    emit_final(overall_exit_code != 0);
+    emit_final(outcome);
     finalize_run(
         mur_home,
         &opts.run_id,
         recorded.is_some(),
         &mut heartbeat,
-        overall_exit_code != 0,
+        outcome,
     )
     .await;
     Ok(PipelineOutput {
@@ -1369,7 +1536,7 @@ async fn finalize_run(
     run_id: &str,
     recorded: bool,
     heartbeat: &mut Option<crate::run_status::heartbeat::Heartbeat>,
-    failed: bool,
+    outcome: RunOutcome,
 ) {
     if !recorded {
         return;
@@ -1381,10 +1548,10 @@ async fn finalize_run(
     // load/save pair here would race `mur job stop` in another process, which
     // does the same read-modify-write on the same file.
     let _ = crate::run_status::store::update(mur_home, run_id, |record| {
-        record.state = if failed {
-            crate::run_status::State::Failed
-        } else {
-            crate::run_status::State::Done
+        record.state = match outcome {
+            RunOutcome::Failed => crate::run_status::State::Failed,
+            RunOutcome::Blocked => crate::run_status::State::Blocked,
+            RunOutcome::Done => crate::run_status::State::Done,
         };
     });
 }

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -32,9 +32,13 @@ pub struct ActionRequest {
 }
 
 /// The gate's verdict. `action_hash` is the pin the caller MUST re-verify just
-/// before executing (fail-closed on mismatch).
+/// before executing (fail-closed on mismatch). `deferred: true` (which implies
+/// `allow: false`) means nobody answered AND nobody was made to wait: the
+/// request is parked durably in the channel and the caller should mark the
+/// step blocked — not failed — so a later approval can release it.
 pub struct GateDecision {
     pub allow: bool,
+    pub deferred: bool,
     pub reason: String,
     pub action_hash: String,
 }
@@ -43,8 +47,29 @@ pub struct GateDecision {
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Approvals and denials settle a gate for this long. Content staleness is
+/// already handled by the hash pin (any input change = a different hash); the
+/// TTL bounds TIME staleness, so a weeks-old approval cannot release a gate
+/// nobody remembers granting.
+pub(crate) const HITL_APPROVAL_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
+/// Pure TTL predicate — split out so the boundary is testable without
+/// backdating channel events.
+pub(crate) fn within_approval_ttl(
+    event_ts: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    (now - event_ts).num_seconds() <= HITL_APPROVAL_TTL_SECS
+}
+
 /// Gate an action. `yes` auto-approves Ask-tier actions (records an `auto`
 /// HitlResponse for the audit trail). Read tier returns `allow` immediately.
+///
+/// `defer` selects what happens when an Ask-tier action has no answer yet:
+/// `false` blocks the caller polling for up to `timeout` (attended);
+/// `true` parks the request and returns `deferred` at once (unattended).
+/// Either way a settled decision for the same `action_hash` — from any earlier
+/// run, inside the TTL — releases the gate without asking again.
 ///
 /// Takes `mur_home: &Path` rather than `&ChannelService` so `ChannelService` is
 /// never held across `.await` — keeping the returned future `Send`.
@@ -53,6 +78,7 @@ pub async fn gate(
     channel_id: &str,
     req: &ActionRequest,
     yes: bool,
+    defer: bool,
     timeout: Option<Duration>,
     run_id: Option<&str>,
 ) -> Result<GateDecision> {
@@ -67,22 +93,50 @@ pub async fn gate(
     match default_mode(req.tier) {
         HitlMode::Auto => Ok(GateDecision {
             allow: true,
+            deferred: false,
             reason: "read-tier: auto".into(),
             action_hash: hash,
         }),
         HitlMode::Deny => Ok(GateDecision {
             allow: false,
+            deferred: false,
             reason: "policy: deny".into(),
             action_hash: hash,
         }),
         HitlMode::Ask => {
-            let hitl_id = format!("hitl-{}", uuid::Uuid::now_v7());
             let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT);
             // Resolve signature-enforcement ONCE here (not deep in the poll
             // loop) so `wait_for_response` is pure w.r.t. config and tests never
             // race on a process-global env var. Only explicit truthy values
             // enable enforcement: `=0` / `=false` must NOT turn it on.
             let require_sig = crate::channel_verify::require_sig_from_env();
+
+            // What does this channel already say about THIS EXACT action?
+            // Keyed on `action_hash`, never on `hitl_id`: the id is minted
+            // fresh on every call, so an id-keyed lookup can never see the
+            // answer a human gave to the previous run — the defect that made
+            // late approval impossible and piled up duplicate requests, one
+            // per loop iteration, all asking the same question.
+            match scan_prior(mur_home, channel_id, &hash, require_sig)? {
+                // Settled (approved or denied) and still inside the TTL:
+                // release the gate now. This is what lets an overnight
+                // approval be picked up by the next run, and what stops a
+                // denial from re-asking every iteration.
+                Prior::Settled(d) => return Ok(d),
+                // Already parked and unanswered: point at the EXISTING
+                // request rather than writing a second one.
+                Prior::Pending(existing_id) if defer => {
+                    return Ok(GateDecision {
+                        allow: false,
+                        deferred: true,
+                        reason: format!("awaiting approval ({existing_id})"),
+                        action_hash: hash,
+                    });
+                }
+                _ => {}
+            }
+
+            let hitl_id = format!("hitl-{}", uuid::Uuid::now_v7());
             let request = HitlRequest {
                 hitl_id: hitl_id.clone(),
                 action_hash: hash.clone(),
@@ -123,6 +177,19 @@ pub async fn gate(
                 )?;
             }
 
+            // Park instead of polling. The request is durable and the channel
+            // stays `InputRequired`, so the answer can arrive at any time from
+            // any surface — nobody is made to wait 5 minutes to learn that
+            // nobody is watching.
+            if defer {
+                return Ok(GateDecision {
+                    allow: false,
+                    deferred: true,
+                    reason: format!("awaiting approval ({hitl_id})"),
+                    action_hash: hash,
+                });
+            }
+
             let decision = if yes {
                 let resp = HitlResponse {
                     hitl_id: hitl_id.clone(),
@@ -146,6 +213,7 @@ pub async fn gate(
                 }
                 GateDecision {
                     allow: true,
+                    deferred: false,
                     reason: "auto-approved (--yes)".into(),
                     action_hash: hash.clone(),
                 }
@@ -165,6 +233,90 @@ pub async fn gate(
             }
             Ok(decision)
         }
+    }
+}
+
+/// What the channel already knows about one specific action.
+enum Prior {
+    /// A human (or `--yes`) settled this exact action, recently enough to count.
+    Settled(GateDecision),
+    /// A request for this exact action is parked and unanswered.
+    Pending(String),
+    /// Never asked — or asked and answered too long ago to still count.
+    None,
+}
+
+/// Look up prior HITL traffic for `hash` in one pass over the channel log.
+///
+/// Matching is on `action_hash`, the deterministic function of
+/// (tool, input, channel, step, agent) — NOT on `hitl_id`, which is minted
+/// per call and therefore cannot connect a run to the answer given to an
+/// earlier one. Two consequences fall out of that choice, both wanted:
+/// re-running a workflow picks up an approval granted overnight, and changing
+/// the action's input changes the hash, so no approval is ever replayed
+/// against bytes a human did not see.
+///
+/// Responses are verified per-actor (v3d-2) before they count; an unverifiable
+/// response is ignored exactly as the wait loop ignores it. A response outside
+/// the TTL leaves the action `None` (ask again), not `Pending` — its request is
+/// answered, just too long ago to act on.
+fn scan_prior(mur_home: &Path, channel_id: &str, hash: &str, require_sig: bool) -> Result<Prior> {
+    let svc = ChannelService::open(mur_home)?;
+    let events = svc.load_events(channel_id)?;
+    drop(svc);
+
+    let now = chrono::Utc::now();
+    let mut responded: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut settled: Option<GateDecision> = None;
+    let mut pending_id: Option<String> = None;
+
+    for e in &events {
+        match e.kind {
+            EventKind::HitlResponse => {
+                let Ok(r) = serde_json::from_value::<HitlResponse>(e.payload.clone()) else {
+                    continue;
+                };
+                if !crate::channel_verify::verify_event(mur_home, channel_id, e, require_sig) {
+                    continue;
+                }
+                // Answered — even if it later fails the TTL check, so the
+                // request it answers is not re-reported as still pending.
+                responded.insert(r.hitl_id.clone());
+                if r.action_hash == hash && within_approval_ttl(e.ts, now) {
+                    // Later events overwrite earlier ones: the newest decision
+                    // for an action is the one that counts.
+                    settled = Some(GateDecision {
+                        allow: r.allow,
+                        deferred: false,
+                        reason: if r.allow {
+                            format!("approved earlier ({})", r.hitl_id)
+                        } else {
+                            format!("denied earlier ({})", r.hitl_id)
+                        },
+                        action_hash: hash.to_string(),
+                    });
+                }
+            }
+            EventKind::HitlRequest => {
+                let Ok(q) = serde_json::from_value::<HitlRequest>(e.payload.clone()) else {
+                    continue;
+                };
+                if q.action_hash == hash
+                    && crate::channel_verify::verify_event(mur_home, channel_id, e, require_sig)
+                {
+                    pending_id = Some(q.hitl_id);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(d) = settled {
+        return Ok(Prior::Settled(d));
+    }
+    match pending_id {
+        Some(id) if !responded.contains(&id) => Ok(Prior::Pending(id)),
+        _ => Ok(Prior::None),
     }
 }
 
@@ -222,6 +374,7 @@ async fn wait_for_response(
             if echoed != expected_hash {
                 return Ok(GateDecision {
                     allow: false,
+                    deferred: false,
                     reason: "hitl_drift: response action_hash mismatch".into(),
                     action_hash: expected_hash.to_string(),
                 });
@@ -233,6 +386,7 @@ async fn wait_for_response(
                 .unwrap_or(false);
             return Ok(GateDecision {
                 allow,
+                deferred: false,
                 reason: if allow {
                     "approved".into()
                 } else {
@@ -244,6 +398,7 @@ async fn wait_for_response(
         if start.elapsed() >= timeout {
             return Ok(GateDecision {
                 allow: false,
+                deferred: false,
                 reason: "hitl timeout".into(),
                 action_hash: expected_hash.to_string(),
             });
@@ -278,6 +433,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Read),
             false,
+            false,
             None,
             Some("run-g"),
         )
@@ -304,6 +460,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             true,
+            false,
             None,
             Some("run-paused"),
         )
@@ -353,7 +510,7 @@ mod tests {
             &r.step_or_call_id,
             &r.agent_id,
         );
-        let d = gate(tmp.path(), &ch.id, &r, true, None, Some("run-g"))
+        let d = gate(tmp.path(), &ch.id, &r, true, false, None, Some("run-g"))
             .await
             .unwrap();
         assert!(d.allow, "--yes auto-approves a high tier");
@@ -538,5 +695,249 @@ mod tests {
             !d.allow,
             "unsigned response must not release when signatures are required"
         );
+    }
+
+    // ── Defer / durable-approval behaviour (unattended HITL, P0) ────────────
+
+    /// Read back the ids of every HitlRequest in a channel, oldest first.
+    fn pending_request_ids(home: &Path, ch: &str) -> Vec<String> {
+        let svc = ChannelService::open(home).unwrap();
+        svc.load_events(ch)
+            .unwrap()
+            .iter()
+            .filter(|e| e.kind == EventKind::HitlRequest)
+            .filter_map(|e| serde_json::from_value::<HitlRequest>(e.payload.clone()).ok())
+            .map(|r| r.hitl_id)
+            .collect()
+    }
+
+    /// Answer a parked request the way `mur channel approve` does: echo the
+    /// request's own `action_hash` so the pin re-verify passes.
+    fn answer(home: &Path, ch: &str, hitl_id: &str, allow: bool) {
+        let svc = ChannelService::open(home).unwrap();
+        let req: HitlRequest = svc
+            .load_events(ch)
+            .unwrap()
+            .iter()
+            .filter(|e| e.kind == EventKind::HitlRequest)
+            .filter_map(|e| serde_json::from_value::<HitlRequest>(e.payload.clone()).ok())
+            .find(|r| r.hitl_id == hitl_id)
+            .expect("request exists");
+        let resp = HitlResponse {
+            hitl_id: req.hitl_id,
+            action_hash: req.action_hash,
+            allow,
+            reason: "test".into(),
+            surface: "cli".into(),
+        };
+        svc.append(
+            ch,
+            ChannelActor::System,
+            EventKind::HitlResponse,
+            serde_json::to_value(&resp).unwrap(),
+            None,
+        )
+        .unwrap();
+    }
+
+    /// Unattended, an unanswered gate must park immediately — not spend the
+    /// wait window discovering that nobody is watching. Elapsed time is the
+    /// assertion: the old path would sit here for the full 300 s timeout.
+    #[tokio::test]
+    async fn defer_parks_immediately_instead_of_waiting() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        let t0 = Instant::now();
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+
+        assert!(d.deferred && !d.allow, "parked, and never allowed");
+        assert!(
+            t0.elapsed() < Duration::from_secs(5),
+            "must not wait out the gate timeout: {:?}",
+            t0.elapsed()
+        );
+        assert_eq!(pending_request_ids(tmp.path(), &ch.id).len(), 1);
+    }
+
+    /// The point of the whole feature: an approval given AFTER the run gave up
+    /// still releases the gate on the next run. The second run mints a fresh
+    /// `hitl_id`, so this only works because matching is on `action_hash`.
+    #[tokio::test]
+    async fn approval_from_an_earlier_run_releases_a_later_one() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        let first = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        assert!(first.deferred);
+
+        // A human answers hours later, from any surface.
+        let id = pending_request_ids(tmp.path(), &ch.id).pop().unwrap();
+        answer(tmp.path(), &ch.id, &id, true);
+
+        let second = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-2"),
+        )
+        .await
+        .unwrap();
+        assert!(second.allow, "the earlier approval must release this run");
+        assert!(!second.deferred);
+        assert_eq!(
+            second.action_hash, first.action_hash,
+            "same action ⇒ same pin"
+        );
+    }
+
+    /// A denial is also durable: re-asking every iteration would be nagging,
+    /// and worse, would let a run eventually catch a distracted "yes".
+    #[tokio::test]
+    async fn denial_persists_and_is_not_re_asked() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        let id = pending_request_ids(tmp.path(), &ch.id).pop().unwrap();
+        answer(tmp.path(), &ch.id, &id, false);
+
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-2"),
+        )
+        .await
+        .unwrap();
+        assert!(!d.allow && !d.deferred, "denied, and not asked again");
+        assert_eq!(
+            pending_request_ids(tmp.path(), &ch.id).len(),
+            1,
+            "no second request written"
+        );
+    }
+
+    /// A loop re-running the same blocked step must not write one request per
+    /// iteration; the human should see the question once.
+    #[tokio::test]
+    async fn repeated_defers_reuse_the_parked_request() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        for run in 0..3 {
+            let d = gate(
+                tmp.path(),
+                &ch.id,
+                &req(RiskTier::Destructive),
+                false,
+                true,
+                None,
+                Some(&format!("run-{run}")),
+            )
+            .await
+            .unwrap();
+            assert!(d.deferred);
+        }
+        assert_eq!(
+            pending_request_ids(tmp.path(), &ch.id).len(),
+            1,
+            "three iterations, one question"
+        );
+    }
+
+    /// An approval covers the bytes a human saw. Change the action and the
+    /// hash changes, so the old approval cannot carry it — the gate asks again
+    /// rather than executing something nobody agreed to.
+    #[tokio::test]
+    async fn an_approval_does_not_carry_to_a_different_action() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            true,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        let id = pending_request_ids(tmp.path(), &ch.id).pop().unwrap();
+        answer(tmp.path(), &ch.id, &id, true);
+
+        let mut other = req(RiskTier::Destructive);
+        other.tool_input = serde_json::json!({ "cmd": "rm -rf /" });
+        let d = gate(tmp.path(), &ch.id, &other, false, true, None, Some("run-2"))
+            .await
+            .unwrap();
+        assert!(
+            d.deferred && !d.allow,
+            "a different action must be asked separately"
+        );
+    }
+
+    /// The TTL bounds how long a decision keeps releasing a gate. Content
+    /// staleness is the pin's job; this is the clock's half.
+    #[test]
+    fn approval_ttl_boundary() {
+        let now = chrono::Utc::now();
+        assert!(within_approval_ttl(now, now));
+        assert!(within_approval_ttl(
+            now - chrono::Duration::seconds(HITL_APPROVAL_TTL_SECS - 1),
+            now
+        ));
+        assert!(!within_approval_ttl(
+            now - chrono::Duration::seconds(HITL_APPROVAL_TTL_SECS + 1),
+            now
+        ));
     }
 }


### PR DESCRIPTION
Design question from the field: *when a fleet runs unattended, what happens to the actions that need a human?* The honest answer today is **they aren't handled, they're outlasted**.

## Problem

Every risk-tiered gate polls `hitl/gate.rs` for 300 s, then denies, then fails the step and the run. And because `hitl_id` is minted fresh per call, the request a human finds the next morning is **already dead** — approving it releases nothing, and the only recovery is a full re-run that mints yet another request. Under `--loop` each iteration re-burns the window and writes another duplicate of the same question.

The second-order cost is worse than the wasted minutes: a gate this painful teaches users to reach for `perm set-mode unrestricted` or a blanket `--yes`. Pressure to bypass is itself a security cost.

Two related defects found on the way:
- `hitl_id`-keyed lookup can never connect a run to an answer given to an earlier one (the duplicate-request pile-up).
- No-channel `needs_approval` + non-TTY **skipped the step and reported it DONE** (`exit_code: 0`, `StepEventKind::Done`) — dependents ran on a prerequisite that never happened and the run claimed success.

## Prior art (checked)

LangGraph `interrupt()`/`Command(resume)`, Temporal signal + durable timer (with an escalation ladder, not a constant), OpenAI Agents SDK `needsApproval` + serialize/resume, AWS Bedrock Return of Control, A2A v0.3 `input-required` as a **non-terminal** state, OWASP Agentic ASI06 on approval fatigue. All converge: **a pending approval is durable state, not a countdown**. MUR's channel already models exactly this (`ChannelState::InputRequired`, hash-pinned durable request, signed responses, Hub "Needs You" inbox, mobile push on channel append) — the gate simply never returned so nothing downstream could act on it.

## What P0 does

- **`gate()` gains a `defer` mode.** Parks the request and returns `deferred` immediately instead of polling. `DagExecOptions.hitl_defer: Option<bool>`; `None` = auto — defer when stdin is not a TTY (daemon ticks, schedules, cron, fleet loops), wait when interactive. `--yes` stays unreachable from unattended fleet paths.
- **`scan_prior()` matches on `action_hash`, never on `hitl_id`** — the hinge of the fix. A settled decision for the same action, inside a 7-day TTL, releases a **later** run: an overnight approval now works, and a denial is not re-asked every iteration. An unanswered request is reused rather than duplicated. Changing the action changes the hash, so an approval is never replayed against bytes nobody saw. Per-actor signature verification (v3d-2) and the execute-boundary pin re-verify are unchanged.
- **`blocked` is a first-class, non-terminal outcome**: `StepResult.blocked`, `StepEventKind::Blocked`, `RunOutcome`, `JobStatus::Blocked` (`is_terminal() == false`), `LoopStop::AwaitingApproval`. A blocked run writes **no** terminal `StateChange`, leaving the channel `input-required` so every surface keeps showing the outstanding question. Dependents inherit blocked per rank; independent branches still run to completion, so an unattended run gets as far as it legitimately can.
- **The silent-skip-as-success is gone**: unapproved now means blocked (unattended) or failed (declined interactively), never "done".

Result: the machine stops waiting, the request stops expiring, work that doesn't depend on the gate still lands, and the human approves whenever they like — `mur channel approve <cid> <hitl_id>` or the Hub card — after which a re-run resumes (the v3c cursor skips completed steps).

## Deliberately NOT in this PR

Blanket `--yes` reachable unattended (stays refused); an LLM as final approver; adopting an external workflow engine. P1–P3 are designed in the spec, not started: `fleet.yaml` policy grants (the approval-fatigue answer), worktree-diverted speculative execution with **diff** approval (review results, not intentions), and approval-history → standing-grant proposals through `mur out`.

Spec: `docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md`

## Verification

- `cargo fmt`; `cargo check --workspace --all-targets`; `cargo clippy -p mur-core -p mur-common --all-targets -- -D warnings` — all clean
- `cargo nextest run -p mur-core -E 'test(/executor::dag|fleet::|hitl::/)'` → **318/318 passed**, including 6 new tests: park-immediately (asserts elapsed, so a regression to polling fails the test), approval-from-an-earlier-run-releases-a-later-one, denial-persists-and-is-not-re-asked, repeated-defers-reuse-the-parked-request, approval-does-not-carry-to-a-different-action, TTL boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)