### PR TITLE
fix(hub): stop teaching users to paste absolute paths into MCP Command

### DIFF
--- a/mur-hub-gui/ui/src/components/inspector/tabs/McpTab.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/tabs/McpTab.tsx
@@ -139,13 +139,16 @@ export function McpTab({
             <input
               className="input"
               value={command}
-              placeholder="/usr/local/bin/my-mcp-server"
+              placeholder="npx"
               onChange={(e) => setCommand(e.target.value)}
             />
             <button className="toolbar-btn" onClick={browseCommand} disabled={busy}>
               {t("detail.browse")}
             </button>
           </div>
+          <p className="field-muted" style={{ fontSize: 12 }}>
+            {t("detail.mcpCommandHint")}
+          </p>
           <label className="field-label">{t("detail.mcpArgs")}</label>
           <input
             className="input"

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -237,6 +237,8 @@ export const en = {
   "installInbox.deny": "Deny",
   "detail.mcpId": "Server ID",
   "detail.mcpCommand": "Command",
+  "detail.mcpCommandHint":
+    "A bare command works — node, npx, uvx, python3 — no absolute path needed. Browse… only if it is somewhere PATH does not reach.",
   "detail.mcpArgs": "Arguments (space-separated)",
   "detail.browse": "Browse…",
   "detail.add": "Add",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -239,6 +239,8 @@ export const zhTW: Table = {
   "installInbox.deny": "拒絕",
   "detail.mcpId": "伺服器 ID",
   "detail.mcpCommand": "指令",
+  "detail.mcpCommandHint":
+    "直接填指令名即可（node、npx、uvx、python3），不需要絕對路徑。只有在 PATH 找不到時才需要「瀏覽…」。",
   "detail.mcpArgs": "參數（以空格分隔）",
   "detail.browse": "瀏覽…",
   "detail.add": "新增",


### PR DESCRIPTION
## Problem

The Hub's Add-MCP-server form used `/usr/local/bin/my-mcp-server` as the Command placeholder, so users learned to type `/opt/homebrew/bin/node` — unlike every other MCP host, where a bare `node` / `npx` is the norm. That was the surface symptom; the real cause was on the runtime side (an agent spawned by the Hub inherited the GUI's minimal PATH, so bare `node` failed there while working fine from a terminal), fixed in #990.

## Fix

Now that MCP commands resolve against an augmented PATH in every spawn context, the form should stop implying otherwise:

- placeholder `/usr/local/bin/my-mcp-server` → `npx`
- a hint line under the field: a bare command works (`node`, `npx`, `uvx`, `python3`), no absolute path needed; **Browse…** is only for a binary PATH cannot reach

Strings added to both locales (`en`, `zh-TW`); `detail.*` key counts stay in parity at 108 each. Reuses the existing `field-muted` hint pattern already used a few lines above for `mcpAddedHint`.

Note on the file picker: the field is one executable path, so a file picker is the right control for the Browse… escape hatch — the earlier "it should pick a directory" instinct came from the absolute-path requirement, which no longer exists. Depends on #990 (merged).

## Verification

TypeScript/lint runs in CI — this worktree has no `node_modules`, so no local typecheck. The change is a string addition plus one JSX line copied from the adjacent hint element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)