### PR TITLE
fix(agent): say that a stopped service-managed agent comes back at login

### DIFF
--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -907,7 +907,17 @@ pub fn cmd_stop(name: &str) -> Result<()> {
         );
     }
     if had_service {
-        println!("Stopped agent '{name}' and unloaded its service");
+        // "unloaded its service" read as permanent, and it is not: the
+        // descriptor stays on disk with RunAtLoad and is not disabled, so the
+        // next login starts the agent again. Say that here, where the user
+        // forms the belief, instead of letting them discover it after a
+        // reboot.
+        println!("Stopped agent '{name}' and unloaded its service for this session");
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        println!(
+            "  It starts again at your next login. To keep it stopped: {}",
+            super::service::lasting_stop_hint(name)
+        );
     } else {
         println!("Stopped agent '{name}'");
     }

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -264,8 +264,12 @@ fn report_unexamined(agents_dir: &Path) {
         );
     }
     if !should_be_running.is_empty() {
+        // Not an anomaly to fix, and deliberately NOT auto-started: this is
+        // exactly the state `mur agent stop` leaves behind (bootout / systemctl
+        // stop, descriptor left in place), so starting these would override a
+        // stop the user asked for. Say what will actually happen instead.
         println!(
-            "⚠ service installed but not running: {} — start with `mur agent start <name>`",
+            "not running, service still installed: {} — each starts again at your next login; `mur agent start <name>` to bring one up now",
             should_be_running.join(", ")
         );
     }

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -54,6 +54,14 @@ pub(super) fn installed_service(name: &str) -> Option<PathBuf> {
 /// Nothing here trusts the exit status: `launchctl bootout` reports failure
 /// when the job simply is not loaded, which is the state we want anyway. The
 /// caller confirms the outcome by looking for a live lock afterwards.
+///
+/// The stop lasts until the next login, not forever: `bootout` (and
+/// `systemctl --user stop`) unload the job from the CURRENT session without
+/// disabling it, and the descriptor stays on disk with `RunAtLoad`, so the
+/// login after this brings the agent back. That is the right default for a
+/// supervised service — but callers must say so rather than let "stopped"
+/// read as permanent. [`lasting_stop_hint`] is the command that does make it
+/// permanent.
 pub(super) fn stop_service(name: &str) -> bool {
     let Some(path) = installed_service(name) else {
         return false;
@@ -103,6 +111,24 @@ pub(super) fn remove_service(name: &str) -> Option<PathBuf> {
             .status();
     }
     Some(path)
+}
+
+/// The command that makes a stop outlive the next login, for the message that
+/// tells the user their stop does not. There is no `mur` subcommand for this
+/// on purpose: disabling is a launchd/systemd-level statement about the job,
+/// and `mur agent remove` (which deletes the descriptor) is the only MUR verb
+/// that currently ends a service for good.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub(super) fn lasting_stop_hint(name: &str) -> String {
+    #[cfg(target_os = "macos")]
+    {
+        let uid = unsafe { libc::getuid() };
+        format!("launchctl disable gui/{uid}/run.mur.agent.{name}")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        format!("systemctl --user disable mur-agent-{name}.service")
+    }
 }
 
 pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {


### PR DESCRIPTION
## Problem

`mur agent stop` prints **"Stopped agent 'X' and unloaded its service"**, which reads as permanent. It is not.

`launchctl bootout` (macOS) and `systemctl --user stop` (Linux) unload the job from the **current session only** — neither disables it, and the descriptor stays on disk with `RunAtLoad`. The next login starts the agent again. The user discovers this after a reboot, if at all.

The same state is then mis-reported by `mur agent restart --stale` — and therefore by `mur update --restart-agents` — as an anomaly:

```
⚠ service installed but not running: mur — start with `mur agent start <name>`
```

That is precisely the state a deliberate `mur agent stop` leaves behind, so the warning fires on the user's own intent.

## Fix

Make the messages true:

- `cmd_stop` says the unload is **for this session**, and names the command that makes it last (`launchctl disable gui/$UID/run.mur.agent.<n>` / `systemctl --user disable mur-agent-<n>.service`).
- `report_unexamined` states the consequence — "each starts again at your next login; `mur agent start <name>` to bring one up now" — instead of presenting it as a fault to correct.
- `stop_service`'s doc records the session-scoped semantics so the next reader doesn't have to re-derive them from launchctl behavior.

## What this deliberately does not do

The obvious-looking next step — have `mur update --restart-agents` kickstart these agents now that #991 gave `kickstart_service` a `load -w` fallback — is **wrong**: this is the state the user asked for by stopping them, and starting them would override it. Naming the behavior is the fix. (The only MUR verb that ends a service for good remains `mur agent remove`; there is no `uninstall-service` subcommand, which is why the hint names the launchctl/systemctl command directly.)

## Verification

`cargo fmt`, `cargo clippy -p mur-core --all-targets -- -D warnings` clean; `cargo nextest run -p mur-core -E 'test(/agent::restart|agent::service|agent::lifecycle/)'` → 68/68.

Last of the system-audit fix series: #986, #987, #988, #989, #990, #991, #993, #997 (merged); #994, #995 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)