### PR TITLE
fix(daemon): persist the offset reset a rotation produces

### DIFF
--- a/mur-daemon/src/consumer.rs
+++ b/mur-daemon/src/consumer.rs
@@ -36,6 +36,20 @@ pub fn write_offset(path: &Path, offset: u64) -> Result<()> {
     Ok(())
 }
 
+/// Whether the drained offset is worth persisting.
+///
+/// `!=`, deliberately not `>`. After the capture queue rotates (#983)
+/// `drain_new` restarts from zero, so the new offset is SMALLER than the one
+/// held — a `>` test reads that as "nothing happened", never persists the
+/// reset, and leaves the daemon re-processing the same records every tick
+/// while `queue/offset` stays pinned to the pre-rotation value.
+///
+/// Named and separate so it can be tested; as an inline comparison in the
+/// event loop it was neither.
+pub fn should_persist(previous: u64, drained: u64) -> bool {
+    previous != drained
+}
+
 /// Read all new events from `queue_file` starting at `start_offset`.
 /// Returns (new_events, new_offset).
 pub fn drain_new(queue_file: &Path, start_offset: u64) -> Result<(Vec<NormalizedEvent>, u64)> {
@@ -119,6 +133,23 @@ mod tests {
             duration_ms: None,
             is_duration_record: false,
         }
+    }
+
+    /// The regression that survived #996: the seek was fixed, the decision to
+    /// PERSIST the reset was not, so the daemon read the right records and
+    /// then threw the new offset away every second.
+    #[test]
+    fn a_backwards_offset_after_rotation_is_still_worth_persisting() {
+        // Pre-rotation: consumed 976 MB. Post-rotation: 17 KB of a fresh file.
+        assert!(
+            should_persist(976_071_950, 17_060),
+            "a rotation reset must be persisted — `>` said no and pinned the offset forever"
+        );
+        assert!(should_persist(100, 200), "ordinary forward progress");
+        assert!(
+            !should_persist(500, 500),
+            "nothing drained, nothing to write"
+        );
     }
 
     /// #983 rotates the queue: the live file is renamed away and a fresh one

--- a/mur-daemon/src/main.rs
+++ b/mur-daemon/src/main.rs
@@ -182,7 +182,17 @@ async fn main() -> Result<()> {
     loop {
         poll.tick().await;
         let (events, new_offset) = consumer::drain_new(&queue_file, offset)?;
-        let had_events = new_offset > offset;
+        // `!=`, not `>`. After the capture queue rotates (#983) `drain_new`
+        // restarts from zero, so the new offset is SMALLER than the one we
+        // held — a `>` test reads that as "nothing happened", never persists
+        // the reset, and re-processes the same records every tick forever
+        // while `queue/offset` stays pinned to the pre-rotation value.
+        //
+        // Observed on a real machine: after the first rotation of a 976 MB
+        // queue the daemon looped on the same handful of events once a second
+        // and the offset file never moved. #996 fixed the seek; this is the
+        // half that persists it.
+        let had_events = consumer::should_persist(offset, new_offset);
         if had_events {
             consumer::write_offset(&offset_file, new_offset)?;
             offset = new_offset;


### PR DESCRIPTION
**#996 fixed the seek. It did not fix the decision to write the result.**

Found by installing the build and watching, not by reasoning.

## What was happening on this machine, live

```rust
let had_events = new_offset > offset;     // main.rs, before
if had_events { consumer::write_offset(...) }
```

After rotation `drain_new` (correctly, per #996) restarts from zero — so the
drained offset is **smaller** than the one held. `>` reads that as "nothing
happened":

- `queue/offset` stays pinned at the pre-rotation value **forever**
- and because the event loop processes `events` *outside* that `if`, the same
  records are re-processed on **every one-second tick**

Observed: the first hook event after install rotated a 976 MB queue exactly as
designed, `events.jsonl.0` appeared at 976,071,950 bytes — and
`~/.mur/queue/offset` stayed at 976,071,950 across a daemon restart while the
new `events.jsonl` grew to 17 KB. The daemon was spinning.

I stopped the daemon before writing this.

## Why the #996 tests did not catch it

They exercised `drain_new` in isolation and passed, because **the bug was in
its caller**. An inline comparison inside an async event loop is not reachable
from a test — so it was the one piece of the change with no way to be checked.

The decision is now `consumer::should_persist(previous, drained)`: named, `!=`
rather than `>`, and covered.

| case | expected |
|---|---|
| `should_persist(976_071_950, 17_060)` | true — a rotation reset must be written |
| `should_persist(100, 200)` | true — ordinary forward progress |
| `should_persist(500, 500)` | false — nothing drained |

Negative control: restoring `>` fails the first.

```
cargo nextest run -p mur-daemon → 44 passed
clippy --all-targets → clean    fmt --check → clean
```

## The pattern, twice in a row

#996: I claimed "only one thing reads this file" after grepping for a *function
name*, and missed a consumer in another crate that opens the *path*.

This one: I tested the function I changed and not the branch that decides
whether to use its result.

Both are the same mistake at different scales — verifying the piece I was
looking at rather than the path the data actually takes. Worth saying plainly
because the fix for it is not more tests, it is checking the caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
