### PR TITLE
feat(hitl): declare the approval policy in fleet.yaml (P1a)

### DIFF
--- a/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
+++ b/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
@@ -57,24 +57,50 @@ Every risk-tiered action flows through three layers; each layer exists to
 spend less of the next layer's budget. Consent is never removed — it moves to
 the time and granularity where a human can actually give it.
 
-### Layer 1 — Policy first (consent given earlier) [P1]
+### Layer 1 — Policy first (consent given earlier) [P1: mode shipped; grants open]
 
-Named standing grants in `fleet.yaml`, signed with the fleet bundle:
+**Shipped (P1a).** `fleet.yaml` declares what an unanswered gate does:
 
 ```yaml
 hitl:
-  mode: defer            # defer | deny | wait   (unattended default: defer)
-  approval_ttl_days: 7
-  grants:
-    - tools: ["write_file", "edit_file"]
-      paths: ["./sandbox/**"]
-      max_uses_per_run: 20
-      expires: 2026-09-19
+  mode: defer            # defer | wait | deny   (absent = auto by TTY)
 ```
 
-Evaluation is pure code (scope + counter checks). A model may **narrow or
-escalate** a decision, never widen it. Routine actions die here; this layer is
-the approval-fatigue answer.
+`Unanswered::{Defer, Wait, Deny}` (`mur-common/src/hitl.rs`) is a **policy
+floor**: every value either tightens the outcome or changes *who waits*. None
+of them approves anything, and there is deliberately no `auto_approve` knob —
+that is what `--yes` is, and it stays unreachable from unattended fleet paths.
+`Deny` short-circuits **before** the resume scan, so a fleet declared free of
+risk-tiered work stays that way even if the channel still carries a valid
+approval for the same action (locked in by
+`deny_mode_outranks_an_existing_approval` and `deny_mode_outranks_yes`).
+
+Why `mode` at all, when P0's TTY detection already picks correctly for the
+common cases: a TTY is a proxy for "somebody is watching", and it is wrong in
+both directions. A monitored ops fleet running headless has a human on Hub and
+wants `wait`; a fleet that must never reach for a person wants `deny` so the
+failure is immediate and legible instead of a request nobody will answer.
+
+**Not shipped: scoped standing grants.** The approval-fatigue answer proper —
+named grants (tool class × path scope × per-run cap × TTL), signed with the
+fleet bundle, evaluated in pure code with a model able to narrow or escalate
+but never widen. Two things must be decided first, and both are the owner's
+call, not the implementer's:
+
+1. **What is grantable at the DAG gate.** The gate's `tool_name` is `sh` or
+   `intent`, not `write_file` — those are *runtime* tool-gate names. So a
+   fleet-level grant must key on something else: a risk tier ("write is fine
+   here, destructive still asks"), a step id, or a command pattern. Command
+   patterns are the leakiest of the three (`git status; rm -rf /`) and should
+   not be the first shape built.
+2. **Whether a standing grant may cover Ask tier at all**, which is a
+   deliberate loosening of the posture CLAUDE.md pins today ("never
+   blanket-approve risk-tiered steps"). Tier-scoped and fleet-scoped is
+   narrower than `--yes`, but it is still a posture change.
+
+Approval TTL stays a constant (7 days, `HITL_APPROVAL_TTL_SECS`) until someone
+needs otherwise: the pin already bounds *content* staleness, and a
+configurable clock adds a knob with no demand behind it.
 
 ### Layer 2 — Divert, don't block (structure) [P0 park; P2 divert]
 

--- a/mur-common/src/fleet.rs
+++ b/mur-common/src/fleet.rs
@@ -32,10 +32,28 @@ pub struct Fleet {
     pub loop_cfg: Option<FleetLoop>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parallel: Option<ParallelConfig>,
+    /// How this fleet handles risk-tiered approvals. Absent → auto: defer when
+    /// nothing can answer (no TTY), wait when a terminal is attached.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hitl: Option<FleetHitl>,
     /// External programs this artifact needs at runtime (portable-deps spec).
     /// Absent → empty; resolved by `mur agent/fleet doctor` + `install-deps`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires_programs: Vec<ProgramDep>,
+}
+
+/// Per-fleet approval policy. A floor, never a grant: every field here can only
+/// make an outcome stricter or change WHO waits — none of them approves
+/// anything, and there is deliberately no "auto-approve" knob (that is what
+/// `--yes` is, and it stays unreachable from unattended fleet paths).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FleetHitl {
+    /// What an unanswered Ask-tier gate does. Absent → auto: defer when no TTY
+    /// is attached, wait when one is. Set it explicitly when the TTY is a bad
+    /// proxy for "somebody is watching" — a monitored ops fleet wants `wait`
+    /// even headless; a fleet that must never reach for a human wants `deny`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<crate::hitl::Unanswered>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -208,6 +226,43 @@ mod tests {
         assert!(f.loop_cfg.is_none());
     }
 
+    /// `hitl.mode` must survive a round-trip and stay absent when unset — an
+    /// absent policy means "use the TTY-derived default", which is a different
+    /// statement from any of the three explicit modes.
+    #[test]
+    fn fleet_hitl_mode_parses_and_defaults_to_absent() {
+        let bare: Fleet = serde_yaml::from_str("name: dev\nchannel_id: fleet-dev\n").unwrap();
+        assert!(bare.hitl.is_none(), "no policy stated ⇒ auto");
+
+        let declared: Fleet =
+            serde_yaml::from_str("name: dev\nchannel_id: fleet-dev\nhitl:\n  mode: deny\n")
+                .unwrap();
+        assert_eq!(
+            declared.hitl.as_ref().and_then(|h| h.mode),
+            Some(crate::hitl::Unanswered::Deny)
+        );
+
+        for (yaml, want) in [
+            ("defer", crate::hitl::Unanswered::Defer),
+            ("wait", crate::hitl::Unanswered::Wait),
+            ("deny", crate::hitl::Unanswered::Deny),
+        ] {
+            let f: Fleet = serde_yaml::from_str(&format!(
+                "name: dev\nchannel_id: fleet-dev\nhitl:\n  mode: {yaml}\n"
+            ))
+            .unwrap();
+            assert_eq!(f.hitl.and_then(|h| h.mode), Some(want));
+        }
+
+        // An unknown mode is a typo, not a silent fallback to something looser.
+        assert!(
+            serde_yaml::from_str::<Fleet>(
+                "name: dev\nchannel_id: fleet-dev\nhitl:\n  mode: yolo\n"
+            )
+            .is_err()
+        );
+    }
+
     #[test]
     fn fleet_yaml_roundtrip_and_router_default() {
         let f = Fleet {
@@ -222,6 +277,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         assert_eq!(f.router_or_concierge(), CONCIERGE_AGENT);

--- a/mur-common/src/hitl.rs
+++ b/mur-common/src/hitl.rs
@@ -38,6 +38,29 @@ pub fn default_mode(tier: RiskTier) -> HitlMode {
     }
 }
 
+/// What an Ask-tier gate does when nobody has answered yet.
+///
+/// This is a policy floor, chosen by the run's owner — it may only tighten the
+/// outcome, never approve anything. `Deny` short-circuits before any lookup so
+/// a fleet declared free of risk-tiered work stays that way even if some older
+/// approval for the same action is still on the channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Unanswered {
+    /// Park the request durably and report the step blocked. Nobody waits; an
+    /// approval arriving later releases the gate on a subsequent run. The
+    /// default when no human is watching.
+    Defer,
+    /// Block the caller, polling until the gate timeout. The default when a
+    /// terminal is attached, and the right choice for an unattended run that
+    /// somebody IS watching on another surface.
+    Wait,
+    /// Refuse every Ask-tier action outright, without writing a request. For a
+    /// run that must never reach for a human — the failure is immediate and
+    /// legible instead of a request nobody will answer.
+    Deny,
+}
+
 /// `EventKind::HitlRequest` payload: the durable, pinned approval request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HitlRequest {

--- a/mur-core/src/cmd/commander.rs
+++ b/mur-core/src/cmd/commander.rs
@@ -241,6 +241,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();

--- a/mur-core/src/cmd/deep_research/run.rs
+++ b/mur-core/src/cmd/deep_research/run.rs
@@ -96,6 +96,7 @@ mod tests {
                 done_when: "marker:RESEARCH_COMPLETE".into(),
             }),
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();

--- a/mur-core/src/cmd/fleet/control.rs
+++ b/mur-core/src/cmd/fleet/control.rs
@@ -61,6 +61,7 @@ mod tests {
                 skills: vec![],
                 loop_cfg: None,
                 parallel: None,
+                hitl: None,
                 requires_programs: vec![],
             },
         )

--- a/mur-core/src/cmd/fleet/create.rs
+++ b/mur-core/src/cmd/fleet/create.rs
@@ -52,6 +52,9 @@ pub fn cmd_fleet_create(
         skills: vec![],
         loop_cfg: None,
         parallel,
+        // No approval policy stated at creation: the TTY-derived default
+        // applies until someone writes `hitl.mode` into fleet.yaml.
+        hitl: None,
         requires_programs: vec![],
     };
     store::save_fleet(mur_home, &fleet)?;

--- a/mur-core/src/cmd/fleet/export.rs
+++ b/mur-core/src/cmd/fleet/export.rs
@@ -232,6 +232,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -265,6 +266,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -540,6 +540,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -775,6 +776,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(s, &fleet).unwrap();
@@ -843,6 +845,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(s, &fleet).unwrap();
@@ -1467,6 +1470,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(s, &fleet).unwrap();
@@ -1554,6 +1558,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(s, &fleet).unwrap();

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -591,6 +591,9 @@ pub async fn run_guarded(
             // (No risk tier on fan-out steps today; this guards future
             // router-emitted risk steps. Best-practice audit / OWASP ASI06.)
             yes: false,
+            // Fleet-declared approval policy (`hitl.mode`); `None` keeps the
+            // TTY-derived default. Tightening only — nothing here approves.
+            hitl_unanswered: fleet.hitl.as_ref().and_then(|h| h.mode),
             channel_id: Some(fleet.channel_id.clone()),
             // uuid nonce so concurrent `--loop` runs don't collide on the
             // channel's idempotency-key dedup (the iteration stays for readability).
@@ -1025,6 +1028,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         // default when nothing set
@@ -1097,6 +1101,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -1141,6 +1146,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -1189,6 +1195,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -1270,6 +1277,7 @@ mod tests {
                 done_when: super::super::done_policy::DONE_WHEN_QUEUE_EMPTY.into(),
             }),
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -1305,6 +1313,7 @@ mod tests {
                 done_when: String::new(), // router policy — the fallback for empty/legacy values
             }),
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
@@ -1343,6 +1352,7 @@ mod tests {
                 done_when: super::super::done_policy::DONE_WHEN_QUEUE_EMPTY.into(),
             }),
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();

--- a/mur-core/src/cmd/fleet/run.rs
+++ b/mur-core/src/cmd/fleet/run.rs
@@ -381,6 +381,10 @@ pub async fn cmd_fleet_run(
         // router-emitted DAG with risk steps must fail-closed, never auto-approve
         // unattended. See the best-practice audit (OWASP Agentic ASI06).
         yes: false,
+        // Fleet-declared approval policy (`hitl.mode` in fleet.yaml); `None`
+        // keeps the TTY-derived default. It can only tighten: there is no
+        // value here that approves anything.
+        hitl_unanswered: fleet.hitl.as_ref().and_then(|h| h.mode),
         channel_id: Some(fleet.channel_id.clone()),
         run_id: run_id.clone(),
         run_kind: Some(crate::run_status::RunKind::Fleet),

--- a/mur-core/src/cmd/fleet/status.rs
+++ b/mur-core/src/cmd/fleet/status.rs
@@ -121,6 +121,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         }
     }

--- a/mur-core/src/cmd/fleet/store.rs
+++ b/mur-core/src/cmd/fleet/store.rs
@@ -98,6 +98,7 @@ mod tests {
             loop_cfg: None,
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         let err = save_fleet(home, &bad).unwrap_err();
@@ -128,6 +129,7 @@ mod tests {
             skills: vec![],
             loop_cfg: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         };
         save_fleet(home, &f).unwrap();

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -87,13 +87,14 @@ pub struct DagExecOptions<'a> {
     pub input: Option<PipelineOutput>,
     /// `--yes` flag: auto-approve all `needs_approval` steps.
     pub yes: bool,
-    /// What an unanswered risk-tiered gate does. `Some(true)` parks the request
-    /// and marks the step blocked; `Some(false)` waits (polling) for the gate
-    /// timeout. `None` = auto: defer when stdin is not a TTY, because an
-    /// unattended run (daemon tick, schedule, cron, fleet loop) has nobody to
-    /// answer inside the wait window — waiting there only converts the whole
-    /// window into a denial, and kills a request a human could still answer.
-    pub hitl_defer: Option<bool>,
+    /// What an unanswered risk-tiered gate does. `None` = auto: defer when
+    /// stdin is not a TTY, wait when it is — because an unattended run (daemon
+    /// tick, schedule, cron, fleet loop) has nobody to answer inside the wait
+    /// window, and waiting there only converts the whole window into a denial
+    /// while killing a request a human could still have answered. Set it
+    /// explicitly (fleet.yaml `hitl.mode`) when the TTY is a poor proxy for
+    /// "somebody is watching".
+    pub hitl_unanswered: Option<mur_common::hitl::Unanswered>,
     /// Explicit override of the env classification (P4-ready).
     pub env_class_override: Option<&'a str>,
     /// Variable substitutions: `(name, value)` pairs for `{{name}}` in commands.
@@ -145,7 +146,7 @@ impl<'a> Default for DagExecOptions<'a> {
         Self {
             input: None,
             yes: false,
-            hitl_defer: None,
+            hitl_unanswered: None,
             env_class_override: None,
             variables: vec![],
             device_id: "cli".to_string(),
@@ -180,12 +181,17 @@ pub enum StepEventKind {
     Blocked,
 }
 
-/// True when nothing can answer an approval prompt in the next few minutes:
-/// no TTY on stdin. Daemon ticks, schedules, cron and the fleet loop all land
-/// here, which is exactly where waiting out a gate timeout converts the whole
-/// window into an automatic denial.
-fn unattended() -> bool {
-    !std::io::IsTerminal::is_terminal(&std::io::stdin())
+/// The default policy when the caller did not state one: nothing can answer an
+/// approval prompt in the next few minutes if stdin has no TTY. Daemon ticks,
+/// schedules, cron and the fleet loop all land here, which is exactly where
+/// waiting out a gate timeout converts the whole window into an automatic
+/// denial.
+fn default_unanswered() -> mur_common::hitl::Unanswered {
+    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        mur_common::hitl::Unanswered::Wait
+    } else {
+        mur_common::hitl::Unanswered::Defer
+    }
 }
 
 /// Display-only step lifecycle event for progress observers. The callback
@@ -814,7 +820,7 @@ async fn execute_step(
             cid,
             &req,
             opts.yes,
-            opts.hitl_defer.unwrap_or_else(unattended),
+            opts.hitl_unanswered.unwrap_or_else(default_unanswered),
             None,
             Some(opts.run_id.as_str()),
         )
@@ -1240,9 +1246,9 @@ pub async fn execute_dag(
         // Concurrent: spawn each step in this rank.
         // Extract owned values from opts for the spawned tasks.
         let opt_yes = opts.yes;
-        // Resolve once per rank, not per step: `unattended()` probes the TTY,
+        // Resolve once per rank, not per step: the default probes the TTY,
         // and every step in a run must agree on whether a human is watching.
-        let opt_hitl_defer = Some(opts.hitl_defer.unwrap_or_else(unattended));
+        let opt_hitl_unanswered = Some(opts.hitl_unanswered.unwrap_or_else(default_unanswered));
         let opt_input = opts.input.clone();
         let opt_env_override = opts.env_class_override.map(|s| s.to_string());
         let opt_vars = opts.variables.clone();
@@ -1275,7 +1281,7 @@ pub async fn execute_dag(
                 };
                 let opts_clone = DagExecOptions {
                     yes: opt_yes,
-                    hitl_defer: opt_hitl_defer,
+                    hitl_unanswered: opt_hitl_unanswered,
                     input: inp,
                     env_class_override: env_override.as_deref(),
                     variables: vars,

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use mur_channel::ChannelService;
 use mur_common::channel::{ChannelActor, ChannelState, EventKind};
-use mur_common::hitl::{HitlMode, HitlRequest, HitlResponse, RiskTier, default_mode};
+use mur_common::hitl::{HitlMode, HitlRequest, HitlResponse, RiskTier, Unanswered, default_mode};
 
 use crate::channel_writer::ROUTER_AGENT;
 use crate::hitl::pin::action_hash;
@@ -65,10 +65,13 @@ pub(crate) fn within_approval_ttl(
 /// Gate an action. `yes` auto-approves Ask-tier actions (records an `auto`
 /// HitlResponse for the audit trail). Read tier returns `allow` immediately.
 ///
-/// `defer` selects what happens when an Ask-tier action has no answer yet:
-/// `false` blocks the caller polling for up to `timeout` (attended);
-/// `true` parks the request and returns `deferred` at once (unattended).
-/// Either way a settled decision for the same `action_hash` — from any earlier
+/// `unanswered` selects what happens when an Ask-tier action has no answer
+/// yet: `Wait` blocks the caller polling for up to `timeout` (attended),
+/// `Defer` parks the request and returns `deferred` at once (unattended), and
+/// `Deny` refuses without writing a request at all. `Deny` is a policy floor,
+/// so it short-circuits before any lookup — a run declared free of risk-tiered
+/// work stays that way even if an older approval for the same action exists.
+/// Otherwise a settled decision for the same `action_hash` — from any earlier
 /// run, inside the TTL — releases the gate without asking again.
 ///
 /// Takes `mur_home: &Path` rather than `&ChannelService` so `ChannelService` is
@@ -78,7 +81,7 @@ pub async fn gate(
     channel_id: &str,
     req: &ActionRequest,
     yes: bool,
-    defer: bool,
+    unanswered: Unanswered,
     timeout: Option<Duration>,
     run_id: Option<&str>,
 ) -> Result<GateDecision> {
@@ -104,6 +107,17 @@ pub async fn gate(
             action_hash: hash,
         }),
         HitlMode::Ask => {
+            // Policy floor: refuse before looking anything up, so an approval
+            // recorded under a looser policy cannot release a gate the fleet
+            // has since declared off-limits.
+            if unanswered == Unanswered::Deny {
+                return Ok(GateDecision {
+                    allow: false,
+                    deferred: false,
+                    reason: "policy: approvals disabled for this run".into(),
+                    action_hash: hash,
+                });
+            }
             let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT);
             // Resolve signature-enforcement ONCE here (not deep in the poll
             // loop) so `wait_for_response` is pure w.r.t. config and tests never
@@ -125,7 +139,7 @@ pub async fn gate(
                 Prior::Settled(d) => return Ok(d),
                 // Already parked and unanswered: point at the EXISTING
                 // request rather than writing a second one.
-                Prior::Pending(existing_id) if defer => {
+                Prior::Pending(existing_id) if unanswered == Unanswered::Defer => {
                     return Ok(GateDecision {
                         allow: false,
                         deferred: true,
@@ -181,7 +195,7 @@ pub async fn gate(
             // stays `InputRequired`, so the answer can arrive at any time from
             // any surface — nobody is made to wait 5 minutes to learn that
             // nobody is watching.
-            if defer {
+            if unanswered == Unanswered::Defer {
                 return Ok(GateDecision {
                     allow: false,
                     deferred: true,
@@ -433,7 +447,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Read),
             false,
-            false,
+            Unanswered::Wait,
             None,
             Some("run-g"),
         )
@@ -460,7 +474,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             true,
-            false,
+            Unanswered::Wait,
             None,
             Some("run-paused"),
         )
@@ -510,9 +524,17 @@ mod tests {
             &r.step_or_call_id,
             &r.agent_id,
         );
-        let d = gate(tmp.path(), &ch.id, &r, true, false, None, Some("run-g"))
-            .await
-            .unwrap();
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &r,
+            true,
+            Unanswered::Wait,
+            None,
+            Some("run-g"),
+        )
+        .await
+        .unwrap();
         assert!(d.allow, "--yes auto-approves a high tier");
         assert_eq!(d.action_hash, hash);
         // Check the trail via a fresh open.
@@ -756,7 +778,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-1"),
         )
@@ -787,7 +809,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-1"),
         )
@@ -804,7 +826,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-2"),
         )
@@ -832,7 +854,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-1"),
         )
@@ -846,7 +868,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-2"),
         )
@@ -875,7 +897,7 @@ mod tests {
                 &ch.id,
                 &req(RiskTier::Destructive),
                 false,
-                true,
+                Unanswered::Defer,
                 None,
                 Some(&format!("run-{run}")),
             )
@@ -905,7 +927,7 @@ mod tests {
             &ch.id,
             &req(RiskTier::Destructive),
             false,
-            true,
+            Unanswered::Defer,
             None,
             Some("run-1"),
         )
@@ -916,13 +938,92 @@ mod tests {
 
         let mut other = req(RiskTier::Destructive);
         other.tool_input = serde_json::json!({ "cmd": "rm -rf /" });
-        let d = gate(tmp.path(), &ch.id, &other, false, true, None, Some("run-2"))
-            .await
-            .unwrap();
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &other,
+            false,
+            Unanswered::Defer,
+            None,
+            Some("run-2"),
+        )
+        .await
+        .unwrap();
         assert!(
             d.deferred && !d.allow,
             "a different action must be asked separately"
         );
+    }
+
+    /// `deny` is a policy floor, not a preference: it must refuse even when
+    /// the channel carries a fresh, valid approval for exactly this action.
+    /// If an old approval could out-rank the current policy, declaring a fleet
+    /// off-limits would be advisory only.
+    #[tokio::test]
+    async fn deny_mode_outranks_an_existing_approval() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        // Park a request and approve it under the permissive policy.
+        gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            Unanswered::Defer,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        let id = pending_request_ids(tmp.path(), &ch.id).pop().unwrap();
+        answer(tmp.path(), &ch.id, &id, true);
+
+        // Same action, now under `deny`.
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            false,
+            Unanswered::Deny,
+            None,
+            Some("run-2"),
+        )
+        .await
+        .unwrap();
+        assert!(!d.allow, "policy floor must outrank a prior approval");
+        assert!(!d.deferred, "deny is a verdict, not a parked question");
+        assert_eq!(
+            pending_request_ids(tmp.path(), &ch.id).len(),
+            1,
+            "deny must not write a request nobody can answer"
+        );
+    }
+
+    /// `deny` also must not out-rank `--yes`… by accident in the other
+    /// direction: `yes` is unreachable from unattended fleet paths, but if a
+    /// caller passes both, the floor still wins.
+    #[tokio::test]
+    async fn deny_mode_outranks_yes() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            true,
+            Unanswered::Deny,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        assert!(!d.allow, "a floor that --yes can lift is not a floor");
     }
 
     /// The TTL bounds how long a decision keeps releasing a gate. Content

--- a/mur-daemon/src/fleet_tick.rs
+++ b/mur-daemon/src/fleet_tick.rs
@@ -222,6 +222,7 @@ mod tests {
             }),
             team_id: None,
             parallel: None,
+            hitl: None,
             requires_programs: vec![],
         }
     }


### PR DESCRIPTION
Follow-on to #993. P0 chose defer-vs-wait from whether stdin is a TTY — a proxy for "somebody is watching" that is wrong in **both** directions:

- a monitored ops fleet running headless has a human on Hub and wants to **wait**;
- a fleet that must never reach for a person wants an immediate, legible **refusal** instead of parking a request nobody will answer.

## What this adds

```yaml
hitl:
  mode: defer      # defer | wait | deny   (absent = auto by TTY, i.e. P0 behavior)
```

`Unanswered::{Defer, Wait, Deny}` in `mur-common/src/hitl.rs` is a **policy floor**: every value either tightens the outcome or changes *who waits*. None of them approves anything, and there is deliberately **no auto-approve knob** — that is what `--yes` is, and it stays unreachable from unattended fleet paths.

**`Deny` short-circuits before the resume scan.** A fleet declared free of risk-tiered work stays that way even when the channel still carries a valid approval for the same action, and even if a caller passes `yes: true`. A floor that an old approval or a stray flag can lift is not a floor — both directions are locked in by tests.

Also renames `DagExecOptions.hitl_defer: Option<bool>` → `hitl_unanswered: Option<Unanswered>`; three outcomes never fit a bool. `None` still means auto.

## Deliberately not in this PR

Scoped standing grants — the approval-fatigue answer proper. Two decisions block it, and both are the owner's rather than the implementer's, so they are written into the spec instead of guessed:

1. **What is grantable at the DAG gate.** Its `tool_name` is `sh` or `intent`, not `write_file` — those are *runtime* tool-gate names. A fleet-level grant must therefore key on a risk tier, a step id, or a command pattern. Command patterns are the leakiest of the three (`git status; rm -rf /`) and should not be the first shape built.
2. **Whether a standing grant may cover Ask tier at all**, which loosens the posture CLAUDE.md pins today ("never blanket-approve risk-tiered steps"). Tier-and-fleet-scoped is narrower than `--yes`, but it is still a posture change.

Approval TTL stays a constant (7 days) — the pin already bounds *content* staleness, and a configurable clock is a knob with no demand behind it.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run -p mur-core -p mur-common -E 'test(/hitl::|fleet|executor::dag/)'` → **458/458**, including 3 new: yaml parse for all three modes (and an unknown mode rejected rather than silently falling back to something looser), `deny_mode_outranks_an_existing_approval`, `deny_mode_outranks_yes`

Spec updated: `docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)