### PR TITLE
feat(hitl): tier-keyed standing grants, capped at write (P1b)

### DIFF
--- a/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
+++ b/docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md
@@ -81,26 +81,47 @@ both directions. A monitored ops fleet running headless has a human on Hub and
 wants `wait`; a fleet that must never reach for a person wants `deny` so the
 failure is immediate and legible instead of a request nobody will answer.
 
-**Not shipped: scoped standing grants.** The approval-fatigue answer proper —
-named grants (tool class × path scope × per-run cap × TTL), signed with the
-fleet bundle, evaluated in pure code with a model able to narrow or escalate
-but never widen. Two things must be decided first, and both are the owner's
-call, not the implementer's:
+**Shipped (P1b): tier-keyed standing grants, capped at `write`.**
 
-1. **What is grantable at the DAG gate.** The gate's `tool_name` is `sh` or
-   `intent`, not `write_file` — those are *runtime* tool-gate names. So a
-   fleet-level grant must key on something else: a risk tier ("write is fine
-   here, destructive still asks"), a step id, or a command pattern. Command
-   patterns are the leakiest of the three (`git status; rm -rf /`) and should
-   not be the first shape built.
-2. **Whether a standing grant may cover Ask tier at all**, which is a
-   deliberate loosening of the posture CLAUDE.md pins today ("never
-   blanket-approve risk-tiered steps"). Tier-scoped and fleet-scoped is
-   narrower than `--yes`, but it is still a posture change.
+```yaml
+hitl:
+  mode: defer
+  auto_approve_tiers: [read, write]   # owner takes standing responsibility
+```
 
-Approval TTL stays a constant (7 days, `HITL_APPROVAL_TTL_SECS`) until someone
-needs otherwise: the pin already bounds *content* staleness, and a
-configurable clock adds a knob with no demand behind it.
+Decisions recorded from the owner's answers to the two open questions:
+
+- **Grant key = risk tier**, the owner's explicit choice (2026-08-19). It is
+  the only key a model cannot widen by rewriting its own input: a command
+  pattern is evadable with `git status; rm -rf /`, and step ids rotate as
+  workflows change. A tier says what *kind* of action is pre-approved, which
+  is exactly the property a standing grant should have.
+- **A standing grant may cover `write` and below.** `tier_may_be_granted`
+  (`mur-common/src/hitl.rs`) is the hard ceiling: `Spend`/`Destructive`/
+  `Privileged` are the actions whose cost a human cannot undo by noticing
+  later, and `NetworkEgress` is how data leaves — none behind a config line
+  today. Widening the list is a code change with a reviewer, not a YAML
+  value.
+
+Enforcement is defense-in-depth, all three layers:
+
+1. `FleetHitl::validate()` refuses an out-of-ceiling tier at `load_fleet` —
+   loud, so a user who wrote `destructive` learns it did NOT take effect.
+2. `GatePolicy::grants()` re-checks `tier_may_be_granted` inside the gate, so
+   a hand-edited fleet.yaml that skipped validation still cannot grant.
+3. Ordering inside the Ask tier, strictest first: `Deny` floor → a settled
+   human decision for this exact action → the tier grant → park-or-wait. A
+   human's explicit "no" therefore outranks a standing grant (locked in by
+   `a_human_denial_outranks_a_tier_grant`).
+
+Every grant-driven approval is still **audited**: the gate writes the
+request+response pair to the channel with `surface: "policy"` and a reason
+naming the pre-approved tier, so "what did this unattended run do without
+asking me?" stays answerable after the fact.
+
+Approval TTL stays a constant (7 days, `HITL_APPROVAL_TTL_SECS`): the pin
+already bounds *content* staleness, and a configurable clock is a knob with
+no demand behind it.
 
 ### Layer 2 — Divert, don't block (structure) [P0 park; P2 divert]
 

--- a/mur-common/src/fleet.rs
+++ b/mur-common/src/fleet.rs
@@ -54,6 +54,41 @@ pub struct FleetHitl {
     /// even headless; a fleet that must never reach for a human wants `deny`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<crate::hitl::Unanswered>,
+    /// Risk tiers this fleet's owner has taken standing responsibility for:
+    /// the gate approves them without asking, and records the auto-approval on
+    /// the channel so the run is still auditable.
+    ///
+    /// An explicit LIST, not a ceiling — `RiskTier`'s ordering would make
+    /// `up_to: spend` quietly cover `network-egress` too, and a grant nobody
+    /// meant to write is the whole failure mode this feature has to avoid.
+    /// [`crate::hitl::tier_may_be_granted`] bounds what may appear here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_approve_tiers: Vec<crate::hitl::RiskTier>,
+}
+
+impl FleetHitl {
+    /// Reject a policy that grants more than config is allowed to grant.
+    ///
+    /// Loud at load time rather than silently ignored at the gate: a user who
+    /// wrote `destructive` here believes it took effect, and the gap between
+    /// that belief and the truth is where the damage lives.
+    pub fn validate(&self) -> Result<(), String> {
+        let bad: Vec<String> = self
+            .auto_approve_tiers
+            .iter()
+            .filter(|t| !crate::hitl::tier_may_be_granted(**t))
+            .map(|t| format!("{t:?}").to_lowercase())
+            .collect();
+        if bad.is_empty() {
+            return Ok(());
+        }
+        Err(format!(
+            "hitl.auto_approve_tiers may not include {} — standing approval is capped at `write`. \
+             Those actions have to be approved per-run (`mur channel approve`), because their cost \
+             cannot be undone by noticing afterwards.",
+            bad.join(", ")
+        ))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -261,6 +296,32 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    /// `auto_approve_tiers` parses; `validate` accepts write-and-below and
+    /// refuses everything above — loudly, because a user who wrote
+    /// `destructive` believes it took effect, and the gap between that belief
+    /// and the truth is where the damage lives.
+    #[test]
+    fn auto_approve_tiers_parse_and_validate_against_the_ceiling() {
+        let f: Fleet = serde_yaml::from_str(
+            "name: dev\nchannel_id: fleet-dev\nhitl:\n  auto_approve_tiers: [read, write]\n",
+        )
+        .unwrap();
+        let hitl = f.hitl.as_ref().unwrap();
+        assert_eq!(
+            hitl.auto_approve_tiers,
+            vec![crate::hitl::RiskTier::Read, crate::hitl::RiskTier::Write]
+        );
+        assert!(hitl.validate().is_ok());
+
+        let f: Fleet = serde_yaml::from_str(
+            "name: dev\nchannel_id: fleet-dev\nhitl:\n  auto_approve_tiers: [write, destructive]\n",
+        )
+        .unwrap();
+        let err = f.hitl.as_ref().unwrap().validate().unwrap_err();
+        assert!(err.contains("destructive"), "{err}");
+        assert!(err.contains("write"), "the ceiling must be named: {err}");
     }
 
     #[test]

--- a/mur-common/src/hitl.rs
+++ b/mur-common/src/hitl.rs
@@ -61,6 +61,28 @@ pub enum Unanswered {
     Deny,
 }
 
+impl Default for Unanswered {
+    /// The strict end of the three: a policy built without stating a mode must
+    /// never be the one that waits or lets something through.
+    fn default() -> Self {
+        Unanswered::Defer
+    }
+}
+
+/// May a run's owner take standing responsibility for this tier in config —
+/// i.e. pre-approve it once instead of being asked every time?
+///
+/// Capped at `Write` deliberately. A standing grant is real authority handed
+/// to an unattended process, so widening it is a decision to make in code with
+/// its reasoning written down, never something a user acquires by typing one
+/// more word into a YAML file. `Spend`, `Destructive` and `Privileged` are
+/// exactly the actions whose cost a human cannot undo by noticing later, and
+/// `NetworkEgress` is how data leaves — none of them belongs behind a config
+/// line today.
+pub fn tier_may_be_granted(tier: RiskTier) -> bool {
+    matches!(tier, RiskTier::Read | RiskTier::Write)
+}
+
 /// `EventKind::HitlRequest` payload: the durable, pinned approval request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HitlRequest {
@@ -117,5 +139,18 @@ mod tests {
         let back: HitlRequest = serde_json::from_str(&s).unwrap();
         assert_eq!(back.tier, RiskTier::Destructive);
         assert_eq!(back.action_hash, "abc");
+    }
+
+    /// The grantable ceiling. Widening this list is a security decision that
+    /// belongs in a commit message, not a YAML typo — the test exists so the
+    /// reviewer has to read the reasoning right here.
+    #[test]
+    fn tier_grant_ceiling_is_write() {
+        assert!(tier_may_be_granted(RiskTier::Read));
+        assert!(tier_may_be_granted(RiskTier::Write));
+        assert!(!tier_may_be_granted(RiskTier::NetworkEgress));
+        assert!(!tier_may_be_granted(RiskTier::Spend));
+        assert!(!tier_may_be_granted(RiskTier::Destructive));
+        assert!(!tier_may_be_granted(RiskTier::Privileged));
     }
 }

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -594,6 +594,11 @@ pub async fn run_guarded(
             // Fleet-declared approval policy (`hitl.mode`); `None` keeps the
             // TTY-derived default. Tightening only — nothing here approves.
             hitl_unanswered: fleet.hitl.as_ref().and_then(|h| h.mode),
+            hitl_auto_approve_tiers: fleet
+                .hitl
+                .as_ref()
+                .map(|h| h.auto_approve_tiers.clone())
+                .unwrap_or_default(),
             channel_id: Some(fleet.channel_id.clone()),
             // uuid nonce so concurrent `--loop` runs don't collide on the
             // channel's idempotency-key dedup (the iteration stays for readability).

--- a/mur-core/src/cmd/fleet/run.rs
+++ b/mur-core/src/cmd/fleet/run.rs
@@ -385,6 +385,11 @@ pub async fn cmd_fleet_run(
         // keeps the TTY-derived default. It can only tighten: there is no
         // value here that approves anything.
         hitl_unanswered: fleet.hitl.as_ref().and_then(|h| h.mode),
+        hitl_auto_approve_tiers: fleet
+            .hitl
+            .as_ref()
+            .map(|h| h.auto_approve_tiers.clone())
+            .unwrap_or_default(),
         channel_id: Some(fleet.channel_id.clone()),
         run_id: run_id.clone(),
         run_kind: Some(crate::run_status::RunKind::Fleet),

--- a/mur-core/src/cmd/fleet/store.rs
+++ b/mur-core/src/cmd/fleet/store.rs
@@ -50,7 +50,19 @@ pub fn load_fleet(mur_home: &Path, name: &str) -> Result<Fleet> {
     let path = fleet_path(mur_home, name);
     let raw = std::fs::read_to_string(&path)
         .with_context(|| format!("fleet '{name}' not found at {}", path.display()))?;
-    serde_yaml::from_str(&raw).with_context(|| format!("parse fleet '{name}'"))
+    let fleet: Fleet =
+        serde_yaml::from_str(&raw).with_context(|| format!("parse fleet '{name}'"))?;
+    // Reject a policy that grants more than config is allowed to grant, at
+    // the moment a run (or daemon tick) would trust it — a fleet that sits on
+    // disk with an invalid grant must not stay silent until the gate quietly
+    // ignores it.
+    fleet
+        .hitl
+        .as_ref()
+        .map(|h| h.validate())
+        .transpose()
+        .map_err(anyhow::Error::msg)?;
+    Ok(fleet)
 }
 
 /// List the names of all persisted fleets (sorted).

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -95,6 +95,11 @@ pub struct DagExecOptions<'a> {
     /// explicitly (fleet.yaml `hitl.mode`) when the TTY is a poor proxy for
     /// "somebody is watching".
     pub hitl_unanswered: Option<mur_common::hitl::Unanswered>,
+    /// Risk tiers the run's owner pre-approved (fleet.yaml
+    /// `hitl.auto_approve_tiers`). Empty = every Ask-tier action still needs a
+    /// person. Capped at `write` by `mur_common::hitl::tier_may_be_granted`,
+    /// re-checked inside the gate.
+    pub hitl_auto_approve_tiers: Vec<mur_common::hitl::RiskTier>,
     /// Explicit override of the env classification (P4-ready).
     pub env_class_override: Option<&'a str>,
     /// Variable substitutions: `(name, value)` pairs for `{{name}}` in commands.
@@ -147,6 +152,7 @@ impl<'a> Default for DagExecOptions<'a> {
             input: None,
             yes: false,
             hitl_unanswered: None,
+            hitl_auto_approve_tiers: Vec::new(),
             env_class_override: None,
             variables: vec![],
             device_id: "cli".to_string(),
@@ -819,8 +825,11 @@ async fn execute_step(
             mur_home,
             cid,
             &req,
-            opts.yes,
-            opts.hitl_unanswered.unwrap_or_else(default_unanswered),
+            &crate::hitl::gate::GatePolicy {
+                yes: opts.yes,
+                unanswered: opts.hitl_unanswered.unwrap_or_else(default_unanswered),
+                auto_approve_tiers: opts.hitl_auto_approve_tiers.clone(),
+            },
             None,
             Some(opts.run_id.as_str()),
         )
@@ -1248,6 +1257,7 @@ pub async fn execute_dag(
         let opt_yes = opts.yes;
         // Resolve once per rank, not per step: the default probes the TTY,
         // and every step in a run must agree on whether a human is watching.
+        let opt_hitl_tiers = opts.hitl_auto_approve_tiers.clone();
         let opt_hitl_unanswered = Some(opts.hitl_unanswered.unwrap_or_else(default_unanswered));
         let opt_input = opts.input.clone();
         let opt_env_override = opts.env_class_override.map(|s| s.to_string());
@@ -1271,6 +1281,7 @@ pub async fn execute_dag(
             let chan_id = opt_chan_id.clone();
             let run_id = opt_run_id.clone();
             let on_step = opt_on_step.clone();
+            let hitl_tiers = opt_hitl_tiers.clone();
             let sem = sem.clone();
             let mh = mur_home.to_path_buf();
             handles.push(tokio::task::spawn(async move {
@@ -1282,6 +1293,7 @@ pub async fn execute_dag(
                 let opts_clone = DagExecOptions {
                     yes: opt_yes,
                     hitl_unanswered: opt_hitl_unanswered,
+                    hitl_auto_approve_tiers: hitl_tiers,
                     input: inp,
                     env_class_override: env_override.as_deref(),
                     variables: vars,

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -36,6 +36,7 @@ pub struct ActionRequest {
 /// `allow: false`) means nobody answered AND nobody was made to wait: the
 /// request is parked durably in the channel and the caller should mark the
 /// step blocked — not failed — so a later approval can release it.
+#[derive(Debug)]
 pub struct GateDecision {
     pub allow: bool,
     pub deferred: bool,
@@ -62,8 +63,33 @@ pub(crate) fn within_approval_ttl(
     (now - event_ts).num_seconds() <= HITL_APPROVAL_TTL_SECS
 }
 
-/// Gate an action. `yes` auto-approves Ask-tier actions (records an `auto`
-/// HitlResponse for the audit trail). Read tier returns `allow` immediately.
+/// Everything the gate needs to know about the run's approval posture.
+///
+/// Bundled rather than passed as loose arguments so a future knob cannot be
+/// added at a call site without the other two being considered — this is the
+/// struct that decides whether an unattended process acts without a human.
+#[derive(Debug, Clone, Default)]
+pub struct GatePolicy {
+    /// `--yes`: auto-approve every Ask-tier action. Interactive/explicit only;
+    /// unattended fleet paths pass `false` and must keep doing so.
+    pub yes: bool,
+    /// What happens when nobody has answered yet.
+    pub unanswered: Unanswered,
+    /// Tiers the run's owner pre-approved in config. Filtered through
+    /// [`mur_common::hitl::tier_may_be_granted`] on the way in AND checked
+    /// again here, so a hand-edited fleet.yaml that skipped validation still
+    /// cannot grant `destructive`.
+    pub auto_approve_tiers: Vec<RiskTier>,
+}
+
+impl GatePolicy {
+    /// Has this tier been pre-approved for this run?
+    fn grants(&self, tier: RiskTier) -> bool {
+        mur_common::hitl::tier_may_be_granted(tier) && self.auto_approve_tiers.contains(&tier)
+    }
+}
+
+/// Gate an action. Read tier returns `allow` immediately.
 ///
 /// `unanswered` selects what happens when an Ask-tier action has no answer
 /// yet: `Wait` blocks the caller polling for up to `timeout` (attended),
@@ -76,12 +102,16 @@ pub(crate) fn within_approval_ttl(
 ///
 /// Takes `mur_home: &Path` rather than `&ChannelService` so `ChannelService` is
 /// never held across `.await` — keeping the returned future `Send`.
+/// Ordering inside the Ask tier, strictest first: the `Deny` floor, then a
+/// settled human decision for this exact action, then a standing tier grant,
+/// then park-or-wait. A human's explicit "no" therefore outranks a standing
+/// grant — a decision someone actually made about this action beats a blanket
+/// one made in advance about its category.
 pub async fn gate(
     mur_home: &Path,
     channel_id: &str,
     req: &ActionRequest,
-    yes: bool,
-    unanswered: Unanswered,
+    policy: &GatePolicy,
     timeout: Option<Duration>,
     run_id: Option<&str>,
 ) -> Result<GateDecision> {
@@ -110,7 +140,7 @@ pub async fn gate(
             // Policy floor: refuse before looking anything up, so an approval
             // recorded under a looser policy cannot release a gate the fleet
             // has since declared off-limits.
-            if unanswered == Unanswered::Deny {
+            if policy.unanswered == Unanswered::Deny {
                 return Ok(GateDecision {
                     allow: false,
                     deferred: false,
@@ -119,6 +149,11 @@ pub async fn gate(
                 });
             }
             let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT);
+            // Pre-approved by config for this tier. Computed before the scan so
+            // it can also skip a stale pending request left over from before
+            // the grant was written — but deliberately NOT before the scan's
+            // `Settled` arm, so a human's explicit denial still outranks it.
+            let granted = policy.grants(req.tier);
             // Resolve signature-enforcement ONCE here (not deep in the poll
             // loop) so `wait_for_response` is pure w.r.t. config and tests never
             // race on a process-global env var. Only explicit truthy values
@@ -139,7 +174,9 @@ pub async fn gate(
                 Prior::Settled(d) => return Ok(d),
                 // Already parked and unanswered: point at the EXISTING
                 // request rather than writing a second one.
-                Prior::Pending(existing_id) if unanswered == Unanswered::Defer => {
+                Prior::Pending(existing_id)
+                    if !granted && policy.unanswered == Unanswered::Defer =>
+                {
                     return Ok(GateDecision {
                         allow: false,
                         deferred: true,
@@ -194,8 +231,9 @@ pub async fn gate(
             // Park instead of polling. The request is durable and the channel
             // stays `InputRequired`, so the answer can arrive at any time from
             // any surface — nobody is made to wait 5 minutes to learn that
-            // nobody is watching.
-            if unanswered == Unanswered::Defer {
+            // nobody is watching. A granted tier skips this: it has an answer
+            // already, given in advance.
+            if !granted && policy.unanswered == Unanswered::Defer {
                 return Ok(GateDecision {
                     allow: false,
                     deferred: true,
@@ -204,13 +242,22 @@ pub async fn gate(
                 });
             }
 
-            let decision = if yes {
+            let decision = if policy.yes || granted {
+                // Record the auto-approval on the channel even though no human
+                // saw it: "what did this unattended run do without asking me?"
+                // has to be answerable afterwards, and the request+response
+                // pair is where that answer lives.
+                let why = if policy.yes {
+                    "--yes".to_string()
+                } else {
+                    format!("fleet policy: {:?} tier pre-approved", req.tier).to_lowercase()
+                };
                 let resp = HitlResponse {
                     hitl_id: hitl_id.clone(),
                     action_hash: hash.clone(),
                     allow: true,
-                    reason: "--yes".into(),
-                    surface: "auto".into(),
+                    reason: why.clone(),
+                    surface: if policy.yes { "auto" } else { "policy" }.into(),
                 };
                 {
                     let svc = ChannelService::open(mur_home)?;
@@ -228,7 +275,7 @@ pub async fn gate(
                 GateDecision {
                     allow: true,
                     deferred: false,
-                    reason: "auto-approved (--yes)".into(),
+                    reason: format!("auto-approved ({why})"),
                     action_hash: hash.clone(),
                 }
             } else {
@@ -446,8 +493,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Read),
-            false,
-            Unanswered::Wait,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Wait,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-g"),
         )
@@ -473,8 +523,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            true,
-            Unanswered::Wait,
+            &GatePolicy {
+                yes: true,
+                unanswered: Unanswered::Wait,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-paused"),
         )
@@ -528,8 +581,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &r,
-            true,
-            Unanswered::Wait,
+            &GatePolicy {
+                yes: true,
+                unanswered: Unanswered::Wait,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-g"),
         )
@@ -777,8 +833,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -808,8 +867,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -825,8 +887,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-2"),
         )
@@ -853,8 +918,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -867,8 +935,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-2"),
         )
@@ -896,8 +967,11 @@ mod tests {
                 tmp.path(),
                 &ch.id,
                 &req(RiskTier::Destructive),
-                false,
-                Unanswered::Defer,
+                &GatePolicy {
+                    yes: false,
+                    unanswered: Unanswered::Defer,
+                    auto_approve_tiers: vec![],
+                },
                 None,
                 Some(&format!("run-{run}")),
             )
@@ -926,8 +1000,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -942,8 +1019,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &other,
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-2"),
         )
@@ -971,8 +1051,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Defer,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Defer,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -986,8 +1069,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            false,
-            Unanswered::Deny,
+            &GatePolicy {
+                yes: false,
+                unanswered: Unanswered::Deny,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-2"),
         )
@@ -1016,8 +1102,11 @@ mod tests {
             tmp.path(),
             &ch.id,
             &req(RiskTier::Destructive),
-            true,
-            Unanswered::Deny,
+            &GatePolicy {
+                yes: true,
+                unanswered: Unanswered::Deny,
+                auto_approve_tiers: vec![],
+            },
             None,
             Some("run-1"),
         )
@@ -1040,5 +1129,133 @@ mod tests {
             now - chrono::Duration::seconds(HITL_APPROVAL_TTL_SECS + 1),
             now
         ));
+    }
+
+    // ── Standing tier grants (P1b) ────────────────────────────────────────
+
+    fn write_policy(grant: bool) -> GatePolicy {
+        GatePolicy {
+            yes: false,
+            unanswered: Unanswered::Defer,
+            auto_approve_tiers: if grant {
+                vec![RiskTier::Write]
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    /// A granted tier runs without a human — but the run must stay answerable:
+    /// the auto-approval is recorded on the channel as a request+response pair,
+    /// so "what did this unattended run do without asking me?" has an answer.
+    #[tokio::test]
+    async fn granted_write_tier_runs_and_is_audited() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        let mut r = req(RiskTier::Write);
+        r.tool_input = serde_json::json!({ "cmd": "touch ./x" });
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &r,
+            &write_policy(true),
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        assert!(d.allow, "granted tier must not ask: {d:?}");
+        assert!(!d.deferred);
+
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let responses: Vec<HitlResponse> = svc
+            .load_events(&ch.id)
+            .unwrap()
+            .iter()
+            .filter(|e| e.kind == EventKind::HitlResponse)
+            .filter_map(|e| serde_json::from_value(e.payload.clone()).ok())
+            .collect();
+        assert_eq!(
+            responses.len(),
+            1,
+            "the auto-approval must be on the channel"
+        );
+        assert!(responses[0].allow);
+        assert!(
+            responses[0].reason.contains("pre-approved"),
+            "reason must say WHERE the authority came from: {:?}",
+            responses[0].reason
+        );
+    }
+
+    /// A human's explicit "no" to THIS action outranks a standing grant for its
+    /// tier — a decision someone actually made beats a blanket one made in
+    /// advance.
+    #[tokio::test]
+    async fn a_human_denial_outranks_a_tier_grant() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        // Ask under a no-grant policy, and get denied.
+        gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Write),
+            &write_policy(false),
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        let id = pending_request_ids(tmp.path(), &ch.id).pop().unwrap();
+        answer(tmp.path(), &ch.id, &id, false);
+
+        // Same action, now under a write grant.
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Write),
+            &write_policy(true),
+            None,
+            Some("run-2"),
+        )
+        .await
+        .unwrap();
+        assert!(!d.allow, "the human said no; the grant must not override");
+    }
+
+    /// The ceiling is enforced inside the gate too, so a hand-edited
+    /// fleet.yaml that skipped validation still cannot grant `destructive`.
+    #[tokio::test]
+    async fn an_ungrantable_tier_is_ignored_even_if_listed() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        drop(svc);
+
+        let policy = GatePolicy {
+            yes: false,
+            unanswered: Unanswered::Defer,
+            auto_approve_tiers: vec![RiskTier::Destructive],
+        };
+        let d = gate(
+            tmp.path(),
+            &ch.id,
+            &req(RiskTier::Destructive),
+            &policy,
+            None,
+            Some("run-1"),
+        )
+        .await
+        .unwrap();
+        assert!(
+            d.deferred && !d.allow,
+            "destructive must still wait for a person, not honor the config line"
+        );
     }
 }


### PR DESCRIPTION
Follow-on to #1000 (P1a). The owner has decided: **grants key on risk tier, starting with `write`.**

```yaml
hitl:
  mode: defer
  auto_approve_tiers: [read, write]   # the owner takes standing responsibility
```

## Why tier, why write

- **Key = risk tier.** The only grant key a model cannot widen by rewriting its own input — a command pattern is evadable with `git status; rm -rf /`, and step ids rotate as workflows change. A tier says what *kind* of action is pre-approved, which is exactly what a standing grant should mean.
- **Ceiling = `write`.** `Spend`/`Destructive`/`Privileged` are actions whose cost a human cannot undo by noticing later, and `NetworkEgress` is how data leaves — none of them belongs behind a config line today. `tier_may_be_granted` is the single place the list lives; widening it is a code change with a reviewer.

## Enforcement: three layers

1. **`FleetHitl::validate()`** at `load_fleet` — loud, so a user who wrote `destructive` learns it did NOT take effect instead of discovering it from a failed run.
2. **`GatePolicy::grants()`** re-checks the ceiling *inside the gate*, so a hand-edited fleet.yaml that skipped validation still cannot grant.
3. **Ordering**, strictest first: `Deny` floor → a settled human decision for this exact action → the tier grant → park-or-wait. A human's explicit "no" to this action outranks a standing grant for its tier — a decision someone actually made beats a blanket one made in advance.

## Auditability

A grant-driven approval is not invisible: the gate writes the request+response pair to the channel with `surface: "policy"` and a reason naming the tier (`auto-approved (fleet policy: write tier pre-approved)`), so "what did this unattended run do without asking me?" stays answerable after the fact.

Also: `gate()`'s posture arguments are bundled into a `GatePolicy` struct instead of loose `yes: bool, unanswered: …` params — the struct that decides whether an unattended process acts without a human should be added to as a whole, not have a knob bolted on at a call site. `GatePolicy::default()` is the strict end (`Defer`, nothing granted).

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run -p mur-core -p mur-common -E 'test(/hitl::|fleet|executor::dag/)'` → **466/466**, including 7 new: grant ceiling boundary (`tier_grant_ceiling_is_write`), validate accept/refuse, `granted_write_tier_runs_and_is_audited`, `a_human_denial_outranks_a_tier_grant`, `an_ungrantable_tier_is_ignored_even_if_listed`, yaml parse of `auto_approve_tiers`

Spec updated (`docs/superpowers/specs/2026-08-19-unattended-hitl-defer-design.md`, P1b section records the two owner decisions and the reasons).

Remaining from the original plan: P2 (worktree-diverted speculative execution with diff approval) and P3 (approval history → standing-grant proposals via `mur out`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)