### PR TITLE
fix(sandbox): partition read grants, and let Linux agents read their own config

### DIFF
--- a/docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md
+++ b/docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md
@@ -1,7 +1,7 @@
 # Agent read confinement under `~/.mur`: audit and options
 
 **Date:** 2026-08-18
-**Status:** audit complete, decision requested — nothing implemented
+**Status:** audit complete; §8 implemented (read partition + Linux runtime reads)
 **Issue:** #850
 
 ## 1. The gap, proven from the generated policy
@@ -118,11 +118,159 @@ A second guard is worth having regardless: assert the SBPL contains **no**
 `deny file-read*` covering `identity.pub` or `rotations.jsonl` in any agent
 home, so a future tightening cannot break verification without a red test.
 
-## 7. Not audited
+## 7. Central-store reads: the runtime's actual read surface
 
-Reads of the central stores (`skills/`, `channels/`, `index/`, `inbox/`,
-`compress/`, `fleets/`) — #850 deliverable 1 asks for these too. The write side
-is already granted selectively in `sandbox/policy.rs`; the read side is open and
-was not surveyed here, because the private-key exposure is the part with an
-integrity consequence and it changes what the deny plan can look like. That
-survey remains open.
+The sandboxed process is `mur-agent-runtime`; spawned children (`mur`, `bash`,
+MCP servers) inherit the same profile, so the *runtime's* reads are the whole
+confinement surface worth enumerating. Surveyed from code, not by guessing:
+every `~/.mur` path the runtime reads is a named `join(...)` site, so the list
+below is the complete one for the process the profile actually seals.
+
+### 7.1 What the runtime reads — and must be able to
+
+| path | read by | why | gated by |
+|---|---|---|---|
+| `config.yaml` | `supervisor_runner.rs:417` (model-switch), `:694` (skills), `tools/fleet_run.rs:56,124`, `tools/remember.rs:45` | global config is load-bearing | always |
+| `compress.yaml` + `compress/` | `hooks/builder.rs:38` | auto-compress hook (Surface 2) | `compress.yaml auto.enabled && auto.agent_runtime` |
+| `fleets/<name>/fleet.yaml` | `protocol/methods/channel_delegate.rs:31,48`, `tools/fleet_run.rs:137` | fleet delegation | fleet-enabled agents only |
+| `models.yaml` + `cache/` | `tools/fleet_run.rs:311-314` | spawned `mur fleet run` child | `fleet_run.agents` allowlist |
+
+The runtime **writes** (not reads) three more: `inbox/` (snapshot outbox,
+`supervisor.rs:271`), `channels/` (peer-writes-own self-reply,
+`policy.rs:226`), `index/channels/` (channels.db refresh, `policy.rs:278`).
+All three are already granted on the write side.
+
+The runtime does **not** read, at any site: `skills/`, `index/` (the `*.lance`
+stores and `capabilities.json`), `inbox/`, `models.yaml` (outside the fleet_run
+carve-in), `secrets/`, `queue/`, `session/`, `telemetry/`, `traces/`,
+`conversations/`, `commander/`. Skills injection reaches the runtime through
+hooks/CLI, not a direct read.
+
+### 7.2 The per-backend posture
+
+- **macOS (SBPL, allow-default).** None of the central stores above is in the
+  read-deny list — the `ordinary stores` gate test
+  (`launch_chain.rs:468-493`) asserts `skills/`, `channels/`, `workflows/`,
+  `commander/` pass through unrefused. So every agent can directly read
+  `skills/`, `index/`, `inbox/`, `config.yaml`, `models.yaml` today. That is
+  exactly the gap #850 deliverable 1 names; it is real and it is open.
+- **Linux (Landlock, default-deny).** The read side is the *opposite* problem
+  and it is live right now: `fs_read` is populated only from user-declared
+  entitlements, the `fleet_run` carve-in, and `system_read_paths()`
+  (`policy.rs:765`) — **`config.yaml`, `compress.yaml` and `fleets/` are not in
+  it**. Landlock denies the runtime's own config reads, so
+  `Config::load_or_default` silently falls back to defaults (wrong models),
+  the compress hook never engages, and `channel/delegate` cannot read a fleet
+  definition. Linux agents already run degraded; nobody noticed because the
+  failure is silent.
+
+### 7.3 The read-side partition gap
+
+`partition_grants` (`launch_chain.rs`) is applied to **write grants only**
+(`linux.rs partition_write_grants`); `fs_read` is never partitioned. So on
+Linux a user-declared `fs_read` that contains a protected path — e.g.
+`fs_read: [~/.mur]` or `~/.mur/secrets` — grants the read outright, because
+Landlock has no deny-within-allow. The write side drops such a grant
+fail-closed; the read side cannot, and does not. Same divergence #975 already
+warned about ("one mechanism, two backends, status tells a different story").
+
+## 8. Decision: partition `fs_read` like `fs_write`, and grant the runtime's own reads
+
+§7 turns the open "should `fs_read` be partitioned like `fs_write`?" question
+into two concrete changes that share one mechanism (the read allow-list on
+Linux is the enforcement surface; the deny list is the macOS one):
+
+**(1) Partition `fs_read` against the launch chain's protected paths.**
+Apply the same `partition_grants` the write side uses to `fs_read`, on both
+backends. On Linux this is the only thing that stops a broad read grant from
+leaking `secrets/`, `queue/`, or a sibling's `identity.key` — Landlock cannot
+carve. On macOS it is a no-op for enforcement (allow-default) but makes the
+two backends agree about what a grant may name, and feeds the same
+`dropped_grants` doctor report the write side already produces.
+
+**(2) Grant the runtime's own central-store reads on Linux.**
+Add `config.yaml`, `compress.yaml`, `fleets/`, and (when `fleet_run` is
+allowlisted) `models.yaml` to `fs_read` for every agent. Without this, Linux
+agents silently run with default config (§7.2). These are the runtime's own
+load-bearing reads, so granting them is not a widening of the trust boundary —
+it is making the allow-list match what the code already does.
+
+Both are fail-closed in the same direction: miss a path in (2) and an agent
+degrades silently; drop a grant in (1) and the agent loses a read it declared.
+Either mistake needs the canary rollout #850 already requires.
+
+**Why the two belong together:** (1) is only safe to populate *because* (2)
+names the complete legitimate read set — once `config.yaml` etc. are on the
+allow-list, the protected-path partition can drop everything else without
+starving the runtime. Shipping (2) without (1) would grant reads of
+`secrets/`-adjacent paths on the way to `config.yaml`; shipping (1) without (2)
+breaks Linux. They are one PR, verified with a canary agent first, then
+per-archetype.
+
+**macOS read-deny extension** (`skills/`, `index/`, `inbox/`) stays **out** of
+this PR. The runtime does not read them, but spawned `mur` children might
+(`mur skill show`, `mur search`), and the canary is the place to learn which
+are load-bearing before denying. The issue's "no new code paths that depend on
+direct central-store reads" rule argues for denying them eventually; the
+canary decides when.
+
+## 9. What shipped, and what it was verified against
+
+Both halves of §8, in one change:
+
+- `LaunchChain::partition_read_grants` — the read counterpart of
+  `partition_grants`, against the credential store plus sibling signing keys
+  (**not** `deny_paths()`, per §2). Applied to the **user-declared** read
+  entitlements only, at profile-build time.
+- The runtime's own reads (`config.yaml`, `compress.yaml`, `compress/`,
+  `fleets/`) added to `fs_read`, existence-checked.
+- `SandboxPolicy::dropped_read_grants` + `mur agent doctor`'s `grant_scope`
+  check extended to report them.
+
+### Why only the user-declared grants are partitioned
+
+The first cut partitioned the finished `fs_read` and silently dropped
+`/private/tmp` — a `system_read_paths()` entry — because the test's `mur_home`
+nested under it. A relocated MUR home would do the same to a real agent. Only a
+human-declared grant may be dropped, because only a human can fix it; the
+builder's own additions are not up for debate. Guarded by
+`the_builders_own_read_paths_survive_an_overbroad_user_grant`.
+
+That flaw was found by dumping a real profile, not by review.
+
+### Verified with `sandbox-exec`, against a generated profile
+
+Profile built from a policy carrying an overbroad `fs_read: [<mur_home>]`:
+
+```
+profile compiles:      sandbox-exec -f <profile> /usr/bin/true   -> exit 0
+secrets/anthropic.key  DENIED      (Operation not permitted)
+agents/pm/identity.key DENIED      (Operation not permitted)
+agents/pm/identity.pub READABLE    <- §2 constraint holds
+skills/x.yaml          READABLE
+dropped_read_grants    ["<mur_home>"]   (and nothing else)
+```
+
+Negative control: delete the one `(deny file-read* … /secrets)` line from that
+same profile and the key reads back as `SUPER-SECRET-KEY`.
+
+**What this proves about macOS:** `skills/x.yaml` is readable even though the
+partition removed its covering allow — because the SBPL baseline is
+`(allow default)`. So dropping a read grant is a **no-op on macOS** and the
+explicit denies are what confine reads there. The change is therefore
+load-bearing on Linux and behaviour-preserving on macOS, which is why it needs
+no macOS canary.
+
+### Still open after this
+
+1. **Linux cannot read peer public key material.** `<mur_home>/agents/` is in
+   no Linux read grant, so a spawned `mur` verifying a peer's signed events
+   would fail-close. macOS handles it (`macos.rs` re-allows `identity.pub` and
+   `rotations.jsonl`); Landlock has no equivalent grant. Not fixed here: it
+   needs enumeration (with the same after-seal gap as `sibling_signing_keys`),
+   and in practice it requires `spawn(mur)`, which #850 withdrew. Worth a
+   canary before building.
+2. **macOS read-deny on the central stores** (`skills/`, `index/`, `inbox/`)
+   — deliberately out of scope, per §8.
+3. **Option (c)**, moving private keys out of the agents tree — still the only
+   variant that closes the after-seal enumeration gap.

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -287,6 +287,49 @@ impl LaunchChain {
         })
     }
 
+    /// The paths no read grant may reach: the user's credential store and
+    /// sibling signing keys.
+    ///
+    /// Deliberately NOT `deny_paths()`. That contains the whole `agents/`
+    /// subtree, and a blanket read-deny there fail-closes every multi-agent
+    /// channel — verifying a peer's signed events reads `identity.pub` and
+    /// `rotations.jsonl` from that peer's home (audit §2). This set is exactly
+    /// what macOS emits as `deny file-read*`, so the two backends refuse the
+    /// same reads instead of diverging.
+    ///
+    /// Inherits `sibling_signing_keys`' after-seal gap: an agent created later
+    /// is not enumerated here either. Same reason, same fix (move private keys
+    /// out of the agents tree).
+    fn read_protected_paths(&self) -> Vec<PathBuf> {
+        let mut out = self.credential_paths();
+        out.extend(self.sibling_signing_keys());
+        out
+    }
+
+    /// Split READ grants into those the sandbox can install and those it must
+    /// drop whole — the counterpart of [`Self::partition_grants`].
+    ///
+    /// Same Landlock reasoning as the write side: a pure allow-list has no deny
+    /// rule, so a protected path inside a grant cannot be carved out and the
+    /// grant is dropped entire, fail-closed. Without this a broad `fs_read`
+    /// (`~/.mur`, or `~` itself) hands an agent the credential store outright,
+    /// while the identical write grant is refused — the divergence #850 names.
+    ///
+    /// The agent's own home is exempt, as on the write side: it must read its
+    /// own profile and state. macOS tier-3 self-protection (own `identity.key`
+    /// / `profile.yaml`) is emitted separately and is unaffected.
+    pub fn partition_read_grants(&self, grants: &[PathBuf]) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let protected = self.read_protected_paths();
+        grants.iter().cloned().partition(|g| {
+            if g.starts_with(self.agent_self_home()) {
+                return true;
+            }
+            !protected
+                .iter()
+                .any(|p| p.starts_with(g) || g.starts_with(p))
+        })
+    }
+
     /// Sibling signing keys, as concrete paths for backends that need a list
     /// rather than a predicate. The rule is `protects_read`'s; this is the
     /// enforcement side of it, which until now had no caller — the predicate
@@ -490,6 +533,71 @@ mod tests {
                 p.display()
             );
         }
+    }
+
+    /// A read grant wide enough to contain the credential store is dropped
+    /// whole, exactly as the write side already drops it. Before #850 the two
+    /// diverged: `fs_write: [~/.mur]` was refused and `fs_read: [~/.mur]` was
+    /// installed, handing out every API key on a backend with no deny rule.
+    #[test]
+    fn a_read_grant_containing_the_credential_store_is_dropped_not_carved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+        let skills = mur.join("skills");
+
+        let (kept, dropped) = chain.partition_read_grants(&[mur.clone(), skills.clone()]);
+
+        // `<mur_home>` contains `<mur_home>/secrets`, and Landlock cannot carve it out.
+        assert_eq!(dropped, vec![mur], "{kept:?}");
+        // Negative control: a grant that contains nothing protected survives intact.
+        assert_eq!(kept, vec![skills]);
+    }
+
+    /// The §2 constraint, as a test: denying a sibling's PRIVATE key must not
+    /// take its PUBLIC verification material with it. `identity.pub` and
+    /// `rotations.jsonl` are what every multi-agent channel reads to verify a
+    /// peer's signed events — dropping those grants fail-closes delegation.
+    #[test]
+    fn a_read_grant_on_peer_public_material_survives_the_signing_key_deny() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let pm = mur.join("agents").join("pm");
+        std::fs::create_dir_all(&pm).unwrap();
+        // sibling_signing_keys() enumerates what is on disk, so the key must exist.
+        std::fs::write(pm.join("identity.key"), b"k").unwrap();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+
+        let (kept, dropped) = chain.partition_read_grants(&[
+            pm.join("identity.key"),
+            pm.join("identity.pub"),
+            pm.join("rotations.jsonl"),
+        ]);
+
+        assert_eq!(dropped, vec![pm.join("identity.key")]);
+        assert_eq!(
+            kept,
+            vec![pm.join("identity.pub"), pm.join("rotations.jsonl")],
+            "public verification material must stay readable or every signed \
+             channel fails closed"
+        );
+    }
+
+    /// The agent's own home is exempt, as on the write side — it must read its
+    /// own profile and state.
+    #[test]
+    fn a_read_grant_on_the_agents_own_home_survives() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let own = mur.join("agents").join("alice");
+        let chain = LaunchChain::for_test(&own, &mur.join("bin"), &mur);
+
+        let (kept, dropped) = chain.partition_read_grants(std::slice::from_ref(&own));
+
+        assert_eq!(kept, vec![own]);
+        assert!(dropped.is_empty());
     }
 
     /// `<tmp>/agents/mur` as agent_home, so mur_home is `<tmp>`.

--- a/mur-agent-runtime/src/sandbox/linux.rs
+++ b/mur-agent-runtime/src/sandbox/linux.rs
@@ -35,6 +35,10 @@ pub fn apply_linux(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
     let mut created = ruleset.create().context("create Landlock ruleset")?;
 
     // FS read-only paths. path_beneath_rules() silently skips non-existent paths.
+    // Already partitioned at profile-build time against the credential store
+    // and sibling signing keys (#850) — and partitioned THERE rather than here
+    // because only the user-declared grants may be dropped; the system read
+    // paths in this list are chosen by the builder and must always survive.
     if !policy.fs_read.is_empty() {
         let read_rules = path_beneath_rules(policy.fs_read.iter(), AccessFs::from_read(abi));
         created = created.add_rules(read_rules).context("add fs_read rules")?;
@@ -152,6 +156,15 @@ pub(crate) fn partition_write_grants(
     chain: &LaunchChain,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     chain.partition_grants(grants)
+}
+
+/// Read counterpart of [`partition_write_grants`]. Same shape, different
+/// protected set — see `LaunchChain::partition_read_grants`.
+pub(crate) fn partition_read_grants(
+    grants: &[PathBuf],
+    chain: &LaunchChain,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    chain.partition_read_grants(grants)
 }
 
 #[cfg(test)]

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -109,6 +109,10 @@ pub struct SandboxPolicy {
     /// the kernel. Read by `mur agent runtime-doctor` to report what the
     /// sandbox neutralised (spec 2026-08-11).
     pub dropped_grants: Vec<PathBuf>,
+    /// Read grants dropped whole for overlapping the credential store or a
+    /// sibling's signing key. Read counterpart of `dropped_grants`; same
+    /// fail-closed rule, reported by `mur agent doctor`.
+    pub dropped_read_grants: Vec<PathBuf>,
 }
 
 impl Default for SandboxPolicy {
@@ -128,6 +132,7 @@ impl Default for SandboxPolicy {
             memory_limit_mb: None,
             launch_chain: crate::sandbox::launch_chain::LaunchChain::default(),
             dropped_grants: Vec::new(),
+            dropped_read_grants: Vec::new(),
         }
     }
 }
@@ -149,7 +154,7 @@ impl SandboxPolicy {
         // dead path recreated or removed from entitlements). Mirrors the
         // fail-closed discipline `resolve_binary_path`/`is_executable_file`
         // already apply to `spawn_allowed_paths` below.
-        let mut fs_read: Vec<PathBuf> = ent
+        let fs_read: Vec<PathBuf> = ent
             .filesystem
             .read
             .iter()
@@ -168,6 +173,33 @@ impl SandboxPolicy {
                 }
             })
             .collect();
+        // Drop any user-declared read grant that reaches the credential store
+        // or a sibling's signing key, BEFORE anything else is added (#850).
+        //
+        // Only the user-declared set is partitioned: everything appended below
+        // — the fleet_run carve-in, the runtime's own central-store reads, the
+        // system paths — is chosen by this function and must never be dropped.
+        // Partitioning the finished list instead would silently discard e.g.
+        // `/private/tmp` whenever `mur_home` happens to nest under a system
+        // read path, which is exactly what a test run surfaced.
+        //
+        // Landlock has no deny rule, so an overlapping grant cannot be carved
+        // and is dropped whole, fail-closed. macOS reaches the same posture the
+        // other way: it installs the grant and re-closes those paths with
+        // `deny file-read*` clauses emitted after every allow (last-match-wins).
+        let launch_chain = crate::sandbox::launch_chain::LaunchChain::new(agent_home);
+        let (kept_reads, dropped_read_grants) =
+            crate::sandbox::linux::partition_read_grants(&fs_read, &launch_chain);
+        for p in &dropped_read_grants {
+            tracing::warn!(
+                path = %p.display(),
+                "filesystem READ entitlement reaches the credential store or a \
+                 sibling signing key; the whole grant is dropped (a protected \
+                 path inside a grant cannot be carved out)"
+            );
+        }
+        let mut fs_read = kept_reads;
+
         let mut fs_write: Vec<PathBuf> = ent
             .filesystem
             .write
@@ -309,6 +341,31 @@ impl SandboxPolicy {
                 }
             }
             for p in [mur_home.join("models.yaml"), mur_home.join("cache")] {
+                if std::fs::metadata(&p).is_ok() && !fs_read.contains(&p) {
+                    fs_read.push(p);
+                }
+            }
+        }
+
+        // The runtime's OWN central-store reads. macOS is allow-default so this
+        // is a no-op there; on Linux Landlock is deny-by-default and WITHOUT
+        // these the runtime cannot read its own configuration —
+        // `Config::load_or_default` silently returns defaults (so the agent
+        // runs on the wrong model), the compress hook never engages, and
+        // `channel/delegate` cannot read a fleet definition. The failure is
+        // silent in every case, which is why it went unnoticed.
+        //
+        // This is not a widening of the trust boundary: these are reads the
+        // runtime already performs unconditionally, enumerated in the audit
+        // (docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md
+        // §7.1). Existence-checked like every other grant (Issue 16).
+        if let Some(mur_home) = agent_home.parent().and_then(|p| p.parent()) {
+            for p in [
+                mur_home.join("config.yaml"),
+                mur_home.join("compress.yaml"),
+                mur_home.join("compress"),
+                mur_home.join("fleets"),
+            ] {
                 if std::fs::metadata(&p).is_ok() && !fs_read.contains(&p) {
                     fs_read.push(p);
                 }
@@ -534,7 +591,6 @@ impl SandboxPolicy {
                 NetworkOutboundMode::Off => (Some(vec![]), Some(vec![]), false),
             };
 
-        let launch_chain = crate::sandbox::launch_chain::LaunchChain::new(agent_home);
         // Linux Landlock cannot carve a protected path out of a grant (pure
         // allow-list), so any write grant overlapping the launch chain is
         // dropped whole here, fail-closed — and recorded for the runtime-doctor
@@ -557,6 +613,7 @@ impl SandboxPolicy {
             memory_limit_mb: Some(ent.limits.memory_mb),
             launch_chain,
             dropped_grants,
+            dropped_read_grants,
         }
     }
 
@@ -856,6 +913,122 @@ mod tests {
         // Only those two files are denied — the rest of agent_home
         // (running.lock, running.sentinel, stderr.log) stays writable.
         assert!(policy.fs_write.contains(&agent_home));
+    }
+
+    /// The runtime reads `config.yaml` unconditionally (model switch, skills,
+    /// remember, fleet_run). On Linux Landlock is deny-by-default, so without a
+    /// read grant `Config::load_or_default` silently returns DEFAULTS and the
+    /// agent runs on the wrong model with no error anywhere. Same for
+    /// `compress.yaml` (hook never engages) and `fleets/` (delegation cannot
+    /// resolve a fleet). Audit §7.1.
+    #[test]
+    fn the_runtimes_own_central_store_reads_are_granted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::write(mur_home.join("config.yaml"), "").unwrap();
+        std::fs::write(mur_home.join("compress.yaml"), "").unwrap();
+        std::fs::create_dir_all(mur_home.join("compress")).unwrap();
+        std::fs::create_dir_all(mur_home.join("fleets")).unwrap();
+
+        let policy = SandboxPolicy::from_entitlements(&minimal_entitlements(), &agent_home);
+
+        for name in ["config.yaml", "compress.yaml", "compress", "fleets"] {
+            assert!(
+                policy.fs_read.contains(&mur_home.join(name)),
+                "{name} must be readable or the runtime silently degrades: {:?}",
+                policy.fs_read
+            );
+        }
+    }
+
+    /// ...and the grant is existence-checked like every other one (Issue 16):
+    /// a rule on a path that does not exist destabilizes the profile, so an
+    /// absent `compress.yaml` must not be emitted.
+    #[test]
+    fn absent_central_store_paths_are_not_granted() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        // Nothing created: no config.yaml, no compress.yaml, no fleets/.
+
+        let policy = SandboxPolicy::from_entitlements(&minimal_entitlements(), &agent_home);
+
+        for name in ["config.yaml", "compress.yaml", "compress", "fleets"] {
+            assert!(
+                !policy.fs_read.contains(&mur_home.join(name)),
+                "{name} does not exist and must not be granted"
+            );
+        }
+    }
+
+    /// The paths the builder itself adds must survive the read partition.
+    ///
+    /// Partitioning the FINISHED `fs_read` instead of just the user-declared
+    /// part silently dropped `/private/tmp` whenever `mur_home` nested under
+    /// it — which is every temp-dir test, and would be a real agent under a
+    /// relocated MUR home. Only a human-declared grant may be dropped, because
+    /// only a human can fix it.
+    #[test]
+    fn the_builders_own_read_paths_survive_an_overbroad_user_grant() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(mur_home.join("secrets")).unwrap();
+        std::fs::write(mur_home.join("config.yaml"), "").unwrap();
+
+        let mut ent = minimal_entitlements();
+        // Overbroad: contains <mur_home>/secrets, so it is dropped.
+        ent.filesystem.read = vec![mur_home.to_string_lossy().into_owned()];
+        let policy = SandboxPolicy::from_entitlements(&ent, &agent_home);
+
+        assert!(policy.dropped_read_grants.contains(&mur_home.to_path_buf()));
+        // ...but the builder's own additions are still there.
+        assert!(
+            policy.fs_read.contains(&mur_home.join("config.yaml")),
+            "the runtime's own config read was collateral damage: {:?}",
+            policy.fs_read
+        );
+        for sys in system_read_paths() {
+            assert!(
+                policy.fs_read.contains(&sys),
+                "system read path {} was dropped: {:?}",
+                sys.display(),
+                policy.fs_read
+            );
+        }
+    }
+
+    /// A read grant that reaches the credential store is dropped whole and
+    /// RECORDED, so `mur agent doctor` can say so instead of the agent finding
+    /// out from an errno.
+    #[test]
+    fn an_overbroad_read_grant_is_recorded_as_dropped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(mur_home.join("secrets")).unwrap();
+        let skills = mur_home.join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+
+        let mut ent = minimal_entitlements();
+        ent.filesystem.read = vec![
+            mur_home.to_string_lossy().into_owned(),
+            skills.to_string_lossy().into_owned(),
+        ];
+        let policy = SandboxPolicy::from_entitlements(&ent, &agent_home);
+
+        assert!(
+            policy.dropped_read_grants.contains(&mur_home.to_path_buf()),
+            "{:?}",
+            policy.dropped_read_grants
+        );
+        // Negative control: the narrow grant is not dropped.
+        assert!(!policy.dropped_read_grants.contains(&skills));
     }
 
     #[test]

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -434,31 +434,57 @@ fn check_dropped_launch_chain_grants(
     agent_home: &std::path::Path,
 ) -> Check {
     let chain = mur_agent_runtime::sandbox::launch_chain::LaunchChain::new(agent_home);
-    let expanded: Vec<std::path::PathBuf> = fs
-        .write
-        .iter()
-        .map(|s| mur_agent_runtime::sandbox::policy::expand_entitlement_path(s))
-        .collect();
-    let (_kept, dropped) = chain.partition_grants(&expanded);
+    let expand = |v: &Vec<String>| -> Vec<std::path::PathBuf> {
+        v.iter()
+            .map(|s| mur_agent_runtime::sandbox::policy::expand_entitlement_path(s))
+            .collect()
+    };
+    let writes = expand(&fs.write);
+    let reads = expand(&fs.read);
+    let (_kept, dropped) = chain.partition_grants(&writes);
+    // Reads are partitioned against a DIFFERENT protected set (the credential
+    // store and sibling signing keys, not the launch chain), so a path may be
+    // fine to write-grant and refused to read-grant. Reported together because
+    // the user-visible consequence is identical: the grant silently vanishes.
+    let (_kept_r, dropped_reads) = chain.partition_read_grants(&reads);
 
-    if dropped.is_empty() {
+    if dropped.is_empty() && dropped_reads.is_empty() {
         return Check::new(
             "grant_scope",
             true,
             format!(
-                "{} write grant(s), none overlap the launch chain",
-                expanded.len()
+                "{} write + {} read grant(s), none overlap a protected path",
+                writes.len(),
+                reads.len()
             ),
         );
     }
-    let names: Vec<String> = dropped.iter().map(|p| p.display().to_string()).collect();
+    let mut parts: Vec<String> = Vec::new();
+    if !dropped.is_empty() {
+        let names: Vec<String> = dropped.iter().map(|p| p.display().to_string()).collect();
+        parts.push(format!(
+            "{} write grant(s) contain a launch-chain path: {}",
+            dropped.len(),
+            names.join(", ")
+        ));
+    }
+    if !dropped_reads.is_empty() {
+        let names: Vec<String> = dropped_reads
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        parts.push(format!(
+            "{} read grant(s) contain the credential store or a sibling signing key: {}",
+            dropped_reads.len(),
+            names.join(", ")
+        ));
+    }
     Check::new(
         "grant_scope",
         false,
         format!(
-            "{} write grant(s) contain a launch-chain path and are DROPPED WHOLE by the sandbox (Landlock cannot carve one out): {}. Grant the specific subdirectory instead.",
-            dropped.len(),
-            names.join(", ")
+            "{} and are DROPPED WHOLE by the sandbox (Landlock cannot carve one out). Grant the specific subdirectory instead.",
+            parts.join("; ")
         ),
     )
 }
@@ -672,6 +698,30 @@ mod tests {
             "a swallowing grant must fail the check: {}",
             c.detail
         );
+        assert!(c.detail.contains("DROPPED WHOLE"), "{}", c.detail);
+    }
+
+    /// The read side of the same check. A read grant reaching the credential
+    /// store is dropped by the sandbox exactly as an overbroad write grant is,
+    /// and the user needs to be told — before #850 nothing reported it, and on
+    /// Linux nothing stopped it either.
+    #[test]
+    fn a_read_grant_that_reaches_the_credential_store_is_reported() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("alice");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(mur_home.join("secrets")).unwrap();
+
+        let fs = mur_common::agent::FilesystemEntitlement {
+            // Contains <mur_home>/secrets.
+            read: vec![mur_home.display().to_string()],
+            write: vec![],
+            deny: vec![],
+        };
+        let c = check_dropped_launch_chain_grants(&fs, &agent_home);
+        assert!(!c.ok, "an overbroad read grant must fail: {}", c.detail);
+        assert!(c.detail.contains("read grant"), "{}", c.detail);
         assert!(c.detail.contains("DROPPED WHOLE"), "{}", c.detail);
     }
 


### PR DESCRIPTION
Deliverable 1 + the read half of deliverable 2 from #850's central-store audit. Two halves of one mechanism, so they ship together — see the "why together" note below.

## 1. Read grants were never partitioned

`partition_grants` was applied to **writes only**. So `fs_write: [~/.mur]` was refused and `fs_read: [~/.mur]` was installed verbatim. On Linux that hands out the credential store outright — Landlock is a pure allow-list with no deny rule, so nothing re-closes the protected paths inside the grant.

`LaunchChain::partition_read_grants` drops such a grant whole, fail-closed.

Its protected set is deliberately **not** `deny_paths()`. That covers the whole `agents/` subtree, and a blanket read-deny there fail-closes every multi-agent channel: verifying a peer's signed events reads `identity.pub` and `rotations.jsonl` from that peer's home (audit §2). The set is instead exactly what macOS emits as `deny file-read*` — credential store + sibling signing keys — so the two backends refuse the same reads instead of diverging.

**Only user-declared reads are partitioned.** The first cut partitioned the finished `fs_read` and silently dropped `/private/tmp` — a `system_read_paths()` entry — because the test's `mur_home` nested under it. A relocated MUR home would do the same to a real agent. Only a human-declared grant may be dropped, because only a human can fix it. That flaw was found by dumping a real profile, not by review.

## 2. Linux agents could not read their own configuration

`fs_read` never contained `config.yaml`, `compress.yaml` or `fleets/`. Under Landlock's deny-by-default that means:

- `Config::load_or_default` silently returns **defaults** → the agent runs on the wrong model
- the compress hook never engages
- `channel/delegate` cannot resolve a fleet definition

Every failure is silent, which is why it went unnoticed. These are reads the runtime already performs unconditionally (audit §7.1), so granting them widens no trust boundary — it makes the allow-list match the code.

### Why the two belong in one PR

(1) is only safe to enforce *because* (2) names the complete legitimate read set. Shipping (2) alone would leave the overbroad-grant hole open; shipping (1) alone would break Linux agents that need `config.yaml`.

## 3. Reporting

`mur agent doctor`'s `grant_scope` check now covers read grants too, via the new `SandboxPolicy::dropped_read_grants`. Previously a dropped grant was recorded and never read by anything.

## Verification — `sandbox-exec`, not reasoning

Profile generated from a policy carrying an overbroad `fs_read: [<mur_home>]`:

```
profile compiles:      sandbox-exec -f <profile> /usr/bin/true   -> exit 0
secrets/anthropic.key  DENIED      (Operation not permitted)
agents/pm/identity.key DENIED      (Operation not permitted)
agents/pm/identity.pub READABLE    <- the §2 constraint holds
skills/x.yaml          READABLE
dropped_read_grants    ["<mur_home>"]   and nothing else
```

**Negative control:** delete the single `(deny file-read* … /secrets)` line from that same profile and the key reads back as `SUPER-SECRET-KEY`.

Unit-test negative controls run too: neutering `partition_read_grants` turns 2 of the 3 new launch-chain tests red; neutering the central-store grants turns the policy test red.

### What this proves about macOS

`skills/x.yaml` is readable **even though the partition removed its covering allow**, because the SBPL baseline is `(allow default)`. Dropping a read grant is therefore a **no-op on macOS**; the explicit denies are what confine reads there. The change is load-bearing on Linux and behaviour-preserving on macOS — which is why it needs no macOS canary.

## Still open (recorded in the audit, not silently dropped)

1. **Linux cannot read peer public key material.** `agents/` is in no Linux read grant, so a spawned `mur` verifying a peer's events would fail-close. macOS re-allows `identity.pub`/`rotations.jsonl`; Landlock has no equivalent. Needs enumeration (same after-seal gap as `sibling_signing_keys`) and in practice needs `spawn(mur)`, which #850 withdrew. Worth a canary first.
2. **macOS read-deny on `skills/`, `index/`, `inbox/`** — out of scope by decision (audit §8): the runtime does not read them, but spawned `mur` children might, and the canary should decide.
3. **Option (c)** — moving private keys out of the agents tree, still the only variant closing the after-seal gap.

## Tests

`mur-agent-runtime` 889 passed · `mur-core` lib 2527 passed · clippy `--all-targets -D warnings` clean on both · `cargo fmt --check` clean.

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)