### PR TITLE
fix(trust): one hash domain for the skill trust store, and a drift baseline on install

### DIFF
--- a/mur-common/src/skill/loader.rs
+++ b/mur-common/src/skill/loader.rs
@@ -2,7 +2,7 @@
 //! resolves trust level, checks drift, returns one flat Vec.
 
 use crate::skill::types::TrustLevel;
-use crate::skill::{DriftStatus, SkillManifest, content_sha256, drift_status, local};
+use crate::skill::{SkillManifest, content_hash_for_trust, local};
 use crate::trust::skills::SkillTrustStore;
 use std::path::Path;
 
@@ -149,7 +149,7 @@ pub struct LoadedSkill {
 }
 
 pub fn load_all(mur_home: &Path, agent_name: &str) -> Vec<LoadedSkill> {
-    let trust = SkillTrustStore::load(mur_home).unwrap_or_default();
+    let trust = load_trust_migrated(mur_home);
     let mut out: Vec<LoadedSkill> = Vec::new();
     let mut seen_names: std::collections::HashSet<String> = Default::default();
 
@@ -241,6 +241,35 @@ pub fn load_all(mur_home: &Path, agent_name: &str) -> Vec<LoadedSkill> {
     out
 }
 
+/// Load the trust store, re-keying it into the trust-hash domain on first use.
+///
+/// The migration runs here rather than in a separate command because this is
+/// the one path every agent start goes through, so a store never stays stale
+/// long enough for the loss to be noticed. It is a no-op once the schema is
+/// current, and it is fail-soft in both directions: if the re-key cannot be
+/// saved the in-memory store is still correct for this run, and if a skill is
+/// missing from disk its entry is kept untouched.
+fn load_trust_migrated(mur_home: &Path) -> SkillTrustStore {
+    let mut trust = SkillTrustStore::load(mur_home).unwrap_or_default();
+    let Some(rekeyed) =
+        trust.migrate_to_trust_hash(|name| local::load_installed(mur_home, name).ok())
+    else {
+        return trust; // already current — the common case, no write
+    };
+    {
+        match trust.save(mur_home) {
+            Ok(()) => tracing::info!(
+                rekeyed,
+                "skill trust store migrated to the trust-hash domain"
+            ),
+            // Not fatal: the in-memory store is already correct, so this run
+            // resolves trust properly and the next start retries the write.
+            Err(e) => tracing::warn!(error = %e, "could not persist trust-store migration"),
+        }
+    }
+    trust
+}
+
 fn load_one<F>(
     mur_home: &Path,
     name: &str,
@@ -270,21 +299,27 @@ where
             return None;
         }
     };
-    let hash = match content_sha256(&manifest) {
+    // `content_hash_for_trust`, not `content_sha256`: this is the trust-store
+    // key, and the trust hash excludes `transfer_chain` / `evolution_log` so a
+    // transfer or a generation increment does not silently re-key an already
+    // trusted skill. Using the plain content hash here is what made every
+    // transfer- and fleet-import-installed skill (which key by the trust hash)
+    // miss its entry and load as Sandboxed regardless of its recorded level.
+    let hash = match content_hash_for_trust(&manifest) {
         Ok(h) => h,
         Err(e) => {
             tracing::warn!(skill = %name, error = %e, "skill hash failed; skipping");
             return None;
         }
     };
-    // Drift check: if there's a pinned hash for this skill in the trust store
-    // and it disagrees, refuse to load.
+    // No separate drift check: the entry is KEYED by the content hash, so
+    // finding one is already proof the content matches the pinned bytes. The
+    // check that used to sit here compared `content_sha256(&manifest)` against
+    // a hash derived from the same manifest — a value against itself, which
+    // could never report drift. Worse, once the key became the trust hash the
+    // two would differ by construction and every skill would refuse to load.
     let entry = trust.entries.get(&hash);
     if let Some(pinned) = entry {
-        if let Ok(DriftStatus::Drift { expected, actual }) = drift_status(&manifest, Some(&hash)) {
-            tracing::warn!(skill = %name, expected, actual, "skill drift detected; skipping");
-            return None;
-        }
         if trust.is_revoked(&hash) {
             tracing::warn!(skill = %name, "skill hash revoked; skipping");
             return None;
@@ -315,6 +350,114 @@ mod tests {
     use super::*;
     use crate::skill::{parse_canonical, write_to_dir};
     use tempfile::tempdir;
+
+    /// The bug this domain unification fixes, stated as a test.
+    ///
+    /// A skill whose `evolution_log` grows — which happens during ordinary use —
+    /// keeps the same `content_hash_for_trust` but gets a NEW `content_sha256`.
+    /// The loader used to key on the latter, so the trust entry written at
+    /// install stopped matching and the skill silently dropped to `Sandboxed`.
+    #[test]
+    fn a_generation_increment_does_not_lose_the_recorded_trust_level() {
+        use crate::trust::skills::{SkillTrustStore, TrustEntry};
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let mut m = make("evolving");
+        let sdir = home
+            .join("agents")
+            .join("a1")
+            .join("skills")
+            .join("evolving");
+        write_to_dir(&sdir, &m).unwrap();
+
+        // Trust recorded at install time, keyed by the trust hash.
+        let key = crate::skill::content_hash_for_trust(&m).unwrap();
+        let mut trust = SkillTrustStore::default();
+        trust.insert(
+            key.clone(),
+            TrustEntry {
+                name: "evolving".into(),
+                version: m.version.clone(),
+                level: TrustLevel::Trusted,
+                installed_at: "2026-08-19T00:00:00Z".into(),
+                ..Default::default()
+            },
+        );
+        trust.save(home).unwrap();
+
+        // The skill evolves in place: plain content hash moves, trust hash does not.
+        let before_plain = crate::skill::content_sha256(&m).unwrap();
+        m.evolution_log
+            .push(crate::skill::evolution::EvolutionEvent::initial_human(
+                "t", "1.0.0",
+            ));
+        write_to_dir(&sdir, &m).unwrap();
+        let after_plain = crate::skill::content_sha256(&m).unwrap();
+        assert_ne!(
+            before_plain, after_plain,
+            "precondition: an evolution entry must move the plain content hash"
+        );
+        assert_eq!(
+            key,
+            crate::skill::content_hash_for_trust(&m).unwrap(),
+            "precondition: the trust hash must be stable across a generation increment"
+        );
+
+        let loaded = load_all(home, "a1");
+        let s = loaded.iter().find(|s| s.name == "evolving").unwrap();
+        assert_eq!(
+            s.trust,
+            TrustLevel::Trusted,
+            "the recorded trust level was lost when the skill evolved"
+        );
+    }
+
+    /// A v1 store (keys from `content_sha256`) is re-keyed on first load, so an
+    /// existing install keeps its trust level across the upgrade instead of
+    /// silently reverting to Sandboxed.
+    #[test]
+    fn a_legacy_store_is_migrated_on_load() {
+        use crate::trust::skills::SkillTrustStore;
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        // The two domains differ only once a skill carries an evolution log or a
+        // transfer chain — for a pristine skill they are the same hash, which is
+        // why this migration touches far fewer entries than it might appear to.
+        let mut m = make("legacy");
+        m.evolution_log
+            .push(crate::skill::evolution::EvolutionEvent::initial_human(
+                "t", "1.0.0",
+            ));
+        write_to_dir(&home.join("skills").join("legacy"), &m).unwrap();
+
+        // v1: keyed by the plain content hash, and no schema field on disk.
+        let legacy_key = crate::skill::content_sha256(&m).unwrap();
+        let trust_key = crate::skill::content_hash_for_trust(&m).unwrap();
+        assert_ne!(
+            legacy_key, trust_key,
+            "precondition: the two domains must differ for this to be a migration"
+        );
+        let json = format!(
+            r#"{{"entries":{{"{legacy_key}":{{"name":"legacy","version":"{}","level":"trusted","installed_at":"2026-08-19T00:00:00Z"}}}},"revoked":[]}}"#,
+            m.version
+        );
+        std::fs::create_dir_all(home.join("trust")).unwrap();
+        std::fs::write(SkillTrustStore::path(home), json).unwrap();
+
+        let loaded = load_all(home, "a1");
+        let s = loaded.iter().find(|s| s.name == "legacy").unwrap();
+        assert_eq!(
+            s.trust,
+            TrustLevel::Trusted,
+            "a v1 entry must survive the domain change"
+        );
+
+        // ...and the migration is persisted, so it runs once.
+        let reloaded = SkillTrustStore::load(home).unwrap();
+        assert_eq!(reloaded.schema, crate::trust::skills::TRUST_STORE_SCHEMA);
+        assert!(reloaded.entries.contains_key(&trust_key));
+        assert!(!reloaded.entries.contains_key(&legacy_key));
+    }
 
     #[test]
     fn load_all_sets_agent_skill_dir() {

--- a/mur-common/src/trust/skills.rs
+++ b/mur-common/src/trust/skills.rs
@@ -7,14 +7,43 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+/// Current on-disk schema. Bump only for a change that needs a migration.
+///
+/// - **1** — hash keys written by `content_sha256` (plain canonical YAML).
+/// - **2** — hash keys written by `content_hash_for_trust` (canonical YAML with
+///   `transfer_chain` / `evolution_log` excluded), so a transfer or a
+///   generation increment no longer re-keys an entry out from under the loader.
+pub const TRUST_STORE_SCHEMA: u32 = 2;
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SkillTrustStore {
+    /// On-disk schema version. Absent in stores written before the field
+    /// existed, which are exactly the v1 stores — hence `default = 1`.
+    #[serde(default = "schema_v1")]
+    pub schema: u32,
+
     pub entries: BTreeMap<String, TrustEntry>,
 
     /// Kill-switch — content hashes that may NEVER load, regardless of
     /// the per-entry trust level.
     #[serde(default)]
     pub revoked: Vec<String>,
+}
+
+fn schema_v1() -> u32 {
+    1
+}
+
+impl Default for SkillTrustStore {
+    /// A store created in memory is already current — only a store read from
+    /// disk can be older, and `serde` supplies 1 for those.
+    fn default() -> Self {
+        Self {
+            schema: TRUST_STORE_SCHEMA,
+            entries: BTreeMap::new(),
+            revoked: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -130,6 +159,67 @@ impl SkillTrustStore {
         None
     }
 
+    /// Re-key v1 hash-keyed entries into the trust hash domain (schema 1 → 2).
+    ///
+    /// v1 keyed by `content_sha256`; the loader now looks up
+    /// `content_hash_for_trust`. Without this every already-installed skill
+    /// misses its entry and silently drops to `Sandboxed` — fail-closed, so no
+    /// privilege is gained, but every recorded trust level would be lost.
+    ///
+    /// Re-keying needs the manifest, which the store does not hold, so each
+    /// entry is recomputed from the skill still on disk. What that implies:
+    ///
+    /// - **Name-keyed entries are left alone.** `registry-add` keys by skill
+    ///   name on purpose (the drift baseline). Only 64-hex keys are candidates.
+    /// - **An entry whose skill is no longer installed is kept as-is.** It
+    ///   cannot be recomputed, and dropping it would silently discard a
+    ///   `Trusted` decision the user made. A stale key is inert; a deleted one
+    ///   is not recoverable.
+    /// - **Already-correct keys are cheap no-ops** — the recomputed hash equals
+    ///   the existing key and the entry is reinserted unchanged.
+    ///
+    /// Returns `None` if the store was already current, or `Some(n)` with the
+    /// number of entries re-keyed. `Some(0)` still means the schema was bumped
+    /// and the store must be saved — otherwise a store with nothing to move
+    /// never records that it migrated and repeats the work on every start.
+    pub fn migrate_to_trust_hash<F>(&mut self, load_manifest: F) -> Option<usize>
+    where
+        F: Fn(&str) -> Option<crate::skill::SkillManifest>,
+    {
+        if self.schema >= TRUST_STORE_SCHEMA {
+            return None;
+        }
+        let is_hash_key = |k: &str| k.len() == 64 && k.chars().all(|c| c.is_ascii_hexdigit());
+
+        let mut rekeyed = 0usize;
+        let mut moved: Vec<(String, String)> = Vec::new();
+        for key in self.entries.keys() {
+            if !is_hash_key(key) {
+                continue; // name-keyed drift baseline — deliberately not a hash
+            }
+            let Some(entry) = self.entries.get(key) else {
+                continue;
+            };
+            let Some(manifest) = load_manifest(&entry.name) else {
+                continue; // skill gone from disk; keep the entry rather than lose it
+            };
+            let Ok(new_key) = crate::skill::content_hash_for_trust(&manifest) else {
+                continue;
+            };
+            if new_key != *key {
+                moved.push((key.clone(), new_key));
+            }
+        }
+        for (old, new) in moved {
+            if let Some(entry) = self.entries.remove(&old) {
+                self.entries.insert(new, entry);
+                rekeyed += 1;
+            }
+        }
+        self.schema = TRUST_STORE_SCHEMA;
+        Some(rekeyed)
+    }
+
     pub fn is_revoked(&self, hash: &str) -> bool {
         self.revoked.iter().any(|r| ct_eq_hex(r, hash))
     }
@@ -155,6 +245,101 @@ mod tests {
             publisher: Some("human:t".into()),
             ..Default::default()
         }
+    }
+
+    fn manifest(name: &str, evolved: bool) -> crate::skill::SkillManifest {
+        let yaml = format!(
+            "name: {name}\nversion: 1.0.0\npublisher: human:t\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n"
+        );
+        let mut m = crate::skill::parse_canonical(&yaml).unwrap();
+        if evolved {
+            m.evolution_log
+                .push(crate::skill::evolution::EvolutionEvent::initial_human(
+                    "t", "1.0.0",
+                ));
+        }
+        m
+    }
+
+    /// A store written before the schema field existed reads as v1 and migrates.
+    #[test]
+    fn a_store_without_a_schema_field_is_v1() {
+        let s: SkillTrustStore = serde_json::from_str(r#"{"entries":{},"revoked":[]}"#).unwrap();
+        assert_eq!(s.schema, 1);
+        // ...while one built in memory is already current.
+        assert_eq!(SkillTrustStore::default().schema, TRUST_STORE_SCHEMA);
+    }
+
+    /// Name-keyed entries are the drift baseline and must survive untouched —
+    /// re-keying them to a hash would destroy the only record that spans
+    /// versions.
+    #[test]
+    fn migration_leaves_name_keyed_entries_alone() {
+        let m = manifest("demo", true);
+        let mut s = SkillTrustStore {
+            schema: 1,
+            ..Default::default()
+        };
+        s.entries.insert("demo".into(), entry());
+
+        let moved = s.migrate_to_trust_hash(|_| Some(m.clone()));
+
+        assert_eq!(moved, Some(0), "a name key is not a hash key");
+        assert!(s.entries.contains_key("demo"));
+        assert_eq!(s.schema, TRUST_STORE_SCHEMA);
+    }
+
+    /// An entry whose skill is gone cannot be recomputed. Keep it: a stale key
+    /// is inert, but discarding it would silently drop a trust decision.
+    #[test]
+    fn migration_keeps_an_entry_whose_skill_is_no_longer_installed() {
+        let legacy = "a".repeat(64);
+        let mut s = SkillTrustStore {
+            schema: 1,
+            ..Default::default()
+        };
+        s.entries.insert(legacy.clone(), entry());
+
+        let moved = s.migrate_to_trust_hash(|_| None);
+
+        assert_eq!(moved, Some(0));
+        assert!(s.entries.contains_key(&legacy), "trust decision was lost");
+    }
+
+    /// The re-key itself, end to end, and the entry keeps its level.
+    #[test]
+    fn migration_rekeys_a_hash_entry_into_the_trust_domain() {
+        let m = manifest("demo", true);
+        let legacy = crate::skill::content_sha256(&m).unwrap();
+        let target = crate::skill::content_hash_for_trust(&m).unwrap();
+        assert_ne!(legacy, target, "precondition: domains must differ");
+
+        let mut s = SkillTrustStore {
+            schema: 1,
+            ..Default::default()
+        };
+        s.entries.insert(legacy.clone(), entry());
+
+        let moved = s.migrate_to_trust_hash(|_| Some(m.clone()));
+
+        assert_eq!(moved, Some(1));
+        assert!(!s.entries.contains_key(&legacy));
+        assert_eq!(s.entries.get(&target).unwrap().level, TrustLevel::Verified);
+    }
+
+    /// Idempotent: a current store is left completely alone, and reports so.
+    #[test]
+    fn migration_is_a_no_op_on_a_current_store() {
+        let m = manifest("demo", true);
+        let mut s = SkillTrustStore::default();
+        let legacy = crate::skill::content_sha256(&m).unwrap();
+        s.entries.insert(legacy.clone(), entry());
+
+        assert_eq!(s.migrate_to_trust_hash(|_| Some(m.clone())), None);
+        assert!(
+            s.entries.contains_key(&legacy),
+            "a v2 store must not be re-keyed again"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/skill_registry_add.rs
+++ b/mur-core/src/cmd/agent/skill_registry_add.rs
@@ -51,8 +51,17 @@ pub struct ConsentInfo {
     pub signer_trust: String,
     /// Raw YAML body of the resolved skill file (for Hub preview / consent display).
     pub body: String,
-    /// SHA-256 hex of the resolved skill YAML file (pinned at install; used for rug-pull detection).
+    /// SHA-256 hex of the resolved skill YAML **file bytes**. This is the value
+    /// the registry index carries and `verify_skill_install` compares against —
+    /// a transport-integrity check ("did I get the exact file the index
+    /// promised"). NOT the trust-store key; see `trust_sha256`.
     pub resolved_sha256: String,
+    /// SHA-256 hex in the TRUST domain (`content_hash_for_trust`): canonical
+    /// YAML with `transfer_chain` / `evolution_log` excluded. This is what the
+    /// trust store keys and compares on, so it must be the value pinned as the
+    /// drift baseline — `resolved_sha256` is a different hash of a different
+    /// thing and comparing the two reports drift on every install.
+    pub trust_sha256: String,
     /// Short human description of detected drift since the last install:
     /// `"content changed"`, `"publisher changed"`, `"downgrade X → Y"`, or `None`.
     /// When set, `needs_ack` is also `true` (in `resolve_consent`; not in `resolve_consent_in`
@@ -207,6 +216,12 @@ pub fn resolve_consent_in(
         hex::encode(Sha256::digest(text.as_bytes()))
     };
 
+    // Trust-domain hash — what the trust store keys and compares on. Distinct
+    // from `resolved_sha256` above: that one is over the raw file bytes for the
+    // index check, this one is over the canonical manifest.
+    let trust_sha256 = mur_common::skill::content_hash_for_trust(&manifest)
+        .map_err(|e| anyhow::anyhow!("trust hash: {e}"))?;
+
     let outcome: VerifyOutcome = verify_skill_install(&manifest, &text, &entry.content_sha256);
     let signer = classify_signer(&outcome.signature, keyring);
     // Fold publisher keyring trust into the gate flags:
@@ -238,6 +253,7 @@ pub fn resolve_consent_in(
         signer_trust: signer.as_str().to_string(),
         body: text,
         resolved_sha256,
+        trust_sha256,
         // Drift is computed only by resolve_consent (has mur_home) and
         // cmd_skill_registry_add; left None here (test seam has no trust store).
         drift: None,
@@ -308,7 +324,10 @@ pub fn resolve_consent(mur_home: &Path, skill: &str, version: Option<&str>) -> R
     let (drift_desc, _) = drift_status(
         mur_home,
         &consent.name,
-        &consent.resolved_sha256,
+        // Trust domain on both sides: the stored baseline is `trust_sha256`,
+        // so comparing `resolved_sha256` (raw file bytes) here would report
+        // "content changed" on every single install.
+        &consent.trust_sha256,
         new_signer_fp.as_deref(),
         &consent.version,
     );
@@ -352,7 +371,10 @@ pub async fn cmd_skill_registry_add(
     let (_, drift_decision) = drift_status(
         &mur_home,
         &consent.name,
-        &consent.resolved_sha256,
+        // Trust domain on both sides: the stored baseline is `trust_sha256`,
+        // so comparing `resolved_sha256` (raw file bytes) here would report
+        // "content changed" on every single install.
+        &consent.trust_sha256,
         new_signer_fp.as_deref(),
         &consent.version,
     );
@@ -402,7 +424,7 @@ pub async fn cmd_skill_registry_add(
                 } else {
                     Some(consent.publisher.clone())
                 },
-                content_sha256: consent.resolved_sha256.clone(),
+                content_sha256: consent.trust_sha256.clone(),
                 signer_key_fp: if consent.signature.key_fp.is_empty() {
                     None
                 } else {
@@ -657,6 +679,7 @@ mcp_requirements:
             signer_trust: "trusted".into(),
             body: "".into(),
             resolved_sha256: "aabbcc".into(),
+            trust_sha256: "ddeeff".into(),
             drift: None,
         }
     }

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -446,7 +446,8 @@ pub fn cmd_audit(name: &str) -> Result<()> {
         println!("Content scan: clean");
     }
 
-    let hash = mur_common::skill::content_sha256(&m)?;
+    // Trust-store key: must match what the loader looks up.
+    let hash = mur_common::skill::content_hash_for_trust(&m)?;
     let trust = mur_common::trust::skills::SkillTrustStore::load(&home)
         .map_err(|e| anyhow!("load trust store: {e}"))?;
     match trust.lookup(&hash) {
@@ -472,7 +473,8 @@ pub fn cmd_trust(name: &str, level_str: &str) -> Result<()> {
     let home = resolve_mur_home()?;
     let m =
         local::load_installed(&home, name).map_err(|_| anyhow!("skill '{name}' not installed"))?;
-    let hash = mur_common::skill::content_sha256(&m)?;
+    // Trust-store key: must match what the loader looks up.
+    let hash = mur_common::skill::content_hash_for_trust(&m)?;
 
     let mut trust = mur_common::trust::skills::SkillTrustStore::load(&home)
         .map_err(|e| anyhow!("load trust store: {e}"))?;

--- a/mur-core/src/cmd/skill_generate.rs
+++ b/mur-core/src/cmd/skill_generate.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use mur_common::llm::LlmClient;
 use mur_common::skill::{
-    SkillManifest, TrustLevel, content_sha256, global_skill_dir, scan::scan_skill,
+    SkillManifest, TrustLevel, content_hash_for_trust, global_skill_dir, scan::scan_skill,
     serialize_canonical, write_to_dir,
 };
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
@@ -85,7 +85,8 @@ pub async fn cmd_generate<L: LlmClient + 'static>(
             eprintln!("    {line}");
         }
     }
-    let hash = content_sha256(&manifest)?;
+    // Trust-store key: the trust hash (see `content_hash_for_trust`).
+    let hash = content_hash_for_trust(&manifest)?;
     let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow!("load trust: {e}"))?;
     trust.insert(
         hash,

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use mur_common::skill::credit::{CreditEntry, CreditEvidence, CreditKind};
 use mur_common::skill::{
-    SkillLock, SkillManifest, TrustLevel, content_hash_for_trust, content_sha256, global_skill_dir,
-    lockfile, scan::scan_skill, write_to_dir,
+    SkillLock, SkillManifest, TrustLevel, content_hash_for_trust, global_skill_dir, lockfile,
+    scan::scan_skill, write_to_dir,
 };
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
 
@@ -206,22 +206,52 @@ fn install_resolved_node(home: &Path, registry_dir: &Path, node: &ResolvedNode) 
         stamp_registry_origin(&mut manifest);
     }
     write_to_dir(&dir, &manifest)?;
-    let hash = content_sha256(&node.manifest)?;
+    // Trust-store key: the trust hash, so a later transfer or generation
+    // increment does not re-key this entry (see `content_hash_for_trust`).
+    let hash = content_hash_for_trust(&node.manifest)?;
     let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow::anyhow!("load trust: {e}"))?;
     let level = if report.has_blocking_findings() {
         TrustLevel::Sandboxed
     } else {
         TrustLevel::Verified
     };
+    let installed_at = chrono::Utc::now().to_rfc3339();
+    let publisher = Some(node.manifest.publisher.clone());
     trust.insert(
-        hash,
+        hash.clone(),
         TrustEntry {
             name: node.name.clone(),
             version: node.version.to_string(),
             level,
-            installed_at: chrono::Utc::now().to_rfc3339(),
-            publisher: Some(node.manifest.publisher.clone()),
+            installed_at: installed_at.clone(),
+            publisher: publisher.clone(),
+            // Hash-keyed entry: the KEY is the content hash, so the field would
+            // only repeat it. The drift baseline is the name-keyed entry below.
             ..Default::default()
+        },
+    );
+    // Drift baseline, keyed by NAME (#960). The hash-keyed entry above is the
+    // load-time allow-list: it answers "is this exact content trusted", and by
+    // construction it can never notice that the content changed — a new version
+    // simply lands under a new key. Comparing against the LAST install needs an
+    // entry that survives the version change, which is what keying by name buys.
+    //
+    // `content_sha256` is populated in the trust domain, matching what
+    // `registry-add` pins, so the two install paths compare like with like. No
+    // signer fingerprint: this path has the security scan but not a verified
+    // publisher signature, so a publisher-change claim would be unfounded.
+    // `check_drift` skips the publisher comparison when it is absent and still
+    // performs the content and rollback checks.
+    trust.entries.insert(
+        node.name.clone(),
+        TrustEntry {
+            name: node.name.clone(),
+            version: node.version.to_string(),
+            level,
+            installed_at,
+            publisher,
+            content_sha256: hash,
+            signer_key_fp: None,
         },
     );
     trust
@@ -557,6 +587,88 @@ mod tests {
     async fn block_on_isolated_runs_inside_ambient_runtime() {
         let out = block_on_isolated(|| async { 1 + 1 }).expect("no panic inside runtime");
         assert_eq!(out, 2);
+    }
+
+    fn node(name: &str, version: &str) -> ResolvedNode {
+        let yaml = format!(
+            "name: {name}\nversion: {version}\npublisher: human:t\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n"
+        );
+        ResolvedNode {
+            name: name.into(),
+            version: semver::Version::parse(version).unwrap(),
+            yaml_path: std::path::PathBuf::from("/nonexistent/skill.yaml"),
+            manifest: mur_common::skill::parse_canonical(&yaml).unwrap(),
+        }
+    }
+
+    /// #960 option 1: `mur skill install` must leave a drift baseline keyed by
+    /// NAME, not only the hash-keyed allow-list entry.
+    ///
+    /// The hash-keyed entry cannot detect drift by construction — a changed
+    /// skill simply lands under a different key, so there is nothing to compare
+    /// against. Only an entry that survives the version change can answer "did
+    /// this change since last time", which is what keying by name buys.
+    #[test]
+    fn install_writes_a_name_keyed_drift_baseline() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path();
+        let n = node("demo", "1.0.0");
+        let registry = home.join("registry");
+        std::fs::create_dir_all(&registry).unwrap();
+
+        install_resolved_node(home, &registry, &n).unwrap();
+
+        let trust = SkillTrustStore::load(home).unwrap();
+        let hash = content_hash_for_trust(&n.manifest).unwrap();
+
+        // Load-time allow-list entry, keyed by content hash.
+        assert!(
+            trust.entries.contains_key(&hash),
+            "hash-keyed entry missing: {:?}",
+            trust.entries.keys().collect::<Vec<_>>()
+        );
+
+        // Drift baseline, keyed by name, carrying a COMPARABLE content hash.
+        let baseline = trust
+            .entries
+            .get("demo")
+            .expect("no name-keyed drift baseline was written");
+        assert_eq!(
+            baseline.content_sha256, hash,
+            "the baseline must pin the trust-domain hash, or it cannot be \
+             compared against what registry-add pins"
+        );
+        assert_eq!(baseline.version, "1.0.0");
+    }
+
+    /// ...and the baseline is what makes a later content change detectable.
+    /// Same name, same version, different content — previously invisible.
+    #[test]
+    fn the_baseline_makes_a_later_content_change_detectable() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path();
+        let registry = home.join("registry");
+        std::fs::create_dir_all(&registry).unwrap();
+
+        let first = node("demo", "1.0.0");
+        install_resolved_node(home, &registry, &first).unwrap();
+        let baseline = SkillTrustStore::load(home)
+            .unwrap()
+            .entries
+            .get("demo")
+            .unwrap()
+            .content_sha256
+            .clone();
+
+        // The publisher rewrites the skill body without bumping the version.
+        let mut second = node("demo", "1.0.0");
+        second.manifest.description = "something else entirely".into();
+        let new_hash = content_hash_for_trust(&second.manifest).unwrap();
+
+        assert_ne!(
+            baseline, new_hash,
+            "a content rewrite must move the trust hash, or drift is undetectable"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #960 — but the investigation found the issue's premise was wrong, so this is larger than "pick one of three options".

## The premise that did not hold

The two writers never hashed the same thing, so nothing was comparing anything. Measured on a real skill file, not reasoned:

```
raw bytes (registry-add pinned):  60f4169a5a31accbb0341033e2b629ed…
canonical (skill install keyed):  f1811908e2c44aa59a36d82c1d00b01b…
SAME? false
```

The store held keys from **three** functions:

| writer | key | function | domain |
|---|---|---|---|
| `registry-add` | name | `resolved_sha256` | raw file bytes |
| `skill install` (registry/local) | hash | `content_sha256` | canonical YAML |
| `skill install` (transfer) / `fleet import` | hash | `content_hash_for_trust` | canonical minus `transfer_chain`/`evolution_log` |

## Two live bugs this exposed

**1. The loader looked up the wrong domain.** `load_one` keyed on `content_sha256`, so every skill installed by transfer or `mur fleet import` — which key by the trust hash — missed its entry and loaded as `Sandboxed` regardless of the level recorded at install. Fail-closed, so no privilege was gained, but the recorded level was dead data for those paths.

**2. A skill that evolved lost its trust level.** `content_sha256` covers `evolution_log`, so a generation increment re-keyed the entry out from under the loader. `content_hash_for_trust` exists precisely to stop this — its doc says it keeps "trust-store keys stable across transfers" — and the primary install path did not use it.

## What changed

Everything that keys or reads the trust store now uses `content_hash_for_trust`. Raw bytes stay where they belong — the registry index and `verify_skill_install`, which answer the different question "did I receive the exact file the index promised". That split is deliberate and `skill_registry_index.rs` already documents it; the trust store had accidentally inherited both sides of it.

`registry-add` gains `ConsentInfo::trust_sha256` alongside `resolved_sha256`, and pins/compares the trust-domain value. Feeding the raw-bytes hash into a comparison against a trust-domain baseline would report `content changed` on **every** install.

### A dead check that was about to become harmful

`load_one` had a drift check comparing `content_sha256(&manifest)` against a hash derived from the same manifest — a value against itself, which could never fire. Removed, with the reasoning recorded: once the key becomes the trust hash the two differ by construction, so leaving it would have made **every skill refuse to load**.

The entry is keyed by the content hash, so finding one already proves the content matches.

## Migration

Store gains `schema` (v1 → v2). On first load, v1 hash-keyed entries are re-keyed from the installed manifest. Boundaries, each with a test:

- **Name-keyed entries are left alone** — they are the drift baseline, keyed by name on purpose.
- **An entry whose skill is gone is kept, not dropped** — a stale key is inert; a discarded trust decision is not recoverable.
- **`Some(0)` still saves**, so a store with nothing to move records that it migrated instead of repeating the work every start.

It runs from `load_all`, the path every agent start already takes, and is fail-soft: if the write fails the in-memory store is still correct for that run.

**Blast radius is smaller than it looks.** The two domains only diverge for a skill carrying an evolution log or transfer chain — a pristine skill hashes identically in both. A test asserts that precondition explicitly rather than assuming it (the first draft of that test failed for exactly this reason).

## #960 option 1

`mur skill install` now also writes a name-keyed drift baseline carrying the trust-domain `content_sha256`.

The hash-keyed entry cannot detect drift by construction — changed content simply lands under a new key, so there is nothing to compare against. Only an entry that survives the version change can answer "did this change since last time".

No signer fingerprint: this path has the security scan but no verified publisher signature, so a publisher-change claim would be unfounded. `check_drift` skips the publisher comparison when the prior signer is absent and still performs the content and rollback checks.

## Verification

Negative controls, each targeted:

| neutered | result |
|---|---|
| loader key reverted to `content_sha256` | both loader tests red |
| migration disabled only | exactly the migration test red |
| name-keyed write removed | both install tests red |

`mur-common` 934 passed · `mur-core` lib 2533 passed · clippy `--all-targets -D warnings` clean on both · `cargo fmt --check` clean. Re-verified after `main` advanced mid-work.

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)