### PR TITLE
fix(sandbox): say that macOS does not confine MCP child processes

### DIFF
--- a/docs/architecture/mcp-supply-chain.md
+++ b/docs/architecture/mcp-supply-chain.md
@@ -98,6 +98,8 @@ It is a command rather than a startup check because it costs a full reinstall. R
 
 **"The same code", never "safe code".** What bounds the damage from a compromised MCP server is the agent's entitlements and sandbox, not its hash. A vendored, signed, provenance-carrying server still runs with everything that agent was granted.
 
+**And on macOS, that bound does not exist for MCP servers at all.** SBPL is not inherited across `exec`, so a server the runtime spawns runs with the *user's* privileges — not the agent's entitlements. Linux is different in kind, not degree: Landlock and seccomp ARE inherited, so there the child really does run under the agent's policy. Until the pre-fork launcher lands (`mur-agent-runtime/src/sandbox/child.rs` names the design and the one call to activate), installing an MCP server on macOS is a trust decision about the whole machine, and no amount of pinning changes that. `mur agent perm show` and `mur agent doctor <name>` both say so rather than letting the entitlement list imply otherwise.
+
 The open follow-on is to connect the two: a server whose provenance cannot be verified is a reason to suggest narrower entitlements at install time — protection that still works when detection fails.
 
 ---

--- a/mur-agent-runtime/src/sandbox/child.rs
+++ b/mur-agent-runtime/src/sandbox/child.rs
@@ -51,8 +51,21 @@ fn spawn_impl(mut cmd: Command, policy: &SandboxPolicy) -> io::Result<Child> {
 
     // cage.spawn(birdcage_cmd) would enforce the policy above, but requires
     // a dedicated single-threaded pre-fork process (see module docs).
-    // For now the cage is built to document intent; the supervisor's
-    // inherited restrictions (Landlock/SBPL) cover the child at the kernel level.
+    // For now the cage is built to document intent.
+    //
+    // What actually confines the child differs by platform, and the
+    // difference is NOT cosmetic:
+    //
+    // - Linux: Landlock and seccomp ARE inherited across `exec`, so the
+    //   child really does run under the supervisor's policy.
+    // - macOS: SBPL is NOT inherited across `exec`. The child runs with the
+    //   user's full privileges — this policy does not reach it at all.
+    //
+    // An earlier version of this comment claimed "the supervisor's inherited
+    // restrictions (Landlock/SBPL) cover the child at the kernel level",
+    // which is true on Linux and false on macOS. Sitting three lines from
+    // `drop(cage)`, it was exactly where a reader stops and concludes this is
+    // fine. Stating both halves is the point.
     drop(cage);
     cmd.spawn()
 }

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -31,6 +31,32 @@ pub(super) fn warn_if_running(name: &str) {
     }
 }
 
+/// Warn that these entitlements stop at the runtime on macOS.
+///
+/// SBPL is not inherited across `exec`, so an MCP server the runtime spawns
+/// runs with the user's full privileges — the policy printed above does not
+/// reach it. (Linux children DO inherit Landlock, so this is macOS-only.)
+///
+/// Printed to STDERR, and only when the agent actually spawns children:
+/// `perm show` output is YAML that callers pipe into a parser, and a caveat
+/// that corrupts the data it qualifies is not an improvement.
+fn warn_children_unconfined(profile: &mur_common::AgentProfile) {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+    let n = profile.mcp_servers.len();
+    if n == 0 {
+        return;
+    }
+    eprintln!(
+        "note: on macOS these entitlements confine the agent runtime, not the \
+         {n} MCP server(s) it spawns — SBPL is not inherited across exec, so \
+         those child processes run unconfined. Linux children do inherit \
+         Landlock. Scope what a server can reach with `mur agent mcp \
+         set-network`, and treat installing one as the trust decision it is."
+    );
+}
+
 pub fn cmd_perm_show(name: &str, section: Option<&str>) -> Result<()> {
     let (_path, profile) = load_profile_for_edit(name)?;
     let v = serde_yaml_ng::to_string(&profile.entitlements).context("serialize entitlements")?;
@@ -54,6 +80,7 @@ pub fn cmd_perm_show(name: &str, section: Option<&str>) -> Result<()> {
     } else {
         print!("{v}");
     }
+    warn_children_unconfined(&profile);
     Ok(())
 }
 

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -574,6 +574,27 @@ pub fn agent_doctor(mur_home: &std::path::Path, name: &str) -> Result<Vec<Check>
         &profile.entitlements.filesystem,
     ));
 
+    #[cfg(target_os = "macos")]
+    if !profile.mcp_servers.is_empty() {
+        // Not a fault in this agent — a platform limit that the entitlement
+        // list does not advertise. It belongs in doctor because this is where
+        // someone lands after asking "why did my MCP server reach a host my
+        // allowlist forbids?", and the honest answer is that the allowlist
+        // never applied to it. `ok: true` on purpose: nothing here is
+        // fixable by the user, and a permanent red would train them to
+        // ignore the whole report.
+        out.push(Check::new(
+            "sandbox_scope",
+            true,
+            format!(
+                "entitlements confine the runtime, NOT the {} MCP server(s) it spawns \
+                 — macOS does not inherit SBPL across exec, so those run unconfined \
+                 (Linux inherits Landlock). Scope them with `mur agent mcp set-network`.",
+                profile.mcp_servers.len()
+            ),
+        ));
+    }
+
     Ok(out)
 }
 
@@ -810,5 +831,70 @@ mod tests {
                 .any(|c| c.name == "model" && !c.ok && c.detail.contains("echo stub")),
             "expected a failing model-resolution check naming the echo fallback, got: {report:?}"
         );
+    }
+
+    /// macOS does not inherit SBPL across `exec`, so an agent's entitlements
+    /// stop at the runtime and its MCP servers run unconfined. Doctor has to
+    /// say so — it is where someone lands after asking why a server reached a
+    /// host the allowlist forbids. Reported as OK, not a failure: it is a
+    /// platform limit the user cannot fix, and a permanent red trains people
+    /// to ignore the report.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn agent_doctor_states_that_mcp_children_are_unconfined() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path().to_path_buf();
+        let agent_dir = mur_home.join("agents").join("scoped");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.mcp_servers.push(mur_common::agent::McpServerEntry {
+            name: "media".into(),
+            command: "npx".into(),
+            ..Default::default()
+        });
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            serde_yaml_ng::to_string(&profile).unwrap(),
+        )
+        .unwrap();
+
+        unsafe { std::env::set_var("MUR_HOME", &mur_home) };
+        let report = agent_doctor(&mur_home, "scoped").unwrap();
+        unsafe { std::env::remove_var("MUR_HOME") };
+
+        let c = report
+            .iter()
+            .find(|c| c.name == "sandbox_scope")
+            .expect("expected a sandbox_scope check");
+        assert!(c.ok, "a platform limit is not this agent's fault");
+        assert!(
+            c.detail.contains("unconfined"),
+            "must name the actual state: {}",
+            c.detail
+        );
+    }
+
+    /// No MCP servers, nothing spawned, nothing to warn about — the note must
+    /// not become background noise on every agent.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn agent_doctor_is_silent_about_scope_without_mcp_servers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path().to_path_buf();
+        let agent_dir = mur_home.join("agents").join("bare");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let profile = mur_common::AgentProfile::default_for_tests();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            serde_yaml_ng::to_string(&profile).unwrap(),
+        )
+        .unwrap();
+
+        unsafe { std::env::set_var("MUR_HOME", &mur_home) };
+        let report = agent_doctor(&mur_home, "bare").unwrap();
+        unsafe { std::env::remove_var("MUR_HOME") };
+
+        assert!(report.iter().all(|c| c.name != "sandbox_scope"));
     }
 }


### PR DESCRIPTION
Tier 1 of the long-term sandbox work: **stop implying a containment that does not exist.** No enforcement changes here.

## The gap

An agent's entitlement list reads like it governs everything that agent runs. On macOS it does not — SBPL is not inherited across `exec`, so an MCP server the runtime spawns runs with the **user's** privileges, not the agent's.

Linux differs in kind, not degree: Landlock and seccomp *are* inherited, so there the child really is confined by the agent's policy. That asymmetry is the whole point, and nothing currently states it where a user or a future maintainer would look.

## Four places that implied otherwise

1. **`child.rs` contradicted itself.** The module doc says *"macOS children spawned here are therefore unconfined"*. An inline comment three lines from `drop(cage)` said the inherited restrictions *"cover the child at the kernel level"* — true on Linux, false on macOS, and sitting exactly where a reader stops and concludes this is fine.
2. **`mur agent perm show`** now notes that the policy it just printed stops at the runtime. On **stderr**, and only when the agent actually has MCP servers — that output is YAML people pipe into a parser, and a caveat that corrupts the data it qualifies is not an improvement.
3. **`mur agent doctor <name>`** gains a `sandbox_scope` check. This is where someone lands after asking *"why did my MCP server reach a host my allowlist forbids?"*, and the honest answer is that the allowlist never applied to it. Reported **`ok: true`** on purpose: it is a platform limit the user cannot fix, and a permanent red trains people to ignore the whole report.
4. **`docs/architecture/mcp-supply-chain.md`** said damage is bounded by *"the agent's entitlements and sandbox"*. On macOS that bound is absent for MCP servers — the doc now says so and points at where the real fix goes.

## What this deliberately does not do

The actual fix — a single-threaded pre-fork launcher that cages itself before `exec` — is already designed in `child.rs` down to the one call to activate (`cage.spawn(birdcage_cmd)`). It is a separate piece of work, not smuggled in here.

Worth stating plainly: this PR makes the product *look worse* and be *more honest*. That trade is the same one the rest of this series made — an unenforced rule that reads as enforced is the failure mode, not the missing enforcement.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo nextest run -p mur-core -E 'test(/agent_doctor|sandbox_scope/)'` → 6/6, including two new: the check fires when MCP servers exist, and stays silent when they don't (so it doesn't become background noise on every agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)