### PR TITLE
fix(channel): an unreadable actor key must not pass as an absent signature

### DIFF
--- a/docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md
+++ b/docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md
@@ -263,14 +263,82 @@ no macOS canary.
 
 ### Still open after this
 
-1. **Linux cannot read peer public key material.** `<mur_home>/agents/` is in
-   no Linux read grant, so a spawned `mur` verifying a peer's signed events
-   would fail-close. macOS handles it (`macos.rs` re-allows `identity.pub` and
-   `rotations.jsonl`); Landlock has no equivalent grant. Not fixed here: it
-   needs enumeration (with the same after-seal gap as `sibling_signing_keys`),
-   and in practice it requires `spawn(mur)`, which #850 withdrew. Worth a
-   canary before building.
+1. ~~**Linux cannot read peer public key material.**~~ **Fixed — see §10.**
+   The reasoning recorded here was wrong on two counts, both corrected below:
+   it does NOT require an opt-in `spawn(mur)`, and it does not fail *closed*.
 2. **macOS read-deny on the central stores** (`skills/`, `index/`, `inbox/`)
    — deliberately out of scope, per §8.
 3. **Option (c)**, moving private keys out of the agents tree — still the only
    variant that closes the after-seal enumeration gap.
+
+## 10. Linux peer public key material — and the fail-open it was hiding
+
+§9 listed this as open and argued it could wait because it "requires
+`spawn(mur)`, which #850 withdrew". Both halves of that were wrong.
+
+### It is not opt-in
+
+`policy.rs` adds `mur` to the spawn allowlist for any `fleet_run`-enabled
+agent:
+
+```rust
+if fleet_run_enabled && !spawn_names.iter().any(|n| n == "mur") {
+    spawn_names.push("mur".to_string());
+}
+```
+
+That carve-in exists for the fleet runner, independently of #850. What #850
+withdrew was *adding `mur` to spawn allowlists as a fix for the read gap* — not
+the pre-existing grant. So on Linux a fleet agent spawns `mur fleet run`, that
+child inherits the Landlock sandbox, and it reaches the HITL gate, which calls
+`channel_verify::verify_event` (`hitl/gate.rs:340`, `:366`, `:418`).
+
+### It fails OPEN, not closed
+
+```rust
+match actor_pubkey(mur_home, &ev.actor, ev.key_version) {
+    Some(pk) => verify_one(channel_id, ev, &pk, require_sig),
+    None     => !require_sig,        // <- the defect
+}
+```
+
+`verify_one` is careful: a **present** signature is always checked
+cryptographically, and only an **absent** one falls back to `!require_sig`.
+`verify_event` never got that far. With the key directory unreadable —
+the normal state under deny-by-default — `actor_pubkey` returns `None` and the
+event is accepted, because `require_sig` defaults off.
+
+So the sandbox did not break verification. **It silently switched it off**, and
+a forged event was indistinguishable from a genuine one. That is worse than the
+fail-closed breakage §9 predicted, and it is why this stopped being a "worth a
+canary" item.
+
+### The fix, both halves
+
+**(1) An unreadable key is not an absent signature.** `verify_event` now
+returns `false` for a signed event whose actor key cannot be resolved, and logs
+why. The migration-safety rule is preserved exactly where it applies: an
+*unsigned* event still follows `require_sig`.
+
+**(2) Grant the public material so verification can succeed.**
+`LaunchChain::peer_public_key_material()` enumerates every agent's
+`identity.pub` and `rotations.jsonl` — existence-checked, malformed directory
+names skipped — and `policy.rs` adds them to `fs_read`.
+
+Granting `agents/` wholesale is not an option: Landlock has no deny rule, so it
+would hand out every sibling's `identity.key`, which is exactly what #975
+closed. Per-file grants also do not confer directory listing, and
+`resolve_writer_pubkey` never lists — it opens the two paths directly.
+
+(1) without (2) would turn a silent accept into approvals being ignored on
+Linux — the gate would defer forever. (2) without (1) leaves the fail-open in
+place for any peer the enumeration misses. Same coupling as §8.
+
+### The after-seal gap, inherited
+
+Enumeration happens at seal time, so an agent created afterwards is not listed
+and its signed events are unverifiable to an already-running agent until that
+one restarts. This is now **fail-closed** rather than silently accepted, which
+is the correct behaviour, but it is still a gap. It is the same gap
+`sibling_signing_keys` has, and it has the same real fix: option (c), move
+private keys out of the agents tree so the subtree can be granted whole.

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -287,6 +287,71 @@ impl LaunchChain {
         })
     }
 
+    /// Every agent's PUBLIC verification material: `identity.pub` and
+    /// `rotations.jsonl`, for each agent home including this one.
+    ///
+    /// These are the two files `mur_channel::sign::resolve_writer_pubkey` reads
+    /// to check a peer's signed channel events. They are public by
+    /// construction — the published counterpart of the `identity.key` that
+    /// `sibling_signing_keys` denies — so granting them is not a widening.
+    ///
+    /// Needed because Landlock is deny-by-default and `<mur_home>/agents/` is
+    /// in no Linux read grant. Without these a sandboxed `mur` (fleet-enabled
+    /// agents get `spawn(mur)`) cannot resolve any peer key, and
+    /// `channel_verify::verify_event` then treats every event as unverifiable.
+    /// The whole agents subtree cannot simply be granted instead: Landlock has
+    /// no deny rule, so that would hand out every sibling's `identity.key` —
+    /// exactly what #975 closed.
+    ///
+    /// Enumerated at seal time, so it carries the same after-seal gap as
+    /// `sibling_signing_keys`: an agent created later is not listed, and its
+    /// events stay unverifiable to an already-running agent until that one
+    /// restarts. Closing that properly is the same fix — move private keys out
+    /// of the agents tree so the subtree can be granted whole
+    /// (docs/superpowers/specs/2026-08-18-agent-read-confinement-audit.md).
+    pub fn peer_public_key_material(&self) -> Vec<PathBuf> {
+        let agents = self.mur_home.join("agents");
+        let entries = match std::fs::read_dir(&agents) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(error) => {
+                // Never silently: without these grants signature verification
+                // cannot succeed, and its failure mode is quiet.
+                tracing::warn!(
+                    dir = %agents.display(),
+                    %error,
+                    "cannot enumerate agents — peer public keys will NOT be \
+                     readable, so signed channel events cannot be verified"
+                );
+                return Vec::new();
+            }
+        };
+        entries
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+            // Same guard as `sibling_signing_keys`: a hand-made directory with
+            // an odd name must not reach a generated profile.
+            .filter(|e| match e.file_name().to_str() {
+                Some(n) if mur_common::validate_agent_name(n).is_ok() => true,
+                other => {
+                    tracing::warn!(
+                        entry = ?other,
+                        "skipping malformed entry under agents/ when building \
+                         the peer public-key read list"
+                    );
+                    false
+                }
+            })
+            .flat_map(|e| {
+                let dir = e.path();
+                [dir.join("identity.pub"), dir.join("rotations.jsonl")]
+            })
+            // Landlock drops a rule on a path that does not exist; keep the
+            // list to what is actually there so the grant set is honest.
+            .filter(|p| std::fs::metadata(p).is_ok())
+            .collect()
+    }
+
     /// The paths no read grant may reach: the user's credential store and
     /// sibling signing keys.
     ///
@@ -533,6 +598,69 @@ mod tests {
                 p.display()
             );
         }
+    }
+
+    /// Peer PUBLIC material is enumerated; the PRIVATE key next to it is not.
+    /// The pair is the whole point: verification needs one and must never get
+    /// the other, and they live in the same directory.
+    #[test]
+    fn peer_public_material_is_listed_and_the_private_key_is_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        for name in ["alice", "pm"] {
+            let d = mur.join("agents").join(name);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("identity.pub"), b"pub").unwrap();
+            std::fs::write(d.join("rotations.jsonl"), b"{}").unwrap();
+            std::fs::write(d.join("identity.key"), b"secret").unwrap();
+        }
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+
+        let listed = chain.peer_public_key_material();
+
+        for name in ["alice", "pm"] {
+            let d = mur.join("agents").join(name);
+            assert!(listed.contains(&d.join("identity.pub")), "{listed:?}");
+            assert!(listed.contains(&d.join("rotations.jsonl")), "{listed:?}");
+        }
+        assert!(
+            !listed.iter().any(|p| p.ends_with("identity.key")),
+            "a signing key must never be granted: {listed:?}"
+        );
+    }
+
+    /// Only files that exist are listed — Landlock silently drops a rule on a
+    /// missing path, so listing one would overstate what was granted.
+    #[test]
+    fn peer_public_material_skips_files_that_do_not_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let d = mur.join("agents").join("pm");
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(d.join("identity.pub"), b"pub").unwrap(); // no rotations.jsonl
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+
+        let listed = chain.peer_public_key_material();
+
+        assert_eq!(listed, vec![d.join("identity.pub")]);
+    }
+
+    /// A hand-made directory with a name the profile text cannot carry is
+    /// skipped rather than allowed to break every agent's startup — same guard
+    /// as `sibling_signing_keys`.
+    #[test]
+    fn peer_public_material_skips_a_malformed_agent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let bad = mur.join("agents").join("we ird\"name");
+        std::fs::create_dir_all(&bad).unwrap();
+        std::fs::write(bad.join("identity.pub"), b"pub").unwrap();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+
+        assert!(chain.peer_public_key_material().is_empty());
     }
 
     /// A read grant wide enough to contain the credential store is dropped

--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -654,7 +654,10 @@ mod tests {
     fn peer_public_material_skips_a_malformed_agent_dir() {
         let tmp = tempfile::tempdir().unwrap();
         let mur = tmp.path().to_path_buf();
-        let bad = mur.join("agents").join("we ird\"name");
+        // A space is rejected by `validate_agent_name` ([A-Za-z0-9_-]) and is
+        // legal on every filesystem — unlike a quote, which Windows refuses to
+        // create, making the test panic before it asserts anything.
+        let bad = mur.join("agents").join("we ird");
         std::fs::create_dir_all(&bad).unwrap();
         std::fs::write(bad.join("identity.pub"), b"pub").unwrap();
         let chain =

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -372,6 +372,19 @@ impl SandboxPolicy {
             }
         }
 
+        // Peer PUBLIC key material (`identity.pub` + `rotations.jsonl`), so a
+        // sandboxed process can verify signed channel events. macOS already
+        // allows these (allow-default, and the launch chain denies only
+        // `identity.key`); Landlock grants nothing it is not told about, so
+        // without this every peer key is unresolvable and verification
+        // degrades silently — `verify_event` cannot tell "no key" from "no
+        // signature". Public by construction, so this widens nothing.
+        for p in launch_chain.peer_public_key_material() {
+            if !fs_read.contains(&p) {
+                fs_read.push(p);
+            }
+        }
+
         // Standard system read paths: libraries, certs, DNS config.
         let system_read = system_read_paths();
         for p in system_read {
@@ -962,6 +975,36 @@ mod tests {
                 "{name} does not exist and must not be granted"
             );
         }
+    }
+
+    /// Peer public key material reaches `fs_read`, so a sandboxed process can
+    /// actually resolve a peer's key. On Linux this is the difference between
+    /// signature verification working and it silently having nothing to check.
+    #[test]
+    fn peer_public_key_material_is_readable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mur_home = tmp.path();
+        let agent_home = mur_home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let pm = mur_home.join("agents").join("pm");
+        std::fs::create_dir_all(&pm).unwrap();
+        std::fs::write(pm.join("identity.pub"), b"pub").unwrap();
+        std::fs::write(pm.join("rotations.jsonl"), b"{}").unwrap();
+        std::fs::write(pm.join("identity.key"), b"secret").unwrap();
+
+        let policy = SandboxPolicy::from_entitlements(&minimal_entitlements(), &agent_home);
+
+        assert!(
+            policy.fs_read.contains(&pm.join("identity.pub")),
+            "{:?}",
+            policy.fs_read
+        );
+        assert!(policy.fs_read.contains(&pm.join("rotations.jsonl")));
+        // ...and the private key beside them is still not readable.
+        assert!(
+            !policy.fs_read.contains(&pm.join("identity.key")),
+            "a sibling signing key was granted"
+        );
     }
 
     /// The paths the builder itself adds must survive the read partition.

--- a/mur-core/src/channel_verify.rs
+++ b/mur-core/src/channel_verify.rs
@@ -20,6 +20,14 @@ pub fn actor_pubkey(
 
 /// True if `ev` verifies against its actor's key (present sig must verify;
 /// missing sig tolerated iff `!require_sig`).
+///
+/// An **unresolvable key is not the same as an absent signature.** Tolerating
+/// a missing signature is the migration-safety rule for legacy unsigned events
+/// (v3d). An event that DOES carry a signature but whose key cannot be read has
+/// not been verified by anything — accepting it would let an unreadable key
+/// directory switch verification off silently, which is precisely what a
+/// deny-by-default sandbox produces on Linux (`agents/` is granted per-file, so
+/// a peer created after the seal is unreadable). It fails closed instead.
 pub fn verify_event(
     mur_home: &Path,
     channel_id: &str,
@@ -28,7 +36,18 @@ pub fn verify_event(
 ) -> bool {
     match actor_pubkey(mur_home, &ev.actor, ev.key_version) {
         Some(pk) => mur_channel::sign::verify_one(channel_id, ev, &pk, require_sig),
-        None => !require_sig,
+        // Unsigned: the legacy-tolerance rule still applies — there is nothing
+        // a key would have checked.
+        None if ev.sig.is_none() => !require_sig,
+        None => {
+            tracing::warn!(
+                channel_id,
+                actor = ?ev.actor,
+                key_version = ?ev.key_version,
+                "event carries a signature but its actor's public key could not                  be read — treating as UNVERIFIED (an unreadable key must not                  pass as an absent signature)"
+            );
+            false
+        }
     }
 }
 
@@ -46,6 +65,74 @@ mod tests {
     use super::*;
     use mur_common::channel::EventKind;
     use mur_common::identity::AgentIdentity;
+
+    /// A SIGNED event whose actor key cannot be read must not pass, even with
+    /// enforcement off. Otherwise an unreadable key directory — which is the
+    /// normal state under a deny-by-default sandbox — silently turns signature
+    /// verification into a no-op, and a forged event is indistinguishable from
+    /// a genuine one.
+    #[test]
+    fn a_signed_event_with_an_unreadable_key_does_not_verify() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let qa_home = tmp.path().join("agents").join("qa");
+        std::fs::create_dir_all(&qa_home).unwrap();
+        let qa = AgentIdentity::generate();
+        qa.save(&qa_home).unwrap();
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_agent("qa").unwrap();
+        svc.append_signed(
+            &ch.id,
+            &qa,
+            0,
+            ChannelActor::Agent { id: "qa".into() },
+            EventKind::Message,
+            serde_json::json!({"text":"hi"}),
+            None,
+        )
+        .unwrap();
+        let ev = svc.load_events(&ch.id).unwrap().pop().unwrap();
+        assert!(ev.sig.is_some(), "precondition: the event is signed");
+        // Sanity: it verifies while the key is readable, with enforcement OFF.
+        assert!(verify_event(tmp.path(), &ch.id, &ev, false));
+
+        // Now make the key unresolvable, exactly as a sandbox would.
+        std::fs::remove_dir_all(&qa_home).unwrap();
+
+        assert!(
+            !verify_event(tmp.path(), &ch.id, &ev, false),
+            "a signed event whose key cannot be read must NOT count as verified"
+        );
+    }
+
+    /// ...while an UNSIGNED event keeps the migration-safety rule: there is no
+    /// signature for a key to have checked, so `require_sig` still decides.
+    #[test]
+    fn an_unsigned_event_still_follows_require_sig() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_agent("ghost").unwrap();
+        svc.append_signed(
+            &ch.id,
+            &AgentIdentity::generate(),
+            0,
+            ChannelActor::Agent { id: "ghost".into() },
+            EventKind::Message,
+            serde_json::json!({"text":"legacy"}),
+            None,
+        )
+        .unwrap();
+        let mut ev = svc.load_events(&ch.id).unwrap().pop().unwrap();
+        ev.sig = None; // legacy, pre-v3d
+
+        assert!(
+            verify_event(tmp.path(), &ch.id, &ev, false),
+            "unsigned + enforcement off = tolerated"
+        );
+        assert!(
+            !verify_event(tmp.path(), &ch.id, &ev, true),
+            "unsigned + enforcement on = rejected"
+        );
+    }
 
     #[test]
     fn event_verifies_against_its_own_actor_key() {


### PR DESCRIPTION
#850 remaining item 1. The audit filed this as "Linux cannot read peer public key material — worth a canary before building", and argued it could wait because it needs `spawn(mur)`, which #850 withdrew.

**Both halves of that reasoning were wrong**, and the second one turns this from a robustness gap into a security one.

## It is not opt-in

`policy.rs` adds `mur` to the spawn allowlist for every `fleet_run`-enabled agent:

```rust
if fleet_run_enabled && !spawn_names.iter().any(|n| n == "mur") {
    spawn_names.push("mur".to_string());
}
```

That carve-in exists for the fleet runner, independently of #850. What #850 withdrew was adding `mur` to spawn allowlists *as a fix for the read gap* — not this pre-existing grant.

So on Linux: a fleet agent spawns `mur fleet run` → the child inherits the Landlock sandbox → it reaches the HITL gate, which calls `channel_verify::verify_event` (`hitl/gate.rs:340`, `:366`, `:418`).

## It fails OPEN, not closed

```rust
match actor_pubkey(mur_home, &ev.actor, ev.key_version) {
    Some(pk) => verify_one(channel_id, ev, &pk, require_sig),
    None     => !require_sig,        // <- the defect
}
```

`verify_one` is careful: a **present** signature is always verified cryptographically, and only an **absent** one falls back to `!require_sig`. `verify_event` never got that far.

With `agents/` unreadable — the normal state under deny-by-default — `actor_pubkey` returns `None`, and since `require_sig` defaults off, the event is **accepted**.

The sandbox did not break signature verification. **It silently switched it off**, and a forged event became indistinguishable from a genuine one. That is worse than the fail-closed breakage the audit predicted.

The same conflation bites outside Linux too: an agent that has been removed, or a renamed/typo'd actor id, also yields an unresolvable key and therefore a free pass.

## The fix — two halves, coupled

**1. An unreadable key is not an absent signature.** `verify_event` returns `false` for a signed event whose actor key cannot be resolved, with a warning naming the actor and key version. The migration-safety rule is preserved exactly where it applies: an *unsigned* event still follows `require_sig`.

**2. Grant the public material so verification can succeed.** `LaunchChain::peer_public_key_material()` enumerates each agent's `identity.pub` and `rotations.jsonl` (existence-checked, malformed dir names skipped, same guard as `sibling_signing_keys`) and `policy.rs` adds them to `fs_read`.

Granting `agents/` wholesale is not available: Landlock has no deny rule, so it would hand out every sibling's `identity.key` — exactly what #975 closed. Per-file grants confer no directory listing, and `resolve_writer_pubkey` never lists; it opens the two paths directly.

**Why together:** (1) alone converts a silent accept into approvals being *ignored* on Linux — the HITL gate would defer forever. (2) alone leaves the fail-open in place for any peer the enumeration misses. Same coupling as #1003.

These land in `fs_read` via the builder, so the read partition from #1003 cannot drop them — only user-declared grants are partitioned.

## Known gap, inherited and now fail-closed

Enumeration happens at seal time, so an agent created afterwards is not listed and its signed events are unverifiable to an already-running agent until that one restarts. Same gap `sibling_signing_keys` has, same real fix: option (c), move private keys out of the agents tree. The difference is that it is now **fail-closed** instead of silently accepted.

## Verification

Negative controls, each targeted:

| neutered | result |
|---|---|
| `None => !require_sig` restored | signed-event test red |
| `fs_read` peer-pubkey grant removed | policy test red |

Tests added: public material listed / private key never listed; missing files skipped; malformed agent dir skipped; policy grants the pair but not `identity.key`; signed-event-with-unreadable-key rejected; unsigned event still follows `require_sig` both ways.

`mur-agent-runtime` 893 passed · `mur-core` lib 2536 passed · clippy `--all-targets -D warnings` clean on both · `cargo fmt --check` clean.

Audit updated (§9 corrected, §10 added) — the wrong reasoning is struck through rather than deleted, so the correction is visible.

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)