### PR TITLE
fix(sandbox): macOS children DO inherit the sandbox — correct #1005

### DIFF
--- a/docs/architecture/mcp-supply-chain.md
+++ b/docs/architecture/mcp-supply-chain.md
@@ -98,7 +98,11 @@ It is a command rather than a startup check because it costs a full reinstall. R
 
 **"The same code", never "safe code".** What bounds the damage from a compromised MCP server is the agent's entitlements and sandbox, not its hash. A vendored, signed, provenance-carrying server still runs with everything that agent was granted.
 
-**And on macOS, that bound does not exist for MCP servers at all.** SBPL is not inherited across `exec`, so a server the runtime spawns runs with the *user's* privileges — not the agent's entitlements. Linux is different in kind, not degree: Landlock and seccomp ARE inherited, so there the child really does run under the agent's policy. Until the pre-fork launcher lands (`mur-agent-runtime/src/sandbox/child.rs` names the design and the one call to activate), installing an MCP server on macOS is a trust decision about the whole machine, and no amount of pinning changes that. `mur agent perm show` and `mur agent doctor <name>` both say so rather than letting the entitlement list imply otherwise.
+**And the bound is per-AGENT, not per-server.** A spawned MCP server inherits the agent's sandbox in full — Landlock/seccomp on Linux, a seatbelt sandbox across `fork`+`exec` on macOS (the mechanism `sandbox-exec(1)` is built on; verified empirically, see `mur-agent-runtime/src/sandbox/child.rs`). Ordering holds it: the supervisor seals before the MCP pool is built, and the pool spawns lazily on first tool use.
+
+What does not exist is granularity: no server can be given a *narrower* cage than the agent itself, because that needs a second `sandbox_init` in the child — the pre-fork launcher tracked in `child.rs`. So installing an MCP server grants it everything that agent was granted, and no amount of pinning changes that. `mur agent perm show` and `mur agent doctor <name>` both say so rather than letting the entitlement list imply per-server scoping.
+
+> An earlier revision of this section claimed macOS children were unconfined. That was wrong — it restated a code comment nobody had tested. The empirical check is in `child.rs`; re-run it before restating either way.
 
 The open follow-on is to connect the two: a server whose provenance cannot be verified is a reason to suggest narrower entitlements at install time — protection that still works when detection fails.
 

--- a/mur-agent-runtime/src/sandbox/child.rs
+++ b/mur-agent-runtime/src/sandbox/child.rs
@@ -14,18 +14,39 @@ use std::process::{Child, Command};
 ///    so the assert would fire.  Children inherit the supervisor's own
 ///    Landlock / seccomp restrictions (B1 Tasks 2–3).
 ///
-/// 2. **macOS**: SBPL (`sandbox_init`/`sandbox_init_with_parameters`) is NOT
-///    inherited across `exec`.  Unlike Landlock on Linux, the SBPL policy
-///    applied to the supervisor is not propagated to spawned children.
-///    **macOS children spawned here are therefore unconfined.**  `cage.spawn`
-///    is not used because it calls `sandbox_init()` on the *calling* process
-///    (re-initialising the already-applied supervisor policy, which is
-///    undefined behaviour).  A dedicated pre-fork single-threaded launcher
-///    subprocess is required to confine macOS children at spawn time; that
-///    work is tracked as a follow-up.
+/// 2. **macOS**: `cage.spawn` would call `sandbox_init()` on the *calling*
+///    process, re-initialising the policy `sandbox::apply` already applied to
+///    the supervisor — undefined behaviour. So the spawn is a plain
+///    `cmd.spawn()`, and the child is confined by INHERITANCE.
 ///
-/// When the supervisor adopts a pre-fork single-threaded launcher subprocess
-/// the `cage.spawn(birdcage_cmd)` call below can be activated.
+/// Children are confined on both platforms, by the supervisor's own policy:
+/// Landlock/seccomp are inherited on Linux, and a macOS seatbelt sandbox is
+/// inherited across `fork` + `exec` (the mechanism `sandbox-exec(1)` is built
+/// on — it sandboxes itself, then execs). Verified empirically:
+///
+/// ```text
+/// $ sandbox-exec -p '(version 1)(allow default)(deny network-outbound)' \
+///     /bin/sh -c 'curl -s -m5 -o /dev/null -w "%{http_code}" https://example.com; echo'
+/// 000          # blocked, through sh's fork AND curl's exec
+/// $ /bin/sh -c 'curl ... ; echo'
+/// 200          # same shape, no sandbox
+/// ```
+///
+/// Ordering makes this hold here: `sandbox::apply` seals the supervisor
+/// (`supervisor.rs`) before the MCP pool is built, and the pool spawns lazily
+/// on first tool use — every MCP server starts after the seal.
+///
+/// **What is actually missing is per-child policy.** A child cannot be given a
+/// NARROWER cage than the agent itself, because that needs a second
+/// `sandbox_init` in the child — hence the pre-fork single-threaded launcher
+/// tracked as a follow-up, after which `cage.spawn(birdcage_cmd)` below can be
+/// activated. Until then the granularity is per-agent, not per-server; the
+/// confinement itself is real.
+///
+/// An earlier version of this doc said macOS children were "unconfined". That
+/// was wrong, and the error escaped into `mur agent perm show`, `mur agent
+/// doctor` and `docs/architecture/mcp-supply-chain.md` before the empirical
+/// check above was run. Do not restate it without re-running that check.
 pub fn spawn_sandboxed(cmd: Command, policy: &SandboxPolicy) -> io::Result<Child> {
     spawn_impl(cmd, policy)
 }
@@ -53,19 +74,10 @@ fn spawn_impl(mut cmd: Command, policy: &SandboxPolicy) -> io::Result<Child> {
     // a dedicated single-threaded pre-fork process (see module docs).
     // For now the cage is built to document intent.
     //
-    // What actually confines the child differs by platform, and the
-    // difference is NOT cosmetic:
-    //
-    // - Linux: Landlock and seccomp ARE inherited across `exec`, so the
-    //   child really does run under the supervisor's policy.
-    // - macOS: SBPL is NOT inherited across `exec`. The child runs with the
-    //   user's full privileges — this policy does not reach it at all.
-    //
-    // An earlier version of this comment claimed "the supervisor's inherited
-    // restrictions (Landlock/SBPL) cover the child at the kernel level",
-    // which is true on Linux and false on macOS. Sitting three lines from
-    // `drop(cage)`, it was exactly where a reader stops and concludes this is
-    // fine. Stating both halves is the point.
+    // The child IS confined — by inheritance, on both platforms: Landlock and
+    // seccomp on Linux, and a macOS seatbelt sandbox across fork+exec (see the
+    // module docs for the empirical check). What the dropped cage would have
+    // added is a NARROWER, per-child policy, which needs the pre-fork launcher.
     drop(cage);
     cmd.spawn()
 }

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -31,29 +31,26 @@ pub(super) fn warn_if_running(name: &str) {
     }
 }
 
-/// Warn that these entitlements stop at the runtime on macOS.
+/// Note the ONE thing this entitlement list does not express: granularity.
 ///
-/// SBPL is not inherited across `exec`, so an MCP server the runtime spawns
-/// runs with the user's full privileges — the policy printed above does not
-/// reach it. (Linux children DO inherit Landlock, so this is macOS-only.)
+/// The policy above does reach the MCP servers this agent spawns — children
+/// inherit it (Landlock on Linux, a seatbelt sandbox across fork+exec on
+/// macOS). What it cannot do is give one server a NARROWER cage than the
+/// agent itself, so every server here can reach everything listed above.
 ///
 /// Printed to STDERR, and only when the agent actually spawns children:
 /// `perm show` output is YAML that callers pipe into a parser, and a caveat
 /// that corrupts the data it qualifies is not an improvement.
-fn warn_children_unconfined(profile: &mur_common::AgentProfile) {
-    if !cfg!(target_os = "macos") {
-        return;
-    }
+fn warn_shared_scope(profile: &mur_common::AgentProfile) {
     let n = profile.mcp_servers.len();
     if n == 0 {
         return;
     }
     eprintln!(
-        "note: on macOS these entitlements confine the agent runtime, not the \
-         {n} MCP server(s) it spawns — SBPL is not inherited across exec, so \
-         those child processes run unconfined. Linux children do inherit \
-         Landlock. Scope what a server can reach with `mur agent mcp \
-         set-network`, and treat installing one as the trust decision it is."
+        "note: this policy is per-AGENT. The {n} MCP server(s) below inherit it \
+         in full — there is no way to give one a narrower cage than the agent \
+         itself. Scope a server's network reach with `mur agent mcp \
+         set-network`, and treat installing one as granting it everything above."
     );
 }
 
@@ -80,7 +77,7 @@ pub fn cmd_perm_show(name: &str, section: Option<&str>) -> Result<()> {
     } else {
         print!("{v}");
     }
-    warn_children_unconfined(&profile);
+    warn_shared_scope(&profile);
     Ok(())
 }
 

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -600,22 +600,20 @@ pub fn agent_doctor(mur_home: &std::path::Path, name: &str) -> Result<Vec<Check>
         &profile.entitlements.filesystem,
     ));
 
-    #[cfg(target_os = "macos")]
     if !profile.mcp_servers.is_empty() {
-        // Not a fault in this agent — a platform limit that the entitlement
+        // Not a fault in this agent — a granularity limit that the entitlement
         // list does not advertise. It belongs in doctor because this is where
-        // someone lands after asking "why did my MCP server reach a host my
-        // allowlist forbids?", and the honest answer is that the allowlist
-        // never applied to it. `ok: true` on purpose: nothing here is
-        // fixable by the user, and a permanent red would train them to
-        // ignore the whole report.
+        // someone lands after asking "which of my MCP servers can reach what?",
+        // and the answer is "all of them, everything this agent can".
+        // `ok: true` on purpose: nothing here is fixable by the user, and a
+        // permanent red would train them to ignore the whole report.
         out.push(Check::new(
             "sandbox_scope",
             true,
             format!(
-                "entitlements confine the runtime, NOT the {} MCP server(s) it spawns \
-                 — macOS does not inherit SBPL across exec, so those run unconfined \
-                 (Linux inherits Landlock). Scope them with `mur agent mcp set-network`.",
+                "policy is per-agent: all {} MCP server(s) inherit it in full — \
+                 none can be given a narrower cage than the agent itself. \
+                 Scope network reach per server with `mur agent mcp set-network`.",
                 profile.mcp_servers.len()
             ),
         ));
@@ -883,15 +881,13 @@ mod tests {
         );
     }
 
-    /// macOS does not inherit SBPL across `exec`, so an agent's entitlements
-    /// stop at the runtime and its MCP servers run unconfined. Doctor has to
-    /// say so — it is where someone lands after asking why a server reached a
-    /// host the allowlist forbids. Reported as OK, not a failure: it is a
-    /// platform limit the user cannot fix, and a permanent red trains people
-    /// to ignore the report.
-    #[cfg(target_os = "macos")]
+    /// A spawned MCP server inherits the agent's sandbox in full, so the
+    /// policy is per-agent and not per-server. Doctor has to say so — it is
+    /// where someone lands after asking which of their servers can reach what.
+    /// Reported as OK, not a failure: it is a granularity limit the user
+    /// cannot fix, and a permanent red trains people to ignore the report.
     #[test]
-    fn agent_doctor_states_that_mcp_children_are_unconfined() {
+    fn agent_doctor_states_that_policy_is_per_agent_not_per_server() {
         let tmp = tempfile::TempDir::new().unwrap();
         let mur_home = tmp.path().to_path_buf();
         let agent_dir = mur_home.join("agents").join("scoped");
@@ -917,17 +913,16 @@ mod tests {
             .iter()
             .find(|c| c.name == "sandbox_scope")
             .expect("expected a sandbox_scope check");
-        assert!(c.ok, "a platform limit is not this agent's fault");
+        assert!(c.ok, "a granularity limit is not this agent's fault");
         assert!(
-            c.detail.contains("unconfined"),
-            "must name the actual state: {}",
+            c.detail.contains("per-agent") && c.detail.contains("narrower"),
+            "must name the actual limit — shared scope, not absent scope: {}",
             c.detail
         );
     }
 
     /// No MCP servers, nothing spawned, nothing to warn about — the note must
     /// not become background noise on every agent.
-    #[cfg(target_os = "macos")]
     #[test]
     fn agent_doctor_is_silent_about_scope_without_mcp_servers() {
         let tmp = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
**#1005 shipped a false claim. This corrects it.**

#1005 said an agent's entitlements do not reach the MCP servers it spawns on macOS, and wrote that into `mur agent perm show`, `mur agent doctor` and `docs/architecture/mcp-supply-chain.md`. It restated a `child.rs` comment that nobody had tested — and I didn't test it either before shipping.

## The measurement

macOS seatbelt sandboxes **are** inherited across fork+exec. That is the mechanism `sandbox-exec(1)` is itself built on: it sandboxes its own process, then execs the target.

```
$ sandbox-exec -p '(version 1)(allow default)(deny network-outbound)' \
    /bin/sh -c 'curl -s -m5 -o /dev/null -w "%{http_code}" https://example.com; echo'
000        # blocked — through sh's fork AND curl's exec

$ /bin/sh -c 'curl -s -m5 -o /dev/null -w "%{http_code}" https://example.com; echo'
200        # identical shape, no sandbox
```

The trailing `; echo` matters: with two statements `sh` must fork rather than exec-replace itself, so this covers **fork+exec**, not just exec.

Ordering holds it in the runtime: `sandbox::apply` seals the supervisor (`supervisor.rs`) *before* the MCP pool is constructed, and the pool spawns lazily on first tool use — every MCP server starts after the seal.

## What is actually true

The policy is **per-agent, not per-server**. A server cannot be given a *narrower* cage than the agent itself, because that would need a second `sandbox_init` in the child — the pre-fork launcher still tracked in `child.rs`. So installing an MCP server grants it everything that agent was granted.

That is a **granularity** limit, not an absence of confinement — and the difference is most of the severity. "Runs with your full user privileges" and "runs with exactly what this agent was granted" are not the same claim.

One half of the old comment was always right and is kept: `cage.spawn` is not used because it would re-init an already-applied policy.

## Changes

- **`child.rs`** — module doc rewritten around the measurement, including a note not to restate the old claim without re-running the check.
- **`perm show` / `agent doctor`** — now say *"policy is per-agent; all N servers inherit it in full, none can be given a narrower cage"*. Both also drop the `#[cfg(target_os = "macos")]` gate, since the granularity limit is not macOS-specific.
- **`mcp-supply-chain.md`** — corrected, and keeps an explicit marker that the previous revision was wrong, so the reasoning isn't silently rewritten.

## Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo nextest run -p mur-core -E 'test(/agent_doctor|sandbox_scope|per_agent/)'` → 11/11. Test assertions updated to require the message name the real limit (`per-agent` + `narrower`) rather than the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)