### PR TITLE
fix(channel): an unreadable signing key must not silently write unsigned events

### DIFF
--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -16,6 +16,12 @@ use std::os::unix::fs::PermissionsExt;
 pub enum IdentityError {
     #[error("identity files not found")]
     NotFound,
+    /// The key is there but this process may not read it — a sandbox deny, or
+    /// wrong ownership. Distinct from `NotFound` on purpose: callers that treat
+    /// an absent key as "not signed yet" must NOT treat an unreadable one the
+    /// same way, or a deny silently downgrades signing to unsigned.
+    #[error("identity key exists but is not readable: {0}")]
+    Denied(String),
     #[error("io error: {0}")]
     Io(#[from] io::Error),
     #[error("invalid key material: {0}")]
@@ -70,10 +76,23 @@ impl AgentIdentity {
     /// present `identity.pub` matches.
     pub fn load(dir: &Path) -> Result<Self, IdentityError> {
         let priv_path = dir.join("identity.key");
-        if !priv_path.exists() {
-            return Err(IdentityError::NotFound);
+        // `Path::exists()` cannot be used here: it answers false for ANY stat
+        // failure, so a sandbox deny is indistinguishable from a missing file
+        // and the caller's "no key yet" branch runs when the truth is "you may
+        // not read this key". Ask for the metadata and keep the error kind.
+        if let Err(e) = fs::metadata(&priv_path) {
+            return Err(match e.kind() {
+                io::ErrorKind::NotFound => IdentityError::NotFound,
+                _ => IdentityError::Denied(format!("{}: {e}", priv_path.display())),
+            });
         }
-        let bytes = fs::read(&priv_path)?;
+        let bytes = fs::read(&priv_path).map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => IdentityError::NotFound,
+            io::ErrorKind::PermissionDenied => {
+                IdentityError::Denied(format!("{}: {e}", priv_path.display()))
+            }
+            _ => IdentityError::Io(e),
+        })?;
         if bytes.len() != SECRET_KEY_LENGTH {
             return Err(IdentityError::InvalidKey(format!(
                 "expected {SECRET_KEY_LENGTH} bytes, got {}",
@@ -569,6 +588,70 @@ fn write_canonical(out: &mut Vec<u8>, v: &serde_json::Value) {
             }
             out.push(b'}');
         }
+    }
+}
+
+#[cfg(test)]
+mod identity_readability_tests {
+    use super::*;
+
+    /// A key that exists but cannot be read must NOT report as absent.
+    ///
+    /// `Path::exists()` answers false for any stat failure, so before this the
+    /// two were indistinguishable and every caller's "no key yet" branch ran
+    /// when the truth was "you may not read this key" — which is exactly what
+    /// a sandbox deny produces.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_key_is_denied_not_notfound() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        AgentIdentity::generate().save(dir.path()).unwrap();
+        let key = dir.path().join("identity.key");
+
+        // Precondition: readable right now, so the assert below is about the
+        // permission change and nothing else.
+        assert!(AgentIdentity::load(dir.path()).is_ok());
+
+        // Case 1 — the file is unreadable but still STATtable (chmod 000).
+        // `exists()` says true here, so this exercises the read mapping.
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let unreadable = AgentIdentity::load(dir.path()).unwrap_err();
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(
+            matches!(unreadable, IdentityError::Denied(_)),
+            "an unreadable key must be Denied, got {unreadable:?}"
+        );
+
+        // Case 2 — the file cannot even be STATted, because the directory
+        // holding it is not searchable. THIS is what a sandbox deny looks
+        // like, and it is the case `Path::exists()` gets wrong: it answers
+        // false, so the old code reported NotFound and every caller's
+        // "no key yet" branch ran.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+        let unstattable = AgentIdentity::load(dir.path()).unwrap_err();
+        let exists_lies = !key.exists();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            exists_lies,
+            "precondition: Path::exists() must be answering false here, or this \
+             case is not reproducing a sandbox deny"
+        );
+        assert!(
+            matches!(unstattable, IdentityError::Denied(_)),
+            "a key that cannot be STATted must be Denied, not NotFound, got {unstattable:?}"
+        );
+    }
+
+    /// ...and a genuinely absent key still reports NotFound, because callers
+    /// legitimately treat that as "nothing signed yet".
+    #[test]
+    fn a_missing_key_is_still_notfound() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            AgentIdentity::load(dir.path()).unwrap_err(),
+            IdentityError::NotFound
+        ));
     }
 }
 

--- a/mur-core/src/channel_writer.rs
+++ b/mur-core/src/channel_writer.rs
@@ -53,11 +53,43 @@ pub fn append_as_writer(
     idem: Option<String>,
 ) -> anyhow::Result<ChannelEvent> {
     let agent_home = home.join("agents").join(router_agent);
-    if let Ok(id) = mur_common::identity::AgentIdentity::load(&agent_home) {
-        let kv = read_key_version(&agent_home);
-        return svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem);
+    match mur_common::identity::AgentIdentity::load(&agent_home) {
+        Ok(id) => {
+            let kv = read_key_version(&agent_home);
+            svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem)
+        }
+        // No key at all: the legitimate bootstrap case (a fresh home, a test,
+        // a workflow channel with no agent behind it). Unsigned is correct.
+        Err(mur_common::identity::IdentityError::NotFound) => {
+            svc.append(channel_id, actor, kind, payload, idem)
+        }
+        // The key is THERE and we may not read it — a sandbox deny (a spawned
+        // `mur` cannot read a sibling's signing key since #975). Falling back
+        // to unsigned here is a silent security downgrade: the event was meant
+        // to be signed, and with `require_sig` off the reader accepts it, so
+        // the whole v3d signing guarantee lapses with nothing to show for it.
+        // The mirror of the read-side fix in `channel_verify::verify_event`.
+        Err(e) => {
+            if crate::channel_verify::require_sig_from_env() {
+                // The reader would reject an unsigned event anyway; fail here,
+                // where the cause is still legible, instead of at verification.
+                anyhow::bail!(
+                    "refusing to write an unsigned event to '{channel_id}': the \
+                     writer key for '{router_agent}' is unreadable ({e}), and \
+                     MUR_CHANNEL_REQUIRE_SIG is set"
+                );
+            }
+            tracing::warn!(
+                channel_id,
+                router_agent,
+                error = %e,
+                "writer signing key is present but unreadable — writing this \
+                 event UNSIGNED. Signature verification is not protecting this \
+                 channel while that holds."
+            );
+            svc.append(channel_id, actor, kind, payload, idem)
+        }
     }
-    svc.append(channel_id, actor, kind, payload, idem)
 }
 
 #[cfg(test)]
@@ -65,6 +97,57 @@ mod tests {
     use super::*;
     use mur_common::identity::AgentIdentity;
     use tempfile::TempDir;
+
+    /// An UNREADABLE writer key must not silently produce an unsigned event.
+    ///
+    /// This is the write-side mirror of `channel_verify::verify_event`: there,
+    /// an unreadable key must not pass as an absent signature; here, it must
+    /// not pass as "no key, so unsigned is fine". A sandboxed `mur` cannot read
+    /// a sibling's signing key (#975), so before this every channel event such
+    /// a process wrote was unsigned — and with `require_sig` off the reader
+    /// accepted it, so the signing guarantee lapsed with no signal anywhere.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_writer_key_does_not_silently_write_unsigned() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let agent_home = home.join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        AgentIdentity::generate().save(&agent_home).unwrap();
+        let key = agent_home.join("identity.key");
+        let svc = ChannelService::open(home).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+
+        // Precondition: with the key readable, the event IS signed.
+        let signed = append_as_writer(
+            &svc,
+            home,
+            &ch.id,
+            "mur",
+            ChannelActor::System,
+            EventKind::Message,
+            serde_json::json!({"text": "before"}),
+            None,
+        )
+        .unwrap();
+        assert!(signed.sig.is_some(), "precondition: signing works");
+
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // MUR_CHANNEL_REQUIRE_SIG is not set in the test env, so this takes the
+        // warn-and-write path — the event is unsigned, but LOUDLY so. What is
+        // asserted here is the discrimination itself: the loader must report
+        // this as Denied, not NotFound, which is what makes the warning
+        // possible at all.
+        let err = mur_common::identity::AgentIdentity::load(&agent_home).unwrap_err();
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(
+            matches!(err, mur_common::identity::IdentityError::Denied(_)),
+            "an unreadable writer key must be distinguishable from an absent \
+             one, or the unsigned fallback stays silent: {err:?}"
+        );
+    }
 
     #[test]
     fn unsigned_when_identity_absent() {


### PR DESCRIPTION
The write-side mirror of #1006. That fixed the reader — an unreadable key must not pass as an *absent signature*. The writer had the same conflation pointing the other way, and it is live.

```rust
if let Ok(id) = AgentIdentity::load(&agent_home) {
    return svc.append_signed(...);
}
svc.append(...)          // <- unsigned, silently
```

## Why the two were indistinguishable

`AgentIdentity::load` tested `priv_path.exists()`. **`Path::exists()` answers false for any stat failure**, so a sandbox deny looked exactly like a missing file. A denied key reported `NotFound`, the caller's "no key yet" branch ran, and the event went out unsigned.

## This is reachable today

Since #975 a spawned `mur` cannot read a sibling's `identity.key`, and `fleet_run`-enabled agents get `spawn(mur)` (policy.rs). So a sandboxed `mur fleet run` writing through the DAG executor (`executor/dag.rs`) or the HITL gate (`hitl/gate.rs`) — 11 call sites across 6 files reach `append_as_writer` — produced **unsigned** events. With `require_sig` off, `verify_event` then accepted them.

Net effect: the v3d signing guarantee lapsed for sandboxed fleet runs, with no signal at either end. #1006 closed the reading half; this closes the writing half.

## The fix

**1. `AgentIdentity::load` keeps the error kind.** `fs::metadata` instead of `exists()`; `NotFound` stays `NotFound`, anything else becomes a new `IdentityError::Denied`. The subsequent read maps `PermissionDenied` the same way.

**2. `append_as_writer` matches on it.**
- `NotFound` → unsigned, unchanged. This is the legitimate bootstrap case (fresh home, workflow channel with no agent behind it) and is covered by the existing `unsigned_when_identity_absent` test.
- `Denied` → warn loudly, naming channel and writer; and when `MUR_CHANNEL_REQUIRE_SIG` is set, refuse outright — the reader would reject the event anyway, and failing at the write keeps the cause legible instead of surfacing as a verification failure later.

**Why the default stays permissive:** hard-failing every unreadable key would break fleet runs that work today, and the reader is where enforcement belongs. What changes is that the downgrade is no longer silent.

## A note on the tests, because the first version proved nothing

`chmod 000` on the key file still permits `stat` — so `exists()` returned **true**, only the read mapping was exercised, and reverting the `metadata` change left the suite green. The negative control caught it.

The test now covers both shapes:

| case | what it reproduces |
|---|---|
| key `chmod 000` | unreadable but STATtable — exercises the read mapping |
| containing dir `chmod 000` | **unSTATtable — what a sandbox deny actually looks like** |

and it asserts `Path::exists()` is lying *before* asserting the fix, so the case cannot silently stop reproducing. With that in place, reverting the `metadata` change yields `got NotFound` and the test fails.

## Verification

| neutered | result |
|---|---|
| `metadata` → `exists()` | `an_unreadable_key_is_denied_not_notfound` red (`got NotFound`) |

`mur-common` 936 passed · `mur-core` lib 2539 passed · `mur-agent-runtime` 893 passed · clippy `--all-targets -D warnings` clean · `cargo fmt --check` clean.

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)