### PR TITLE
fix(publish): stop overwriting the host key, and make save write-if-absent

### DIFF
--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -16,6 +16,13 @@ use std::os::unix::fs::PermissionsExt;
 pub enum IdentityError {
     #[error("identity files not found")]
     NotFound,
+    /// Refused to overwrite a key that is already there. `save` is
+    /// write-if-absent by contract: a private key has no `.prev` and no
+    /// rotation attestation behind it, so clobbering one is unrecoverable.
+    /// Callers that legitimately replace a key (`mur agent rekey`) write to a
+    /// scratch directory and rename.
+    #[error("refusing to overwrite an existing identity key at {0}")]
+    Exists(String),
     /// The key is there but this process may not read it — a sandbox deny, or
     /// wrong ownership. Distinct from `NotFound` on purpose: callers that treat
     /// an absent key as "not signed yet" must NOT treat an unreadable one the
@@ -53,10 +60,29 @@ impl AgentIdentity {
 
     /// Write both halves of the keypair to the given directory.
     /// Private key is mode 0600 on Unix.
+    ///
+    /// **Write-if-absent.** Refuses when `identity.key` already exists, because
+    /// `fs::write` truncates and a private key has nothing behind it to restore
+    /// from — no `.prev`, and no rotation attestation to bridge the swap, so
+    /// every event the old key signed silently stops attributing. A caller that
+    /// means to replace a key writes to a scratch directory and renames, which
+    /// is what `mur agent rekey` does.
+    ///
+    /// This is not hypothetical caution: `mur skill publish` guarded on
+    /// `publisher-identity.key` and wrote `identity.key`, so it overwrote the
+    /// host key on every machine that had one (#1011).
     pub fn save(&self, dir: &Path) -> Result<(), IdentityError> {
         fs::create_dir_all(dir)?;
         let priv_path = dir.join("identity.key");
         let pub_path = dir.join("identity.pub");
+
+        // `exists()` is the right call here despite #1010: a false from a
+        // denied stat means we are about to fail the write anyway, and the
+        // conservative reading (treat unknown as "might exist") would block
+        // legitimate first-time saves under a sandbox.
+        if priv_path.exists() {
+            return Err(IdentityError::Exists(priv_path.display().to_string()));
+        }
 
         fs::write(&priv_path, self.signing.to_bytes())?;
         #[cfg(unix)]
@@ -640,6 +666,47 @@ mod identity_readability_tests {
         assert!(
             matches!(unstattable, IdentityError::Denied(_)),
             "a key that cannot be STATted must be Denied, not NotFound, got {unstattable:?}"
+        );
+    }
+
+    /// `save` must never clobber an existing private key.
+    ///
+    /// This is the mechanism that would have turned #1011 into a loud failure:
+    /// `mur skill publish` called `save` on a directory that already held the
+    /// HOST key, and `fs::write` truncated it. There is no `.prev` and no
+    /// rotation attestation for such a swap, so the old key's signatures stop
+    /// attributing with nothing to restore from.
+    #[test]
+    fn save_refuses_to_overwrite_an_existing_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = AgentIdentity::generate();
+        first.save(dir.path()).unwrap();
+        let original = std::fs::read(dir.path().join("identity.key")).unwrap();
+
+        let err = AgentIdentity::generate().save(dir.path()).unwrap_err();
+
+        assert!(
+            matches!(err, IdentityError::Exists(_)),
+            "expected Exists, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("identity.key")).unwrap(),
+            original,
+            "the existing key was modified despite the refusal"
+        );
+    }
+
+    /// ...but a first save into a fresh directory still works, which is every
+    /// legitimate caller (agent create, export minting a missing key, rekey
+    /// writing to its scratch dir).
+    #[test]
+    fn save_into_an_empty_directory_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = AgentIdentity::generate();
+        id.save(dir.path()).unwrap();
+        assert_eq!(
+            AgentIdentity::load(dir.path()).unwrap().pubkey_text(),
+            id.pubkey_text()
         );
     }
 

--- a/mur-core/src/cmd/skill_publish.rs
+++ b/mur-core/src/cmd/skill_publish.rs
@@ -163,16 +163,32 @@ pub fn cmd_publish(path: &str) -> Result<()> {
 
 fn resolve_publisher_identity() -> Result<AgentIdentity> {
     let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
-    let key_path = home.join(".mur").join("publisher-identity.key");
-    if key_path.exists() {
-        AgentIdentity::load(&home.join(".mur")).map_err(|e| anyhow!("load publisher identity: {e}"))
+    resolve_publisher_identity_in(&home.join(".mur"))
+}
+
+/// Split out from `resolve_publisher_identity` so the thing that matters can be
+/// asserted: that this never writes `<mur_home>/identity.key`. The version that
+/// read `dirs::home_dir()` directly could not be tested at all, which is part of
+/// why #1011 sat there.
+fn resolve_publisher_identity_in(mur_home: &std::path::Path) -> Result<AgentIdentity> {
+    // Its OWN directory (#1011). This used to guard on
+    // `~/.mur/publisher-identity.key` while `AgentIdentity::save`/`load` join
+    // `identity.key` — so the guard tested a file nothing ever created, always
+    // took the else branch, and overwrote `~/.mur/identity.key`: the HOST key,
+    // with no `.prev` and no rotation attestation to recover from.
+    //
+    // A separate directory keeps `save`/`load` usable as-is and makes a
+    // collision structurally impossible rather than merely unlikely.
+    let dir = mur_home.join("publisher");
+    if dir.join("identity.key").exists() {
+        AgentIdentity::load(&dir).map_err(|e| anyhow!("load publisher identity: {e}"))
     } else {
         let identity = AgentIdentity::generate();
-        std::fs::create_dir_all(key_path.parent().unwrap())?;
+        std::fs::create_dir_all(&dir)?;
         identity
-            .save(&home.join(".mur"))
+            .save(&dir)
             .map_err(|e| anyhow!("save publisher identity: {e}"))?;
-        eprintln!("ℹ Generated new publisher identity at ~/.mur/");
+        eprintln!("ℹ Generated new publisher identity at ~/.mur/publisher/");
         Ok(identity)
     }
 }
@@ -186,4 +202,53 @@ fn current_gh_user() -> Result<String> {
         bail!("failed to get GitHub username. Run `gh auth login` first");
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #1011: resolving a publisher identity must never touch the HOST key.
+    ///
+    /// The old code guarded on `publisher-identity.key` — a file nothing ever
+    /// created — while `save`/`load` join `identity.key`. So the guard was
+    /// always false, the else branch always ran, and `fs::write` truncated
+    /// `~/.mur/identity.key`. Unrecoverable: no `.prev`, and no rotation
+    /// attestation to bridge the swap.
+    #[test]
+    fn resolving_a_publisher_identity_never_touches_the_host_key() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        std::fs::create_dir_all(mur_home).unwrap();
+
+        // A host key, exactly as a real ~/.mur has.
+        let host = AgentIdentity::generate();
+        host.save(mur_home).unwrap();
+        let host_bytes = std::fs::read(mur_home.join("identity.key")).unwrap();
+
+        let publisher = resolve_publisher_identity_in(mur_home).unwrap();
+
+        assert_eq!(
+            std::fs::read(mur_home.join("identity.key")).unwrap(),
+            host_bytes,
+            "the host key was overwritten"
+        );
+        assert_ne!(
+            publisher.pubkey_text(),
+            host.pubkey_text(),
+            "the publisher identity must not BE the host key"
+        );
+        assert!(mur_home.join("publisher").join("identity.key").exists());
+    }
+
+    /// ...and it is stable: a second call returns the same identity rather than
+    /// minting a new one, which is what makes published signatures verifiable
+    /// across releases.
+    #[test]
+    fn resolving_twice_returns_the_same_publisher_identity() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let first = resolve_publisher_identity_in(tmp.path()).unwrap();
+        let second = resolve_publisher_identity_in(tmp.path()).unwrap();
+        assert_eq!(first.pubkey_text(), second.pubkey_text());
+    }
 }


### PR DESCRIPTION
Fixes #1011 — a live, unrecoverable data-loss bug found while surveying key paths for #850 option (c).

## The defect

`resolve_publisher_identity` guarded on one file and wrote another:

```rust
let key_path = home.join(".mur").join("publisher-identity.key");   // guard
if key_path.exists() {
    AgentIdentity::load(&home.join(".mur"))                        // reads identity.key
} else {
    AgentIdentity::generate().save(&home.join(".mur"))             // WRITES identity.key
```

`AgentIdentity::save`/`load` join `identity.key`, and **nothing anywhere creates `publisher-identity.key`** (`grep -rn 'publisher-identity' --include='*.rs'` finds only that one line). So the guard was always false, the else branch always ran, and `fs::write` truncated `~/.mur/identity.key` — the host key.

Unrecoverable: unlike `mur agent rekey` there is no `.prev`, and no rotation attestation exists to bridge the swap, so every event the old key signed stops attributing and `verify_chain` cannot span the gap.

## Two changes

**1. The publisher identity gets its own directory** — `~/.mur/publisher/`. `save`/`load` stay usable unchanged and a collision becomes structurally impossible rather than merely unlikely.

`resolve_publisher_identity_in(mur_home)` is split out so this is testable at all. The version that called `dirs::home_dir()` directly could not be tested, which is part of why the bug sat there.

**2. `AgentIdentity::save` is now write-if-absent** — returns `IdentityError::Exists` instead of truncating. This turns the entire bug class into a loud failure instead of silent destruction.

### Why (2) is safe — checked, not assumed

No production caller relies on overwriting:

| caller | why it is fine |
|---|---|
| `agent/export.rs:70` | saves only in the `NotFound` branch (mints a missing key) |
| `agent_rekey.rs:224` | saves into `.rekey-scratch`, then renames — and writes `identity.key.prev` first |
| `agent_companion/connector.rs:500` | `bail!("agent dir already exists")` immediately above |
| `commander.rs:169` | inside `#[cfg(test)]` |
| `muragent/installer.rs` | lists `identity.key` among files a bundle must **never** carry |

Full suites confirm: `mur-common` 938, `mur-core` lib 2544, `mur-agent-runtime` 893 — all passing.

## Verified by reproducing the destruction, not by reading

The new test plants a host key, resolves a publisher identity, and asserts the host key is byte-identical afterwards. Negative control — restore the old guard and drop the `save` hardening:

```
FAIL resolving_a_publisher_identity_never_touches_the_host_key
     assertion `left == right` failed: the host key was overwritten
```

So the bug is demonstrated in a test rather than by destroying a real key. I deliberately never ran `mur skill publish` to confirm it live, for the obvious reason.

A second test asserts resolving twice returns the *same* identity — otherwise published signatures would not verify across releases.

## Note for anyone already affected

On a machine where `mur skill publish` has already run, a publisher key is now sitting at `~/.mur/identity.key` where the host key used to be, and the two are indistinguishable after the fact. This change stops it happening again; it cannot detect or undo it.

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)