### PR TITLE
feat(identity): migrate private keys out of the agents tree (#850 option (c), step 2)

### DIFF
--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -171,6 +171,27 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // 3a. Load agent identity (Ed25519 keypair) for Noise-XK TCP transport.
     //     If missing, fall back to an ephemeral identity and warn that
     //     cross-host TCP won't work (peers can't verify our static key).
+    // #850 option (c) step 2: move THIS agent's private key out of the agents
+    // tree, before it is loaded. Runs here rather than from `mur update`
+    // because that is not the only upgrade path — `build.sh --install` +
+    // `mur agent restart --stale` never invokes it. Scoped to one key, so
+    // concurrent agent starts cannot contend.
+    //
+    // Advisory: a failure leaves the key where it is, and step 1's fallback
+    // still loads it. What must NOT happen is starting anyway after a refusal
+    // to overwrite a different key — that case is reported loudly and the key
+    // is left untouched, so the next start retries.
+    match mur_common::identity::migrate_private_key(&agent_home) {
+        Ok(true) => info!("private key migrated out of the agents tree"),
+        Ok(false) => {}
+        Err(e) => warn!(
+            error = %e,
+            "could not migrate the private key; it stays where it is and still \
+             loads, but this agent's key remains readable to siblings created \
+             after the sandbox sealed"
+        ),
+    }
+
     let identity = Arc::new(match AgentIdentity::load(&agent_home) {
         Ok(id) => id,
         Err(e) => {

--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -85,6 +85,89 @@ pub fn private_key_dir(dir: &Path) -> PathBuf {
     mur_home.join("keys").join(name)
 }
 
+/// Move one agent's private key out of the agents tree (#850 option (c), step 2).
+///
+/// Scoped to a SINGLE agent on purpose. Every agent runs this for its own key at
+/// startup, so 27 agents starting together never contend — no two of them touch
+/// the same file. A sweep that migrated everyone from whichever process got
+/// there first would have that race for no gain.
+///
+/// Runs at startup rather than from `mur update` because `mur update` is not the
+/// only upgrade path: `build.sh --install` + `mur agent restart --stale` never
+/// invokes it, and neither does `brew upgrade`. A migration hooked there simply
+/// would not run on those machines.
+///
+/// Refuses rather than overwrites when the destination already holds a
+/// DIFFERENT key. Silently picking one would change the agent's identity, which
+/// forges attribution on every channel it has ever written to, and there is no
+/// `.prev` and no rotation attestation to undo it with.
+///
+/// Returns `Ok(true)` when a key was moved. Idempotent: a second call finds
+/// nothing. Never an error for "nothing to migrate".
+pub fn migrate_private_key(agent_dir: &Path) -> Result<bool, IdentityError> {
+    let key_dir = private_key_dir(agent_dir);
+    if key_dir == agent_dir {
+        return Ok(false); // not an agent home — commander, publisher, host key
+    }
+    let legacy = agent_dir.join("identity.key");
+    let target = key_dir.join("identity.key");
+
+    let legacy_bytes = match fs::read(&legacy) {
+        Ok(b) => b,
+        // Nothing to move. Note this deliberately does NOT distinguish denied
+        // from absent: a migration that cannot read the source has nothing to
+        // do either way, and the load path (which does distinguish) is what
+        // reports the problem.
+        Err(_) => return Ok(false),
+    };
+
+    if let Ok(existing) = fs::read(&target) {
+        if existing == legacy_bytes {
+            // Already migrated, with a leftover copy behind. Remove the copy —
+            // leaving a private key in the agents tree is the exposure this
+            // whole change exists to remove.
+            let _ = fs::remove_file(&legacy);
+            return Ok(false);
+        }
+        return Err(IdentityError::Exists(format!(
+            "{} already holds a DIFFERENT key than {}; refusing to migrate —              resolve by hand, because picking one silently changes this agent's              identity",
+            target.display(),
+            legacy.display()
+        )));
+    }
+
+    fs::create_dir_all(&key_dir)?;
+    // Copy-then-remove rather than rename: `keys/` and `agents/` are both under
+    // mur_home so a rename would normally work, but a bind-mounted or symlinked
+    // agents dir would make it cross-device, and a failed rename there would
+    // leave the key nowhere.
+    fs::write(&target, &legacy_bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600))?;
+    }
+    // Only now is it safe to drop the original.
+    fs::remove_file(&legacy)?;
+
+    // `.prev` follows its key if present; rekey writes it beside the private
+    // half, so leaving it behind would strand a usable old key in the tree.
+    let legacy_prev = agent_dir.join("identity.key.prev");
+    if let Ok(prev) = fs::read(&legacy_prev) {
+        let target_prev = key_dir.join("identity.key.prev");
+        if fs::metadata(&target_prev).is_err() {
+            fs::write(&target_prev, &prev)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&target_prev, fs::Permissions::from_mode(0o600))?;
+            }
+        }
+        let _ = fs::remove_file(&legacy_prev);
+    }
+    Ok(true)
+}
+
 impl AgentIdentity {
     /// Generate a fresh Ed25519 keypair using OS CSPRNG.
     pub fn generate() -> Self {
@@ -807,6 +890,95 @@ mod identity_readability_tests {
             current.pubkey_text(),
             "the migrated key must win over the leftover"
         );
+    }
+
+    /// The migration moves the key and leaves nothing behind.
+    #[test]
+    fn migration_moves_the_key_out_of_the_agents_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path();
+        let agent = mur.join("agents").join("pm");
+        std::fs::create_dir_all(&agent).unwrap();
+        let id = AgentIdentity::generate();
+        std::fs::write(agent.join("identity.key"), id.signing.to_bytes()).unwrap();
+
+        assert!(migrate_private_key(&agent).unwrap());
+
+        assert!(!agent.join("identity.key").exists(), "key left in agents/");
+        assert!(mur.join("keys/pm/identity.key").exists());
+        assert_eq!(
+            AgentIdentity::load(&agent).unwrap().pubkey_text(),
+            id.pubkey_text(),
+            "the same identity must load after the move"
+        );
+    }
+
+    /// Idempotent: a second run finds nothing to do.
+    #[test]
+    fn migration_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agent = tmp.path().join("agents").join("pm");
+        AgentIdentity::generate().save(&agent).unwrap(); // already in keys/
+        assert!(!migrate_private_key(&agent).unwrap());
+        assert!(!migrate_private_key(&agent).unwrap());
+    }
+
+    /// The property that protects an unrecoverable file: when the destination
+    /// holds a DIFFERENT key, refuse and touch nothing. Picking one silently
+    /// would change the agent's identity and forge attribution on every channel
+    /// it has written to.
+    #[test]
+    fn migration_refuses_when_the_destination_differs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path();
+        let agent = mur.join("agents").join("pm");
+        let migrated = AgentIdentity::generate();
+        migrated.save(&agent).unwrap();
+        let stray = AgentIdentity::generate();
+        std::fs::write(agent.join("identity.key"), stray.signing.to_bytes()).unwrap();
+
+        let err = migrate_private_key(&agent).unwrap_err();
+
+        assert!(matches!(err, IdentityError::Exists(_)), "got {err:?}");
+        assert_eq!(
+            std::fs::read(mur.join("keys/pm/identity.key")).unwrap(),
+            migrated.signing.to_bytes().to_vec(),
+            "the destination key was modified despite the refusal"
+        );
+        assert!(
+            agent.join("identity.key").exists(),
+            "the source was removed despite the refusal"
+        );
+    }
+
+    /// An identical leftover copy is cleaned up rather than refused — leaving a
+    /// private key in the agents tree is the exposure being removed.
+    #[test]
+    fn migration_clears_an_identical_leftover() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agent = tmp.path().join("agents").join("pm");
+        let id = AgentIdentity::generate();
+        id.save(&agent).unwrap();
+        std::fs::write(agent.join("identity.key"), id.signing.to_bytes()).unwrap();
+
+        assert!(!migrate_private_key(&agent).unwrap());
+        assert!(!agent.join("identity.key").exists());
+    }
+
+    /// The three non-agent identities must never be migrated.
+    #[test]
+    fn migration_skips_non_agent_identities() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path();
+        for dir in [
+            mur.to_path_buf(),
+            mur.join("commander"),
+            mur.join("publisher"),
+        ] {
+            AgentIdentity::generate().save(&dir).unwrap();
+            assert!(!migrate_private_key(&dir).unwrap());
+            assert!(dir.join("identity.key").exists(), "{}", dir.display());
+        }
     }
 
     /// `save` must never clobber an existing private key.


### PR DESCRIPTION
Step 2 of three. Each agent moves **its own** key at startup: `agents/<name>/identity.key` → `keys/<name>/identity.key`, plus `.prev` if present.

Step 1's legacy fallback stays, so **this changes nothing observable** — it drains the old location. Step 3 (drop the fallback, deny `keys/` as a subtree) waits on this having actually run.

## Decision 1 — where it runs: startup, not `mur update`

`mur update` is not the only upgrade path, and this is not hypothetical: **every deploy in the session that wrote this used `build.sh --release --install` + `mur agent restart --stale`**, which never invokes it. `brew upgrade` doesn't either — already a recorded trap. A migration hooked to `mur update` would not have executed once.

The spec's counter-concern — key I/O in a process about to be confined — does not apply: the runtime already loads its identity at `supervisor.rs:174` and seals the sandbox at `:314`.

**Scoped to one key**, which removes the only real hazard: 27 agents starting together never contend, because no two touch the same file. A sweep migrating everyone from whichever process arrived first would have that race and buy nothing.

## Decision 2 — no rollback command

Step 1's dual-read *is* the safety: a half-migrated tree is a fully working tree, so there is no broken state to roll back from. After step 3 the recovery is downgrading the binary, which restores the fallback. A dedicated `--revert` would be a second rarely-taken branch that moves private keys — and the last two key bugs found this week (#1011, and step 1's own rekey defect) were both exactly that.

What is built instead is the refusal the spec asked for.

## The property that matters

| destination state | behaviour |
|---|---|
| absent | move, 0600, then remove the source |
| holds an **identical** key | remove the leftover — a private key in the agents tree is the exposure being removed |
| holds a **different** key | **refuse, touch nothing**, report |

Silently picking one changes the agent's identity, which forges attribution on every channel it has written to. There is no `.prev` and no rotation attestation to undo that.

**Copy-then-remove, not rename.** Both paths are normally under `mur_home`, but a bind-mounted or symlinked agents dir makes a rename cross-device, and a failed rename there would leave the key nowhere.

**Failure is advisory:** the key stays, step 1's fallback still loads it, and the warning names what remains exposed. The next start retries.

## Verification

Negative control: replacing the refusal with an overwrite fails `migration_refuses_when_the_destination_differs`.

Tests: moves and leaves nothing behind; idempotent; refuses on a different destination *and* leaves both files untouched; clears an identical leftover; skips the three non-agent identities (commander, publisher, host key).

**Workspace suite 7695 passed** — run whole this time. In step 1 I ran `-p mur-core --lib`, and `--lib` skips `tests/`, which hid a real defect (rekey writing the rotated key back into `agents/`, silently un-migrating the agent). Not repeating that.

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)