### PR TITLE
test(sandbox): pin the credential predicate and the emitted list together

### DIFF
--- a/mur-agent-runtime/src/sandbox/launch_chain.rs
+++ b/mur-agent-runtime/src/sandbox/launch_chain.rs
@@ -666,6 +666,52 @@ mod tests {
         assert!(chain.peer_public_key_material().is_empty());
     }
 
+    /// Every path the SBPL emitter denies must ALSO be refused by the
+    /// predicate, and vice versa.
+    ///
+    /// `protects_credential`/`protects_capture_store` (predicates) and
+    /// `credential_paths()` (the concrete list the macOS emitter walks) are two
+    /// implementations of one rule. They are consulted by different callers —
+    /// the predicate by the file tools and `mur agent perm`, the list by the
+    /// kernel profile — so a divergence means a path is denied by one and
+    /// allowed by the other, with nothing saying so.
+    ///
+    /// This is not hypothetical: adding `keys/` to the list alone (#850 option
+    /// (c) step 3) left `protects_read` still permitting it, and only a
+    /// behaviour test caught it. Neutering this test the same way reproduces
+    /// that failure exactly.
+    ///
+    /// LIMIT, deliberate: this checks one direction only — list ⊆ predicate.
+    /// The reverse (a predicate branch with no emitted path) cannot be
+    /// enumerated, because the predicates match by prefix and family rather
+    /// than by a closed set. A gap that way is also less severe: the file
+    /// tools still refuse, so the kernel is merely less strict than the tools,
+    /// not the other way round.
+    #[test]
+    fn every_emitted_credential_path_is_also_refused_by_the_predicate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mur = tmp.path().to_path_buf();
+        let chain =
+            LaunchChain::for_test(&mur.join("agents").join("alice"), &mur.join("bin"), &mur);
+
+        let mut gaps: Vec<String> = Vec::new();
+        for p in chain.credential_paths() {
+            if chain.protects_read(&p).is_none() {
+                gaps.push(format!("{} (read)", p.display()));
+            }
+            if chain.protects_write(&p).is_none() {
+                gaps.push(format!("{} (write)", p.display()));
+            }
+        }
+
+        assert!(
+            gaps.is_empty(),
+            "the SBPL emitter denies these but the predicate permits them, so \
+             the file tools and `mur agent perm` disagree with the kernel: {}",
+            gaps.join(", ")
+        );
+    }
+
     /// A read grant wide enough to contain the credential store is dropped
     /// whole, exactly as the write side already drops it. Before #850 the two
     /// diverged: `fs_write: [~/.mur]` was refused and `fs_read: [~/.mur]` was


### PR DESCRIPTION
`protects_credential`/`protects_capture_store` and `credential_paths()` are **two implementations of one rule**, consulted by different callers:

| implementation | consulted by |
|---|---|
| the predicates | the file tools, `mur agent perm` |
| `credential_paths()` | the macOS SBPL emitter (the kernel profile) |

Nothing made them agree.

## They agree today

This test **passes on main**, so it documents an invariant rather than fixing a live gap. I checked before writing it, rather than assuming the asymmetry (8 predicate branches vs 13 list entries) meant a hole.

## Why it is still worth having

The divergence is easy to create and invisible when you do. Adding `keys/` to the list alone in #1017 left `protects_read` still permitting it — caught by a behaviour test, not by review. Reproducing that exact edit here fails this test, naming both directions:

```
the SBPL emitter denies these but the predicate permits them, so the file
tools and `mur agent perm` disagree with the kernel:
  <tmp>/keys (read), <tmp>/keys (write)
```

## Stated limit

Checks **list ⊆ predicate** only. The reverse cannot be enumerated — the predicates match by prefix and family, not a closed set — and it matters less: a gap that way leaves the kernel *less* strict than the tools, not the tools less strict than the kernel. That is in the doc comment rather than left for a reader to work out.

`mur-agent-runtime` 897 passed · clippy `--all-targets -D warnings` clean.