### PR TITLE
fix(secret): pre-seal caching missed the per-agent credential path

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -142,6 +142,17 @@ impl AnthropicClient {
     /// the env var — masking those would defeat the whole purpose.
     pub async fn from_agent_credentials(agent_name: &str, model: String) -> Result<Self, LlmError> {
         let account = format!("{agent_name}/ANTHROPIC_API_KEY");
+        // Through `SecretRef`, so a value cached before the sandbox sealed is
+        // used. Reaching the backend here is what fails after an upgrade: the
+        // Keychain grant binds to the signing identity and a background agent
+        // cannot re-prompt (#866). The supervisor pre-caches this exact ref.
+        let pre = mur_common::secret::SecretRef::Keychain {
+            service: MUR_AGENT_KEYCHAIN_SERVICE.to_string(),
+            account: account.clone(),
+        };
+        if let Some(v) = pre.resolve_preseal_cached() {
+            return Ok(Self::from_secret_string(&v, model, None));
+        }
         match mur_common::secret::keychain_get(MUR_AGENT_KEYCHAIN_SERVICE, &account).await {
             Ok(Some(secret)) => Ok(Self::from_secret_string(&secret, model, None)),
             Ok(None) => Self::from_env(model),
@@ -185,6 +196,17 @@ impl AnthropicClient {
         http: reqwest::Client,
     ) -> Result<Self, LlmError> {
         let account = format!("{agent_name}/ANTHROPIC_API_KEY");
+        // Through `SecretRef`, so a value cached before the sandbox sealed is
+        // used. Reaching the backend here is what fails after an upgrade: the
+        // Keychain grant binds to the signing identity and a background agent
+        // cannot re-prompt (#866). The supervisor pre-caches this exact ref.
+        let pre = mur_common::secret::SecretRef::Keychain {
+            service: MUR_AGENT_KEYCHAIN_SERVICE.to_string(),
+            account: account.clone(),
+        };
+        if let Some(v) = pre.resolve_preseal_cached() {
+            return Ok(Self::from_secret_string_with_http(&v, model, None, http));
+        }
         match mur_common::secret::keychain_get(MUR_AGENT_KEYCHAIN_SERVICE, &account).await {
             Ok(Some(secret)) => Ok(Self::from_secret_string_with_http(
                 &secret, model, None, http,

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -88,6 +88,17 @@ impl OpenAiClient {
     /// env var; backend errors propagate rather than silently falling through.
     pub async fn from_agent_credentials(agent_name: &str, model: String) -> Result<Self, LlmError> {
         let account = format!("{agent_name}/OPENAI_API_KEY");
+        // Through `SecretRef`, so a value cached before the sandbox sealed is
+        // used. Reaching the backend here is what fails after an upgrade: the
+        // Keychain grant binds to the signing identity and a background agent
+        // cannot re-prompt (#866). The supervisor pre-caches this exact ref.
+        let pre = mur_common::secret::SecretRef::Keychain {
+            service: MUR_AGENT_KEYCHAIN_SERVICE.to_string(),
+            account: account.clone(),
+        };
+        if let Some(v) = pre.resolve_preseal_cached() {
+            return Ok(Self::from_secret_string(&v, model, None));
+        }
         match mur_common::secret::keychain_get(MUR_AGENT_KEYCHAIN_SERVICE, &account).await {
             Ok(Some(secret)) => Ok(Self::from_secret_string(&secret, model, None)),
             Ok(None) => Self::from_env(model),
@@ -120,6 +131,17 @@ impl OpenAiClient {
         http: reqwest::Client,
     ) -> Result<Self, LlmError> {
         let account = format!("{agent_name}/OPENAI_API_KEY");
+        // Through `SecretRef`, so a value cached before the sandbox sealed is
+        // used. Reaching the backend here is what fails after an upgrade: the
+        // Keychain grant binds to the signing identity and a background agent
+        // cannot re-prompt (#866). The supervisor pre-caches this exact ref.
+        let pre = mur_common::secret::SecretRef::Keychain {
+            service: MUR_AGENT_KEYCHAIN_SERVICE.to_string(),
+            account: account.clone(),
+        };
+        if let Some(v) = pre.resolve_preseal_cached() {
+            return Ok(Self::from_secret_string_with_http(&v, model, None, http));
+        }
         match mur_common::secret::keychain_get(MUR_AGENT_KEYCHAIN_SERVICE, &account).await {
             Ok(Some(secret)) => Ok(Self::from_secret_string_with_http(
                 &secret, model, None, http,

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -361,6 +361,25 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 }
             }
         }
+        // Per-agent credentials too. These are NOT in models.yaml — the account
+        // name is derived from the agent's name at resolve time
+        // (`llm/anthropic.rs::from_agent_credentials`), so an entry with no
+        // `secret:` of its own falls through to them. Missing this is why the
+        // first cut of the pre-seal fix left that path still broken after an
+        // upgrade.
+        //
+        // Absent credentials are the normal case (most agents use a model
+        // secret), so a miss here is silent — only a resolvable one is cached.
+        for key in ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] {
+            let r = mur_common::secret::SecretRef::Keychain {
+                service: "mur-agent".to_string(),
+                account: format!("{}/{}", profile.inner.name, key),
+            };
+            if mur_common::secret::cache_before_seal(&r).is_ok() {
+                cached += 1;
+            }
+        }
+
         if cached > 0 {
             info!(cached, "provider secrets resolved before sandbox seal");
         }

--- a/mur-common/src/secret.rs
+++ b/mur-common/src/secret.rs
@@ -225,6 +225,16 @@ impl SecretRef {
     /// uses block_in_place; inside a current-thread runtime (where
     /// block_in_place panics) it hops to a fresh thread; otherwise it spins
     /// a current-thread runtime.
+    /// The pre-seal cached value for this ref, if any — WITHOUT falling back
+    /// to the backend.
+    ///
+    /// For callers that reach a backend directly rather than through
+    /// `resolve_blocking`, so they can honour the cache without changing what
+    /// they do when it misses.
+    pub fn resolve_preseal_cached(&self) -> Option<SecretString> {
+        preseal_lookup(self)
+    }
+
     pub fn resolve_blocking(&self) -> Result<SecretString, SecretError> {
         // A value cached before the sandbox sealed wins. Without this, a `file:`
         // ref inside the denied credential store is unreadable post-seal and the
@@ -920,6 +930,40 @@ mod resolve_blocking_tests {
             r.resolve_blocking().is_err(),
             "an uncached ref must not resolve once its path is gone"
         );
+    }
+
+    /// `resolve_preseal_cached` returns the cached value and NEVER reaches a
+    /// backend — the property the per-agent Keychain path depends on.
+    ///
+    /// That path (`from_agent_credentials`) calls `keychain_get` directly
+    /// rather than going through `resolve_blocking`, so the first cut of the
+    /// pre-seal fix did not cover it at all: an agent whose model entry has no
+    /// `secret:` of its own still broke on every upgrade.
+    #[test]
+    fn preseal_cached_lookup_does_not_touch_the_backend() {
+        let r = SecretRef::Keychain {
+            service: "mur-agent-test-nonexistent".into(),
+            account: "no-such-agent/NO_SUCH_KEY".into(),
+        };
+        // Never cached, and the backend has no such item: a miss, not a hang
+        // and not an error.
+        assert!(r.resolve_preseal_cached().is_none());
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.key");
+        std::fs::write(&path, "sk-agent").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let f = SecretRef::File(path.clone());
+        cache_before_seal(&f).unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        use secrecy::ExposeSecret;
+        let got = f.resolve_preseal_cached().expect("cached hit");
+        assert_eq!(got.expose_secret(), "sk-agent");
     }
 
     /// Caching is idempotent and does not grow on repeat calls.


### PR DESCRIPTION
Follow-up to #1023 — which had a gap I introduced and did not catch until I went looking for one.

## The gap

#1023 cached `models.yaml` secrets before the seal. But `from_agent_credentials` calls **`keychain_get` directly**, not through `SecretRef::resolve_blocking`, so the cache was never consulted on that path.

And that path is reachable: a model entry with **no `secret:` of its own** falls through to per-agent credentials. On the machine used for this work, `dev` is such an entry.

So an agent relying on per-agent credentials still broke on every upgrade — **the exact failure #1023 claimed to fix**.

## The fix

All four sites now check the cache first (`anthropic`/`openai` × plain/`_with_http`) via a new `SecretRef::resolve_preseal_cached`, which returns a cached value and never reaches a backend.

The supervisor additionally pre-caches `<agent>/ANTHROPIC_API_KEY` and `<agent>/OPENAI_API_KEY`. A miss there is silent — most agents use a model secret, so absent per-agent credentials are the normal case.

**Incidental improvement:** the cached value is passed as `&SecretString`, not `expose_secret()`. The secret is never materialised as a `&str` on this path — the type error that forced this turned out to be the better design.

## Verification

`preseal_cached_lookup_does_not_touch_the_backend` pins the property the per-agent path depends on: a cached hit resolves, an uncached ref for a nonexistent backend item returns `None` rather than erroring or blocking.

**Workspace suite 7702 passed** · clippy `--all-targets -D warnings` clean · `cargo fmt --check` clean.

Ran the *whole* workspace deliberately: this touches four LLM client construction paths, and `-p <crate>` scoping is what hid a real defect in an earlier step of this series.

## Still unverified

Not yet exercised on a live agent that actually uses per-agent credentials. The end-to-end check on #1023 used `mur` (a `models.yaml` `file:` ref), which was already fixed by that PR — so it does not cover this path.

Refs #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)