### PR TITLE
chore(release): bump workspace version to 2.70.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6642,7 +6642,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.69.0"
+version = "2.70.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.69.0"
+version = "2.70.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
**This PR is the release approval.** Merging tags `v2.70.0`, dispatches `release.yml`, and publishes to crates.io — which is irreversible (yank-only). There is no later gate, so the review below is the gate.

118 non-merge commits since `v2.70.0`'s predecessor: 64 `fix`, 24 `feat`, 25 `docs`.

## What carries risk — read this part

Three changes alter on-disk state or resolution behaviour. Each ran on a real 27-agent install before this PR.

### 1. Private keys move (`#1015`–`#1017`)

`agents/<name>/identity.key` → `keys/<name>/identity.key`, migrated automatically at agent startup.

Verified here: **27/27 migrated, zero private keys left under `agents/`, all `0600`, and every moved key cryptographically matches its agent's `identity.pub`** — no key was cross-wired, which is the one unrecoverable failure mode. Non-agent identities (host key, commander, publisher) confirmed untouched.

Refuses rather than overwrites when the destination holds a *different* key.

**Caveat:** verified on one machine. The migration is per-agent and idempotent, and a failure leaves the key in place with a warning rather than losing it.

### 2. Secret resolution moved before the sandbox seal (`#1023`, `#1024`)

Provider secrets are now resolved into memory before `sandbox::apply`, because a `file:` ref inside `~/.mur/secrets/` is unreadable afterwards — the caller was silently falling back to a per-agent Keychain lookup.

Verified end to end: an agent that returned `all 3 model candidates failed` now completes. The `secrets/` deny is **not** weakened — the agent holds the value, never the path, and `mur agent perm allow-read ~/.mur/secrets` is still refused.

### 3. Trust store schema v1 → v2 (`#1004`)

Skill trust store re-keys itself on first load. Verified: `schema: 2`, 12 entries intact, name-keyed drift baselines untouched.

## Also shipping

- **`#1003`/`#1006`** — sandbox read confinement: `fs_read` partitioned against the credential store; Linux agents can finally read their own `config.yaml` (they were silently running on default config)
- **`#1010`** — an unreadable signing key no longer silently writes *unsigned* channel events
- **`#1013`** — `mur skill publish` no longer overwrites the host key (unrecoverable data loss)
- **`#1014`** — B0 adversarial corpus now runs through the real hook chain at PR time; the mock-based promptfoo gate is deleted
- **`#1019`/`#1022`** — `mur doctor` warns when Keychain grants will not survive an upgrade

Closed by this batch: #850, #809, #960, #1011.

## Known gaps, stated rather than discovered later

- `#866` direction 2 (signed release artifacts) needs a machine that has never run the local re-signer — could not be tested here
- `#1021` (secret backend policy) is a decision, no code pending

## Verification

Workspace suite **7702 passed** on the tip. Every merged PR in this batch was green on all three platforms.