### PR TITLE
docs(claude): the release tag is automatic — CLAUDE.md described the pre-#874 flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Before changing anything that pins, verifies, or launches an MCP server, read `d
 
 ## Release Process
 
-`main` is protected, so the version bump goes through a PR and the tag is pushed only after the bump lands on `main`. Full step-by-step (both Cargo.lock files, the macOS `sed` trap, why never `git push origin main --tags`): the **`mur-release`** skill (`.claude/skills/mur-release/`).
+`main` is protected, so the whole release is one PR: **merging the version bump to `main` IS the release.** `tag.yml` tags the merge commit and dispatches `release.yml` automatically — there is no manual tag step, so review the bump PR as the release approval. Full step-by-step (both Cargo.lock files, the macOS `sed` trap, why a hand-pushed `git push origin main --tags` is still the one thing never to do): the **`mur-release`** skill (`.claude/skills/mur-release/`).
 
 ## Documentation Checklist
 


### PR DESCRIPTION
Two sources in this repo said opposite things about releases. Spotted by the user while I was quoting both at once without noticing they disagreed.

| source | claim |
|---|---|
| `CLAUDE.md` | "the tag **is pushed** only after the bump lands on `main`" |
| `mur-release` skill | "merging the bump to `main` **IS** the release … **There is no manual tag step.**" |

## The skill is right

`tag.yml`'s own header states it:

> When a version bump lands on main, tag it and kick off release.yml.

True since #874. `tag.yml` creates the tag and then `workflow_dispatch`es `release.yml` at the tag ref — the explicit dispatch existing precisely because a `GITHUB_TOKEN`-pushed tag does not fire `on: push: tags`.

## Why the stale line was worth fixing rather than leaving

It failed in the direction that matters. Someone following CLAUDE.md goes looking for a tag step that does not exist — and the nearest thing to reach for is a hand-pushed tag, which is exactly the `git push origin main --tags` trap **the same sentence warns about**: branch protection rejects `main`, the tag lands anyway, and the error names only the rejected branch. It reads as a clean failure while a release is already building from a commit that is not on `main`.

So the sentence simultaneously pointed at the hazard and nudged the reader toward it.

## Also folded in

The consequence the skill draws and CLAUDE.md omitted: with no later gate, **the bump PR is the release approval**. Worth having in the file that gets loaded every session, not only in the skill someone has to think to open.

Docs only.