### PR TITLE
fix(release): sign every macOS binary in the tarball, not just the runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,13 +154,33 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}
           p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
 
-      - name: Sign mur-agent-runtime (macOS)
+      # Every binary in the tarball, not just the runtime. Measured on v2.70.0:
+      # `mur`, `murmurd` and `mur-mcp-server` shipped `flags=0x20002(adhoc,
+      # linker-signed)` — the Rust linker's default when nothing signs them —
+      # while only mur-agent-runtime carried a Developer ID.
+      #
+      # That matters beyond tidiness: a Keychain Always-Allow grant binds to the
+      # signing IDENTITY, and an ad-hoc signature has none, so the identity
+      # degenerates to the binary's hash and every upgrade reads as a different
+      # app. A background agent cannot re-prompt, so the secret silently
+      # resolves to nothing (#866).
+      #
+      # Keep this list in step with the `tar czf` below — signing a binary that
+      # is not shipped is harmless, but shipping one that is not signed is the
+      # bug this fixes.
+      - name: Sign macOS binaries
         if: matrix.target == 'aarch64-apple-darwin'
         run: |
-          codesign --force --options runtime --timestamp \
-            --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
-            target/aarch64-apple-darwin/release/mur-agent-runtime
-          codesign --verify --verbose -R "=anchor apple generic and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" target/aarch64-apple-darwin/release/mur-agent-runtime
+          set -euo pipefail
+          for b in mur mur-mcp-server murmurd mur-agent-runtime; do
+            p="target/aarch64-apple-darwin/release/$b"
+            codesign --force --options runtime --timestamp \
+              --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
+              "$p"
+            codesign --verify --verbose \
+              -R "=anchor apple generic and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" \
+              "$p"
+          done
         env:
           APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
Measured on the **v2.70.0 artifact** — the exact tarball the Homebrew formula installs:

| binary | flags |
|---|---|
| `mur` | `0x20002(adhoc,linker-signed)` |
| `murmurd` | `0x20002(adhoc,linker-signed)` |
| `mur-mcp-server` | `0x20002(adhoc,linker-signed)` |
| `mur-agent-runtime` | `0x10000(runtime)` — Developer ID |

`linker-signed` is what Rust's linker emits when nothing signs the binary afterwards. The step was named `Sign mur-agent-runtime` and targeted exactly that one path, while `tar czf` ships four.

## This is #866's mechanism, in the shipped product

A Keychain Always-Allow grant binds to the signing **identity**. An ad-hoc signature has none, so the identity degenerates to the binary's hash and every upgrade reads as a different app. A background agent cannot re-prompt, so the secret silently resolves to nothing.

Three of the four shipped binaries were in exactly that state.

## Correcting my own note on #866

That comment listed a second step — "run notarization on them". **I am not doing that, because it does not serve the issue.**

- Notarization is a **Gatekeeper** concern (will macOS let an unknown binary run), with no bearing on Keychain ACL binding, which is what #866 is about.
- A bare Mach-O executable cannot carry a stapled ticket — only bundles, DMGs and PKGs can.
- `brew` strips quarantine from what it installs, so the practical gain for a tarball is close to nil.

The DMG and `.pkg` paths are notarized already, where it does matter. Adding an unstaplable notarization pass over four loose binaries would be work that looks like security and buys nothing.

## Scope note

The loop covers all four rather than only the three that were unsigned. Signing is idempotent, and one list that matches `tar czf` is harder to let drift than a list of exceptions — with a comment saying to keep the two in step.

## What this does not fix

Whether a signed tarball's signature **survives `brew install`** still needs a machine that has never run `mur update`'s local re-signer. Unchanged by this PR; the evidence on my machine is overwritten by that re-signer.

Workflow change only — verifiable at the next release, not by CI here.

Refs #866