### PR TITLE
chore(release): bump workspace version to 2.70.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6642,7 +6642,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.70.0"
+version = "2.70.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.70.0"
+version = "2.70.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
**This PR is the release approval.** Merging tags `v2.70.1`, dispatches `release.yml`, and publishes to crates.io — irreversible (yank-only). There is no later gate.

## Why a release with no code changes

One commit since `v2.70.0`: **#1027**, a `release.yml` change. Zero source changes, so `mur --version` gains a number and nothing else behaves differently.

The point is the **artifact**, which is what users actually receive. Measured on the v2.70.0 tarball:

| binary | v2.70.0 | v2.70.1 (expected) |
|---|---|---|
| `mur` | `adhoc,linker-signed` | Developer ID |
| `murmurd` | `adhoc,linker-signed` | Developer ID |
| `mur-mcp-server` | `adhoc,linker-signed` | Developer ID |
| `mur-agent-runtime` | Developer ID | Developer ID |

Three of four shipped unsigned because the signing step targeted one path by name while `tar czf` shipped four. An ad-hoc signature has no certificate, so a Keychain Always-Allow grant binds to the binary's hash and dies on every upgrade — a background agent cannot re-prompt, so the secret silently resolves to nothing (#866).

That state is live in v2.70.0 right now. This release is how it stops being live.

## Risk

Lower than a normal release: no source changed, so the crates.io publish is a version-only republish and the binaries differ from v2.70.0 solely by signature.

The one thing that could go wrong is the signing step itself — it now loops over four binaries with `set -euo pipefail`, so a failure to sign any of them fails the release rather than shipping a partially-signed tarball. That is the intended behaviour and the opposite of what produced v2.70.0.

## Verify after merge

```bash
gh release download v2.70.1 -p 'mur-aarch64-apple-darwin.tar.gz' -D /tmp/v2701
tar -xzf /tmp/v2701/*.tar.gz -C /tmp/v2701
for b in mur murmurd mur-mcp-server mur-agent-runtime; do
  codesign -dv -- /tmp/v2701/$b 2>&1 | grep -o 'flags=0x[0-9a-f]*([^)]*)'
done
```

All four should read `flags=0x10000(runtime)`. Anything still saying `adhoc` means the loop did not cover it.

## Unchanged by this

Whether the signature survives `brew install` still needs a machine that has never run `mur update`'s local re-signer.