### PR TITLE
fix(runtime): expand `~` in tool-gate entitlement roots

### DIFF
--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -127,6 +127,24 @@ pub(crate) fn self_protected(
     fs
 }
 
+/// True when `canonical` falls under any of `roots`.
+///
+/// Roots go through the SAME `~` expansion the sandbox builder applies
+/// ([`crate::sandbox::policy::expand_entitlement_path`]) before
+/// canonicalization. Without it the two layers disagreed about one grant:
+/// the kernel policy expanded `~/...` and let the access through, while this
+/// gate compared a literal `~/...` root (whose `canonicalize` always fails,
+/// falling back to the un-expanded string) and answered "not entitled".
+/// A `~`-written *deny* entry — the very form `detect_warnings` suggests for
+/// `~/.ssh` — was silently inert here for the same reason.
+pub(crate) fn under_any(roots: &[String], canonical: &Path) -> bool {
+    roots.iter().any(|r| {
+        let expanded = crate::sandbox::policy::expand_entitlement_path(r);
+        let root = std::fs::canonicalize(&expanded).unwrap_or(expanded);
+        canonical.starts_with(&root)
+    })
+}
+
 pub(crate) fn check_write_entitlement(
     fs: &FilesystemEntitlement,
     canonical: &Path,
@@ -141,19 +159,13 @@ pub(crate) fn check_write_entitlement(
             canonical.display()
         )));
     }
-    let under = |roots: &[String]| {
-        roots.iter().any(|r| {
-            let root = std::fs::canonicalize(r).unwrap_or_else(|_| PathBuf::from(r));
-            canonical.starts_with(&root)
-        })
-    };
-    if under(&fs.deny) {
+    if under_any(&fs.deny, canonical) {
         return Err(ToolError::Execution(format!(
             "path denied by entitlement: {}",
             canonical.display()
         )));
     }
-    if under(&fs.write) {
+    if under_any(&fs.write, canonical) {
         return Ok(());
     }
     Err(ToolError::Execution(format!(
@@ -198,6 +210,53 @@ mod tests {
         // set, so the refusal above is the launch chain and not a broken check.
         check_write_entitlement(&fs, &home.join("skills/x.yaml"), &chain)
             .expect("unprotected path under the same grant must still be allowed");
+    }
+
+    /// The regression this helper exists for: a `~`-written grant must cover
+    /// the expanded path, because the sandbox builder already expands it. The
+    /// probe dir deliberately does NOT exist, so `canonicalize` fails on both
+    /// sides and the assertion turns purely on the expansion — no dependency
+    /// on the test host's home layout.
+    #[test]
+    fn tilde_grant_is_expanded_like_the_sandbox() {
+        let home = dirs::home_dir().expect("home dir");
+        let chain = crate::sandbox::launch_chain::LaunchChain::inert();
+        let fs = FilesystemEntitlement {
+            write: vec!["~/mur-tilde-grant-probe".to_string()],
+            ..Default::default()
+        };
+
+        check_write_entitlement(&fs, &home.join("mur-tilde-grant-probe/photo.jpg"), &chain)
+            .expect("a ~ grant must cover the path it expands to");
+
+        // Negative control: expansion must not widen the grant to everything,
+        // or the assertion above would pass on a helper that always says yes.
+        check_write_entitlement(
+            &fs,
+            Path::new("/tmp/mur-tilde-grant-probe/photo.jpg"),
+            &chain,
+        )
+        .expect_err("grant must stay scoped to the expanded root");
+    }
+
+    /// Same expansion, deny side. `detect_warnings` tells users to deny
+    /// `~/.ssh`; before this helper that entry was inert at the tool gate.
+    #[test]
+    fn tilde_deny_is_expanded_too() {
+        let home = dirs::home_dir().expect("home dir");
+        let chain = crate::sandbox::launch_chain::LaunchChain::inert();
+        let fs = FilesystemEntitlement {
+            write: vec![home.to_string_lossy().into_owned()],
+            deny: vec!["~/.ssh".to_string()],
+            ..Default::default()
+        };
+
+        check_write_entitlement(&fs, &home.join(".ssh/id_ed25519"), &chain)
+            .expect_err("a ~ deny entry must outrank a grant covering it");
+
+        // Negative control: the surrounding grant still works.
+        check_write_entitlement(&fs, &home.join("notes.md"), &chain)
+            .expect("the write grant itself must still hold");
     }
 
     fn eperm() -> std::io::Error {

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -137,6 +137,12 @@ pub(crate) fn self_protected(
 /// falling back to the un-expanded string) and answered "not entitled".
 /// A `~`-written *deny* entry — the very form `detect_warnings` suggests for
 /// `~/.ssh` — was silently inert here for the same reason.
+///
+/// Windows note: `canonicalize` returns a `\\?\` UNC path and succeeds only
+/// for a path that exists, so a present root canonicalizes to a different
+/// spelling than an absent one. Callers pass an already-canonical path, so a
+/// live grant matches; a grant naming a missing path fails closed — and
+/// `mur agent perm` rejects those up front (`reject_dead_grant`).
 pub(crate) fn under_any(roots: &[String], canonical: &Path) -> bool {
     roots.iter().any(|r| {
         let expanded = crate::sandbox::policy::expand_entitlement_path(r);
@@ -241,21 +247,29 @@ mod tests {
 
     /// Same expansion, deny side. `detect_warnings` tells users to deny
     /// `~/.ssh`; before this helper that entry was inert at the tool gate.
+    /// Every path here sits under a probe dir that does NOT exist, grant and
+    /// deny alike. That is not tidiness: on Windows `canonicalize` succeeds
+    /// only for a real path and returns a `\\?\` UNC prefix, so an earlier
+    /// version of this test that mixed a real root (UNC) with an absent one
+    /// (verbatim) compared two spellings of the same place — it passed on
+    /// Unix and failed on Windows CI. Keeping both sides absent makes the
+    /// assertion turn on the tilde expansion, which is what it is about.
     #[test]
     fn tilde_deny_is_expanded_too() {
         let home = dirs::home_dir().expect("home dir");
         let chain = crate::sandbox::launch_chain::LaunchChain::inert();
         let fs = FilesystemEntitlement {
-            write: vec![home.to_string_lossy().into_owned()],
-            deny: vec!["~/.ssh".to_string()],
+            write: vec!["~/mur-deny-probe".to_string()],
+            deny: vec!["~/mur-deny-probe/keys".to_string()],
             ..Default::default()
         };
 
-        check_write_entitlement(&fs, &home.join(".ssh/id_ed25519"), &chain)
-            .expect_err("a ~ deny entry must outrank a grant covering it");
+        check_write_entitlement(&fs, &home.join("mur-deny-probe/keys/id_ed25519"), &chain)
+            .expect_err("a ~ deny entry must outrank a ~ grant covering it");
 
-        // Negative control: the surrounding grant still works.
-        check_write_entitlement(&fs, &home.join("notes.md"), &chain)
+        // Negative control: the surrounding grant still works, so the refusal
+        // above is the deny entry and not a grant that never matched.
+        check_write_entitlement(&fs, &home.join("mur-deny-probe/notes.md"), &chain)
             .expect("the write grant itself must still hold");
     }
 

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -5,7 +5,7 @@
 //! kernel denial, and so file access is visible to per-tool policy instead
 //! of hiding inside `bash`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use mur_common::agent::FilesystemEntitlement;
 
@@ -65,19 +65,15 @@ impl ReadFileTool {
                 canonical.display()
             )));
         }
-        let under = |roots: &[String]| {
-            roots.iter().any(|r| {
-                let root = std::fs::canonicalize(r).unwrap_or_else(|_| PathBuf::from(r));
-                canonical.starts_with(&root)
-            })
-        };
-        if under(&self.fs.deny) {
+        if crate::tools::fs_policy::under_any(&self.fs.deny, canonical) {
             return Err(ToolError::Execution(format!(
                 "path denied by entitlement: {}",
                 canonical.display()
             )));
         }
-        if under(&self.fs.read) || under(&self.fs.write) {
+        if crate::tools::fs_policy::under_any(&self.fs.read, canonical)
+            || crate::tools::fs_policy::under_any(&self.fs.write, canonical)
+        {
             return Ok(());
         }
         Err(ToolError::Execution(format!(
@@ -159,6 +155,7 @@ Relative paths resolve against the shared session working directory (the same ba
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn fs_ent(read: &[&str], write: &[&str], deny: &[&str]) -> FilesystemEntitlement {
         FilesystemEntitlement {

--- a/mur-agent-runtime/src/voice/tts.rs
+++ b/mur-agent-runtime/src/voice/tts.rs
@@ -85,10 +85,11 @@ impl KokoroTts {
             style_bytes.len(),
         );
 
-        let floats: Vec<f32> = style_bytes
-            .chunks_exact(4)
-            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-            .collect();
+        // `as_chunks` over `chunks_exact`: the length is already pinned by the
+        // `ensure!` above, and fixed-size chunks hand `from_le_bytes` its
+        // `[u8; 4]` directly instead of re-indexing four times.
+        let (quads, _rest) = style_bytes.as_chunks::<4>();
+        let floats: Vec<f32> = quads.iter().copied().map(f32::from_le_bytes).collect();
         let mut style = Vec::with_capacity(N_VOICES);
         for v in 0..N_VOICES {
             let mut rows = Vec::with_capacity(STYLE_ROWS);

--- a/mur-agent-runtime/src/voice/tts.rs
+++ b/mur-agent-runtime/src/voice/tts.rs
@@ -325,10 +325,11 @@ mod tests {
         }
         // Replicate the parsing logic from KokoroTts::new
         let mut style_matrix = [[0f32; 256]; 5];
-        for (i, chunk) in blob.chunks_exact(4).enumerate() {
+        let (quads, _rest) = blob.as_chunks::<4>();
+        for (i, chunk) in quads.iter().enumerate() {
             let row = i / 256;
             let col = i % 256;
-            style_matrix[row][col] = f32::from_le_bytes(chunk.try_into().unwrap());
+            style_matrix[row][col] = f32::from_le_bytes(*chunk);
         }
         for (row, row_vals) in style_matrix.iter().enumerate() {
             for (col, val) in row_vals.iter().enumerate() {

--- a/mur-core/tests/skill_evolve_e2e.rs
+++ b/mur-core/tests/skill_evolve_e2e.rs
@@ -92,9 +92,8 @@ async fn evolve_writes_new_version_and_log_entry() {
     // 3. Scripted LLM: diagnosis then optimized YAML.
     let responses = vec![
         r#"[{"dimension":"Tool","severity":0.9,"finding":"wrong.tool not found","suggested_fix":"replace wrong.tool with correct.tool","evidence":["t1"]}]"#.to_string(),
-        format!(
-            "name: broken-skill\nversion: 0.1.1\npublisher: human:test\ndescription: test skill\ncategory: context\nhosts:\n  - mur-agent\ncontent:\n  abstract: test\n  context: \"Use correct.tool.\"\nevolution_log:\n  - version: 0.1.1\n    generation: 1\n    source: agent:evolver\n    changes: replace wrong.tool with correct.tool\n    quality_score: 0.0\n    timestamp: 2026-05-25T00:00:00Z\n"
-        ),
+        "name: broken-skill\nversion: 0.1.1\npublisher: human:test\ndescription: test skill\ncategory: context\nhosts:\n  - mur-agent\ncontent:\n  abstract: test\n  context: \"Use correct.tool.\"\nevolution_log:\n  - version: 0.1.1\n    generation: 1\n    source: agent:evolver\n    changes: replace wrong.tool with correct.tool\n    quality_score: 0.0\n    timestamp: 2026-05-25T00:00:00Z\n"
+            .to_string(),
     ];
     let llm = ScriptedChatBackend::new(responses);
 

--- a/mur-core/tests/skill_install_agent_wire.rs
+++ b/mur-core/tests/skill_install_agent_wire.rs
@@ -70,24 +70,38 @@ impl Drop for RuntimeGuard {
     }
 }
 
-fn boot_runtime(home: &std::path::Path, agent: &str, runtime_bin: &str) -> RuntimeGuard {
+fn boot_runtime(
+    home: &std::path::Path,
+    agent: &str,
+    runtime_bin: &str,
+    sock_path: &str,
+) -> RuntimeGuard {
     let child = Command::new(runtime_bin)
         .env("MUR_HOME", home)
         .args(["--profile", agent])
         .spawn()
         .expect("spawn runtime");
-    // Wait for running.lock to be written with valid content. The macOS
-    // SBPL sandbox may kill the runtime mid-startup; a zero-byte lock
-    // file signals the runtime was killed before binding its socket.
+    // Two conditions, both waited for rather than assumed:
+    //
+    //   running.lock non-empty — the runtime came up at all. The macOS SBPL
+    //   sandbox may kill it mid-startup, and a zero-byte lock is that signal.
+    //
+    //   the socket exists — it is actually reachable. This used to be a flat
+    //   `sleep(100ms)` after the lock appeared, which is a bet, not a wait: on
+    //   a loaded CI runner the bind had not happened yet and the test died
+    //   later with `connect …/alice.sock: No such file or directory`, pointing
+    //   at the install path instead of at startup. Waiting on the real
+    //   indicator also returns as soon as it is ready, so the common case is
+    //   faster than the fixed sleep it replaces.
     let lock = home.join("agents").join(agent).join("running.lock");
+    let sock = std::path::Path::new(sock_path);
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut found = false;
     while Instant::now() < deadline {
         if let Ok(meta) = std::fs::metadata(&lock)
             && meta.len() > 0
+            && sock.exists()
         {
-            // Brief settle — let the runtime finish binding.
-            std::thread::sleep(Duration::from_millis(100));
             found = true;
             break;
         }
@@ -95,7 +109,12 @@ fn boot_runtime(home: &std::path::Path, agent: &str, runtime_bin: &str) -> Runti
     }
     assert!(
         found,
-        "runtime did not write valid running.lock within 5s (sandbox may have killed it)"
+        "runtime did not come up within 5s: running.lock non-empty = {}, socket {sock_path} present = {} \
+         (sandbox may have killed it mid-startup)",
+        std::fs::metadata(&lock)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false),
+        sock.exists()
     );
     RuntimeGuard { child }
 }
@@ -132,7 +151,7 @@ content:
     let bob_profile = write_profile(home.path(), "bob", None);
 
     // Boot alice; her runtime serves `skills/get` on the unix socket.
-    let _alice = boot_runtime(home.path(), "alice", runtime_str);
+    let _alice = boot_runtime(home.path(), "alice", runtime_str, &sock_path);
 
     // Install. SAFETY: env mutation isn't thread-safe across parallel tests.
     // This test file must be run with `--test-threads=1`.
@@ -220,7 +239,7 @@ fn wire_install_propagates_handler_error_for_missing_skill() {
     let home = TempDir::new().unwrap();
     let sock_path = home.path().join("eve.sock").to_str().unwrap().to_string();
     write_profile(home.path(), "eve", Some(&sock_path));
-    let _eve = boot_runtime(home.path(), "eve", runtime_str);
+    let _eve = boot_runtime(home.path(), "eve", runtime_str, &sock_path);
 
     unsafe { std::env::set_var("MUR_AGENT_RUNTIME_BIN", runtime_str) };
     let err = cmd_install(

--- a/mur-daemon/src/stt_sink.rs
+++ b/mur-daemon/src/stt_sink.rs
@@ -36,10 +36,8 @@ pub fn transcribe(mur_home: &Path, pcm_f32le: &[u8]) -> SttOutcome {
         return SttOutcome::ModelsMissing;
     };
 
-    let samples: Vec<f32> = pcm_f32le
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-        .collect();
+    let (quads, _rest) = pcm_f32le.as_chunks::<4>();
+    let samples: Vec<f32> = quads.iter().copied().map(f32::from_le_bytes).collect();
     match stt.transcribe(&samples) {
         Ok(t) if !t.is_empty() => SttOutcome::Text(t),
         Ok(_) => SttOutcome::Empty,


### PR DESCRIPTION
## What

The tool-level filesystem gate compared entitlement roots with `std::fs::canonicalize()` alone, while the sandbox builder resolves them through `sandbox::policy::expand_entitlement_path()`. A `~/...` root behaved differently in the two layers: `canonicalize("~/x")` always fails, the gate fell back to the literal string, and `starts_with` could never match.

## Why it matters

Two consequences, both hit in a real agent session:

- **A `~` grant was honored by the kernel and refused by the tool.** The sandbox let the read through; the tool still answered `path not entitled: /Users/…/x (grant it via mur agent perm allow-read)`. Nothing in either message tells the user the two layers disagree, so the grant looks broken rather than half-applied.
- **A `~` deny entry was silently inert at this gate.** `entitlements::detect_warnings` tells users to deny `~/.ssh` — in exactly that form. On Linux this gate is the *only* enforcement point for deny-within-allow, because Landlock cannot express it.

`mur agent perm ...` already tests the expanded path (`reject_dead_grant` → `expand_entitlement_path`), so the CLI accepted a grant that the gate then could not honor.

## Change

Extract the matcher into `fs_policy::under_any()`, expanding each root the way the sandbox does, and route both copies of the old closure (`read_file.rs`, `fs_policy.rs`) through it. This also closes the `read_file keeps its own equivalent check — dedup is a follow-up` TODO in the module header.

Net +73/−17, most of it tests.

## Verification

| Check | Result |
|---|---|
| `cargo test -p mur-agent-runtime --lib` | 548 passed, 0 failed |
| `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` | exit 0 |
| `cargo fmt -p mur-agent-runtime -- --check` | exit 0, empty diff |

Negative control: with `under_any` reverted to the old body, both new tests fail —

```
tilde_grant_is_expanded_like_the_sandbox
  panicked: a ~ grant must cover the path it expands to:
  Execution("path not write-entitled: /Users/david/mur-tilde-grant-probe/photo.jpg …")
tilde_deny_is_expanded_too
```

Each new test carries its own negative control, so a matcher that always returns `true` cannot pass them. The probe dir deliberately does not exist, so `canonicalize` fails on both sides and the assertion turns purely on the expansion — no dependency on the test host's home layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)