### PR TITLE
feat(runtime): let a tool hand the model an image, not a description of one

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -294,10 +294,34 @@ fn rich_messages_to_anthropic(
                 let parts: Vec<serde_json::Value> = results
                     .iter()
                     .map(|r| {
+                        // `content` stays a bare string when there is no image,
+                        // so the overwhelmingly common shape is byte-identical
+                        // to what this adapter always sent — a tool result that
+                        // gained an empty `images` vec must not change the
+                        // request (and must not break the prompt cache).
+                        let content = if r.images.is_empty() {
+                            json!(r.content)
+                        } else {
+                            let mut blocks = vec![json!({
+                                "type": "text",
+                                "text": r.content,
+                            })];
+                            blocks.extend(r.images.iter().map(|img| {
+                                json!({
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": img.media_type,
+                                        "data": img.data,
+                                    },
+                                })
+                            }));
+                            json!(blocks)
+                        };
                         json!({
                             "type": "tool_result",
                             "tool_use_id": r.call_id,
-                            "content": r.content,
+                            "content": content,
                             "is_error": r.is_error,
                         })
                     })
@@ -803,6 +827,7 @@ mod tests {
                     content: "hi\n".into(),
                     is_error: false,
                     status: crate::tools::ToolStatus::Ok,
+                    images: Vec::new(),
                 }],
             },
         ];
@@ -821,6 +846,56 @@ mod tests {
         let result_content = result_msg["content"].as_array().unwrap();
         assert_eq!(result_content[0]["type"], "tool_result");
         assert_eq!(result_content[0]["tool_use_id"], "id1");
+    }
+
+    /// The whole point of the feature: an image on a tool result must reach
+    /// the wire as a real `image` block inside `tool_result.content`, because
+    /// that is the only shape the model can actually see.
+    #[test]
+    fn tool_result_image_becomes_a_wire_image_block() {
+        let msgs = vec![RichMessage::ToolResults {
+            results: vec![ToolResultEntry {
+                call_id: "id1".into(),
+                content: "[image /tmp/car.jpg — image/jpeg, 9 bytes]".into(),
+                is_error: false,
+                status: Default::default(),
+                images: vec![crate::tools::ToolImage {
+                    media_type: "image/jpeg".into(),
+                    data: "QUJD".into(),
+                }],
+            }],
+        }];
+        let (_sys, convo, _) = rich_messages_to_anthropic(&msgs);
+        let content = convo[0]["content"][0]["content"]
+            .as_array()
+            .expect("with an image, tool_result.content must be a block array, not a bare string");
+        assert_eq!(content[0]["type"], "text", "text block leads");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "image/jpeg");
+        assert_eq!(content[1]["source"]["data"], "QUJD");
+    }
+
+    /// Negative control for the test above, and a compatibility guard: with no
+    /// image the request must be byte-identical to what this adapter always
+    /// sent — a bare string, not a one-element block array. A silent change
+    /// here would invalidate every cached prefix in the wild.
+    #[test]
+    fn tool_result_without_images_stays_a_bare_string() {
+        let msgs = vec![RichMessage::ToolResults {
+            results: vec![ToolResultEntry {
+                call_id: "id1".into(),
+                content: "15 degrees".into(),
+                is_error: false,
+                status: Default::default(),
+                images: vec![],
+            }],
+        }];
+        let (_sys, convo, _) = rich_messages_to_anthropic(&msgs);
+        assert_eq!(
+            convo[0]["content"][0]["content"], "15 degrees",
+            "no image must mean no shape change"
+        );
     }
 
     #[test]
@@ -881,6 +956,7 @@ mod tests {
                     content: "ok".into(),
                     is_error: false,
                     status: crate::tools::ToolStatus::Ok,
+                    images: Vec::new(),
                 }],
             },
             RichMessage::Text {

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -85,6 +85,11 @@ pub struct ToolResultEntry {
     pub is_error: bool,
     #[serde(default)]
     pub status: crate::tools::ToolStatus,
+    /// Images this tool call produced. Rendered as real `image` blocks inside
+    /// the provider's `tool_result` where the provider supports it, so an
+    /// agent can look at what its own tool fetched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<crate::tools::ToolImage>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -194,6 +194,15 @@ fn rich_messages_to_openai(msgs: &[RichMessage]) -> Vec<serde_json::Value> {
             }
             RichMessage::ToolResults { results } => {
                 for r in results {
+                    // `r.images` is dropped here, deliberately. The OpenAI
+                    // `role: "tool"` message takes a plain string — the
+                    // multimodal `image_url` block is only valid on a user
+                    // message, so there is no in-protocol place to put a tool's
+                    // image. The tool's text still describes it (`[image …]`),
+                    // which is why the placeholder in `render_mcp_result` and
+                    // `read_file` is text and not an empty string. To give an
+                    // OpenAI-backed agent real vision, send the image as a user
+                    // turn (`RichMessage::ImageText`, handled below) instead.
                     result.push(json!({
                         "role": "tool",
                         "tool_call_id": r.call_id,
@@ -630,6 +639,7 @@ mod tests {
                     content: "hi\n".into(),
                     is_error: false,
                     status: crate::tools::ToolStatus::Ok,
+                    images: Vec::new(),
                 }],
             },
         ];

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1279,6 +1279,7 @@ impl TaskRunner {
                 status: crate::tools::ToolStatus::Denied {
                     detail: format!("unknown tool: {}", call.tool_name),
                 },
+                images: Vec::new(),
             });
         }
 
@@ -1314,6 +1315,7 @@ impl TaskRunner {
                         status: crate::tools::ToolStatus::Denied {
                             detail: format!("Tool `{}` is denied by policy.", call.tool_name),
                         },
+                        images: Vec::new(),
                     });
                 }
                 ToolPolicy::Allow => {
@@ -1334,14 +1336,16 @@ impl TaskRunner {
                             .await;
                     }
                     let t0 = std::time::Instant::now();
-                    let (output, status, is_error) = match tool.execute(call.input.clone()).await {
-                        Ok(out) => (out.text, out.status, false),
-                        Err(e) => (
-                            format!("tool error: {e}"),
-                            crate::tools::ToolStatus::Failed { exit_code: -1 },
-                            true,
-                        ),
-                    };
+                    let (output, status, is_error, images) =
+                        match tool.execute(call.input.clone()).await {
+                            Ok(out) => (out.text, out.status, false, out.images),
+                            Err(e) => (
+                                format!("tool error: {e}"),
+                                crate::tools::ToolStatus::Failed { exit_code: -1 },
+                                true,
+                                Vec::new(),
+                            ),
+                        };
                     if let Some(ref n) = step_notifier {
                         let (out, truncated, full_len) = cap_step_output(&output);
                         let _ = n
@@ -1370,6 +1374,7 @@ impl TaskRunner {
                         content: output,
                         is_error,
                         status,
+                        images,
                     });
                 }
                 ToolPolicy::Ask => {
@@ -1451,12 +1456,13 @@ impl TaskRunner {
                 .await;
         }
         let t0_ask = std::time::Instant::now();
-        let (output, status, is_error) = match tool.execute(call.input.clone()).await {
-            Ok(out) => (out.text, out.status, false),
+        let (output, status, is_error, images) = match tool.execute(call.input.clone()).await {
+            Ok(out) => (out.text, out.status, false, out.images),
             Err(e) => (
                 format!("tool error: {e}"),
                 crate::tools::ToolStatus::Failed { exit_code: -1 },
                 true,
+                Vec::new(),
             ),
         };
         if let Some(ref n) = step_notifier {
@@ -1491,6 +1497,7 @@ impl TaskRunner {
             content: output,
             is_error,
             status,
+            images,
         })
     }
 
@@ -1500,6 +1507,12 @@ impl TaskRunner {
     /// `compress.yaml` `auto.min_tokens`) or B0 rule 8 PII redaction.
     /// Mutates in place; no-op when no chain is wired or every hook returns
     /// `None`. Closes the M7.6 gap where the patch was computed but discarded.
+    ///
+    /// `entry.images` is deliberately untouched: a hook patches the model-facing
+    /// TEXT, and the compress path in particular offloads text by size — an
+    /// image is not counted in that budget and swapping its bytes for a digest
+    /// would leave the model looking at nothing. A hook that must suppress an
+    /// image should deny the tool call, not blank the result.
     async fn apply_post_tool_use(
         &self,
         calls: &[crate::llm::ToolCallResult],
@@ -2037,6 +2050,7 @@ fn sanitize_dangling_tool_uses(
                     content: format!("[stopped: {}]", reason.as_str()),
                     is_error: true,
                     status: crate::tools::ToolStatus::Ok,
+                    images: Vec::new(),
                 })
                 .collect();
             if !missing.is_empty() {
@@ -2318,12 +2332,14 @@ mod tests {
                 content: "this is a large tool output".into(),
                 is_error: false,
                 status: crate::tools::ToolStatus::Ok,
+                images: Vec::new(),
             },
             ToolResultEntry {
                 call_id: "c2".into(),
                 content: "ok".into(),
                 is_error: false,
                 status: crate::tools::ToolStatus::Ok,
+                images: Vec::new(),
             },
         ];
         runner.apply_post_tool_use(&calls, &mut results).await;

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -309,6 +309,7 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
         Ok(ToolOutput {
             text: combined,
             status,
+            images: Vec::new(),
         })
     }
 }

--- a/mur-agent-runtime/src/tools/mcp.rs
+++ b/mur-agent-runtime/src/tools/mcp.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use super::{ToolError, ToolExecutor, ToolOutput};
+use super::{ToolError, ToolExecutor, ToolImage, ToolOutput};
 use crate::llm::ToolDef;
 use crate::mcp::pool::McpPool;
 use crate::protocol::mcp_client::McpClient;
@@ -47,6 +47,34 @@ pub fn render_mcp_result(result: &Value) -> String {
         }
     }
     out.trim_end().to_string()
+}
+
+/// Pull the image blocks out of an MCP `tools/call` result.
+///
+/// MCP image content is `{"type":"image","data":<base64>,"mimeType":…}`;
+/// the Messages API wants `source.media_type`, so the rename happens here and
+/// nowhere else. [`render_mcp_result`] still writes an `[image]` placeholder
+/// into the text for the same block — that is deliberate, and it is what an
+/// adapter without vision tool results shows the model.
+///
+/// Unsupported media types and oversize images are dropped
+/// ([`ToolImage::is_supported`]): a provider rejects the whole turn over one
+/// bad image, so losing the picture beats losing the turn.
+pub fn extract_mcp_images(result: &Value) -> Vec<ToolImage> {
+    let Some(content) = result.get("content").and_then(|c| c.as_array()) else {
+        return Vec::new();
+    };
+    content
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("image"))
+        .filter_map(|b| {
+            Some(ToolImage {
+                media_type: b.get("mimeType").and_then(|m| m.as_str())?.to_string(),
+                data: b.get("data").and_then(|d| d.as_str())?.to_string(),
+            })
+        })
+        .filter(ToolImage::is_supported)
+        .collect()
 }
 
 /// A [`ToolExecutor`] backed by a single MCP tool, dispatched via the shared pool.
@@ -106,9 +134,13 @@ impl ToolExecutor for McpToolExecutor {
             .unwrap_or(false);
         let text = render_mcp_result(&result);
         if is_error {
+            // An error result carries no images: the error path is a String,
+            // and a failed call has nothing to show.
             Err(ToolError::Execution(text))
         } else {
-            Ok(text.into())
+            let mut out: ToolOutput = text.into();
+            out.images = extract_mcp_images(&result);
+            Ok(out)
         }
     }
 }
@@ -145,5 +177,28 @@ mod tests {
     fn render_fallback_json() {
         let r = json!({"notContent": "foo"});
         assert!(!render_mcp_result(&r).is_empty());
+    }
+
+    /// MCP names the field `mimeType`; the Messages API wants `media_type`.
+    /// The rename happens in `extract_mcp_images` and nowhere else, so this
+    /// pins it — and pins that junk media types are dropped rather than sent
+    /// (a provider rejects the entire turn over one bad image).
+    #[test]
+    fn extracts_mcp_images_and_drops_unusable_ones() {
+        let r = json!({"content": [
+            {"type": "text", "text": "here"},
+            {"type": "image", "data": "QUJD", "mimeType": "image/png"},
+            {"type": "image", "data": "QUJD", "mimeType": "image/tiff"},
+            {"type": "image", "data": "QUJD"}
+        ]});
+        let imgs = extract_mcp_images(&r);
+        assert_eq!(imgs.len(), 1, "only the supported, well-formed image");
+        assert_eq!(imgs[0].media_type, "image/png");
+        assert_eq!(imgs[0].data, "QUJD");
+
+        // Negative control: a result with no image block yields nothing,
+        // so the filter above is real and not "always returns one".
+        let text_only = json!({"content": [{"type": "text", "text": "hi"}]});
+        assert!(extract_mcp_images(&text_only).is_empty());
     }
 }

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -50,6 +50,43 @@ pub enum ToolStatus {
 pub struct ToolOutput {
     pub text: String,
     pub status: ToolStatus,
+    /// Images the tool produced, handed to the model as real vision input
+    /// rather than described in prose.
+    ///
+    /// Before this existed a tool could only return text, so an agent that
+    /// fetched a photo had no way to show it to its own model — the runtime
+    /// was the missing link between MCP (whose results already carry image
+    /// content) and the Messages API (whose `tool_result` already accepts
+    /// image blocks). Adapters that cannot express images in a tool result
+    /// drop these and keep `text`; see `llm::openai`.
+    pub images: Vec<ToolImage>,
+}
+
+/// One image carried out of a tool call.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ToolImage {
+    /// e.g. "image/jpeg" — passed through to the provider unchanged.
+    pub media_type: String,
+    /// Base64-encoded bytes, with no `data:` prefix.
+    pub data: String,
+}
+
+/// Media types a vision model will accept. A tool that produces anything
+/// else keeps it as text: handing the provider an unsupported media type
+/// fails the whole turn, which is worse than losing the picture.
+pub const SUPPORTED_IMAGE_MEDIA_TYPES: [&str; 4] =
+    ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Ceiling on a single decoded image, mirroring the provider's own limit.
+/// Base64 inflates by 4/3, so this lands just under the 5 MB wire cap.
+pub const MAX_IMAGE_BYTES: usize = 3_750_000;
+
+impl ToolImage {
+    /// True when this image is small enough and of a type the provider takes.
+    pub fn is_supported(&self) -> bool {
+        SUPPORTED_IMAGE_MEDIA_TYPES.contains(&self.media_type.as_str())
+            && self.data.len() <= MAX_IMAGE_BYTES.div_ceil(3) * 4
+    }
 }
 
 impl From<String> for ToolOutput {
@@ -57,6 +94,7 @@ impl From<String> for ToolOutput {
         ToolOutput {
             text,
             status: ToolStatus::Ok,
+            images: Vec::new(),
         }
     }
 }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -12,6 +12,23 @@ use mur_common::agent::FilesystemEntitlement;
 use crate::llm::ToolDef;
 use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 
+/// The image media type for a path's extension, or `None` for everything else.
+///
+/// Deliberately narrower than the runtime's general extension→MIME map: this
+/// gates what gets handed to a vision model, so it lists only types a provider
+/// accepts. `image/svg+xml` is absent on purpose — it is markup, and reading it
+/// as text is the more useful answer.
+fn image_media_type(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
 /// Hard ceiling on returned bytes so a huge file cannot blow up the turn.
 const MAX_RETURN_BYTES: usize = 512 * 1024;
 
@@ -92,7 +109,8 @@ impl ToolExecutor for ReadFileTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "read_file".into(),
-            description: "Read a UTF-8 text file. Optional 1-indexed `offset`/`limit` select a line window. \
+            description: "Read a UTF-8 text file, or an image you want to LOOK AT. \
+PNG/JPEG/GIF/WebP are returned as real image input you can see — use this rather than describing a picture you have not been shown. Optional 1-indexed `offset`/`limit` select a line window (text only). \
 Relative paths resolve against the shared session working directory (the same base the `bash` tool uses, moved only by passing `bash` an explicit `cwd`); reads are checked against the agent's filesystem entitlements."
                 .into(),
             input_schema: serde_json::json!({
@@ -125,6 +143,37 @@ Relative paths resolve against the shared session working directory (the same ba
                 "read", &canonical, &base, &e,
             ))
         })?;
+        // An image is returned AS an image, not as its bytes decoded into
+        // mojibake. Before this branch existed a vision-capable agent that
+        // fetched a photo could only read it as text and then guess at what
+        // it "saw" — the model has no way to signal that it never got a
+        // picture, so the guess came back with a confidence score attached.
+        if let Some(media_type) = image_media_type(&canonical) {
+            if bytes.len() > crate::tools::MAX_IMAGE_BYTES {
+                return Err(ToolError::Execution(format!(
+                    "image is {} bytes, over the {} byte limit a vision request accepts: {}. \
+                     Resize it before reading, or read it with `bash` if you only need the bytes.",
+                    bytes.len(),
+                    crate::tools::MAX_IMAGE_BYTES,
+                    canonical.display()
+                )));
+            }
+            use base64::Engine as _;
+            return Ok(ToolOutput {
+                text: format!(
+                    "[image {} — {}, {} bytes]",
+                    canonical.display(),
+                    media_type,
+                    bytes.len()
+                ),
+                status: crate::tools::ToolStatus::Ok,
+                images: vec![crate::tools::ToolImage {
+                    media_type: media_type.to_string(),
+                    data: base64::engine::general_purpose::STANDARD.encode(&bytes),
+                }],
+            });
+        }
+
         let text = String::from_utf8_lossy(&bytes);
 
         let offset = input["offset"].as_i64().filter(|v| *v >= 1);
@@ -163,6 +212,52 @@ mod tests {
             write: write.iter().map(|s| s.to_string()).collect(),
             deny: deny.iter().map(|s| s.to_string()).collect(),
         }
+    }
+
+    /// A 1x1 PNG read through the tool must come back as image input, not as
+    /// its bytes lossily decoded into text — the exact failure that made a
+    /// vision-capable agent invent a car model it had never been shown.
+    #[test]
+    fn image_file_returns_image_input_not_mojibake() {
+        use base64::Engine as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let home = std::fs::canonicalize(tmp.path()).unwrap();
+        // Smallest valid PNG header bytes; content does not matter here,
+        // only that the tool routes on the extension and preserves bytes.
+        let png: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+        let path = home.join("shot.png");
+        std::fs::write(&path, png).unwrap();
+
+        let tool = ReadFileTool::new_for_test(
+            crate::tools::fs_policy::SessionCwd::new(home.clone()),
+            fs_ent(&[&home.to_string_lossy()], &[], &[]),
+        );
+        let out = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(tool.execute(serde_json::json!({"path": path.to_str().unwrap()})))
+            .expect("read must succeed");
+
+        assert_eq!(out.images.len(), 1, "the png must arrive as image input");
+        assert_eq!(out.images[0].media_type, "image/png");
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(&out.images[0].data)
+                .unwrap(),
+            png,
+            "bytes must survive the round trip intact"
+        );
+
+        // Negative control: a text file under the same grant still returns
+        // text and carries no images, so the branch above is the extension
+        // routing and not "everything is an image now".
+        let txt = home.join("notes.txt");
+        std::fs::write(&txt, "hello").unwrap();
+        let out = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(tool.execute(serde_json::json!({"path": txt.to_str().unwrap()})))
+            .expect("read must succeed");
+        assert!(out.images.is_empty(), "text file must not produce images");
+        assert_eq!(out.text, "hello");
     }
 
     #[test]


### PR DESCRIPTION
> **Merge #1029 first.** This branch was cut from it, so until #1029 lands the diff above also shows its four commits (tilde expansion + two clippy fixes + a Windows test fix). GitHub drops them from the diff automatically once #1029 is in main — the feature commit itself is `9243ec79` and touches only the eight files listed below.
>
> Base was retargeted from `fix/tilde-entitlement-expansion` to `main` because `ci.yml` filters `pull_request: branches: [main]` — a PR based on any other branch gets no CI at all.

## The gap

A tool could only ever return text (`ToolOutput { text, status }`). So an agent that fetched a photo had no way to show it to its own model:

- `read_file` ran the JPEG bytes through `String::from_utf8_lossy` — the model got mojibake.
- `render_mcp_result` collapsed an MCP image block to the literal string `[image]`.

A model cannot signal that it never received a picture, so it answers anyway. An observed run returned a make, model and year with `confidence: 0.85` for a car it had never been shown. Swapping models doesn't help — it changes whether the guess is honest, not whether the image arrived.

MUR sat between two sides that already supported this:

- **MCP** results carry `{"type":"image","data":"<base64>","mimeType":"…"}`
- **Messages API** accepts image blocks inside `tool_result.content` ([docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls))

Only the runtime in the middle dropped them.

## Change

| Seam | What it does now |
|---|---|
| `ToolOutput.images` / `ToolResultEntry.images` | Carry `ToolImage { media_type, data }` from tool to adapter |
| `read_file` | Returns PNG/JPEG/GIF/WebP as image input; **says so in its description** |
| `extract_mcp_images` | `mimeType` → `media_type` rename in exactly one place |
| `llm::anthropic` | Emits text block + image blocks in `tool_result.content` |
| `llm::openai` | Documents the drop (no in-protocol slot on `role: "tool"`) |
| `apply_post_tool_use` | Leaves `images` alone — documented why |

Three deliberate calls:

1. **No image → `content` stays a bare string**, byte-identical to what the adapter always sent. A one-element block array would have invalidated every cached prefix in the wild. Pinned by `tool_result_without_images_stays_a_bare_string`.
2. **Unsupported media types and oversize images are dropped, not sent.** A provider rejects the entire turn over one bad image — losing the picture beats losing the turn.
3. **`read_file`'s description advertises the capability.** A tool that can do something the model isn't told about is a tool the model won't use.

## Verification

| Check | Result |
|---|---|
| `cargo test -p mur-agent-runtime --lib` | 552 passed, 0 failed (548 before + 4 new) |
| `cargo clippy -p mur-agent-runtime --all-targets --no-deps -- -D warnings` | exit 0 |
| `cargo fmt -p mur-agent-runtime -- --check` | exit 0, empty diff |

**Negative control** — reverting each fix and re-running its test, one filter per run:

```
ANTHROPIC_NEG=101   tool_result_image_becomes_a_wire_image_block ... FAILED
READFILE_NEG=101    image_file_returns_image_input_not_mojibake ... FAILED
```

(An earlier attempt passed both filters to one `cargo test` and got exit 1 from *argument parsing*, not a test failure — redone properly above.)

Each new test carries its own negative control, so an implementation that always returns an image cannot pass them. The `read_file` test asserts the bytes survive base64 round-trip intact, and that a text file under the same grant still returns text with no images.

## Not covered

- **OpenAI-backed agents still can't see tool images** — the protocol has no slot for it. They keep the `[image …]` text; real vision goes through the user turn.
- **Ollama** unchanged.
- No size/count budget across *multiple* images in one turn — each image is individually capped at `MAX_IMAGE_BYTES`, but ten of them still go out. Worth revisiting if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
