### PR TITLE
chore(release): bump workspace version to 2.71.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6642,7 +6642,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6659,7 +6659,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6671,7 +6671,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.70.1"
+version = "2.71.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.70.1"
+version = "2.71.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases `v2.71.0`. Merging this PR **is** the release — `tag.yml` tags the
merge commit and dispatches `release.yml`, which publishes to crates.io
(irreversible; yank-only). There is no gate after this one.

## What ships

**`murmur /login`** (#1031) — re-authenticate an expired provider OAuth token
without leaving the TUI. Repair escalates and stops at the cheapest rung that
works: re-read the credential store → ask the owner CLI to refresh (no browser,
no terminal handover) → only then a real login. murmur never holds a token;
health comes from the owner CLI's own status output and "did a refresh happen"
from credential-store metadata.

Also on this range: `#1030` (a tool can hand the model an image rather than a
description of one), `#1029` (`~` expansion in tool-gate entitlement roots).

## Version hygiene

Both lock files moved with `Cargo.toml` — the root one and
`mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace
crate's version and breaks the Hub's release build when it disagrees. Verified:
12 entries at 2.71.0 in the root lock, 6 in the Hub's, and zero `2.70.1`
remnants in either.

## Known unverified behaviour in the shipped `/login`

Four things no test reaches, disclosed on #1031 and unchanged by this bump:
`/login` as the first command of a session, Ctrl-C during the child process, a
wedged owner CLI producing the timeout wording rather than "not installed", and
any terminal handover on Windows (CI proves it compiles; nothing proves how it
behaves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)