### PR TITLE
fix(schedule): let workflow skills be scheduled, and stop lying about when they fire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6513,6 +6513,7 @@ dependencies = [
  "hex",
  "hostname",
  "http-body-util",
+ "iana-time-zone",
  "keyring",
  "lancedb",
  "libc",

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -44,6 +44,7 @@ reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
+iana-time-zone = "0.1"  # real local tz for schedule labels (launchd/cron fire in local time)
 uuid = { workspace = true }
 anyhow = { workspace = true }
 toml = "0.8"

--- a/mur-core/src/cmd/system_schedule.rs
+++ b/mur-core/src/cmd/system_schedule.rs
@@ -12,6 +12,27 @@ fn mur_binary() -> String {
         .unwrap_or_else(|_| "mur".to_string())
 }
 
+/// PATH to give scheduled runs.
+///
+/// launchd and cron start with a bare `/usr/bin:/bin:/usr/sbin:/sbin`, so a
+/// workflow step calling `mysql`, `gh`, `node` — anything from Homebrew, mise,
+/// or a language version manager — fails at fire time while working perfectly
+/// when the user runs it by hand. Freeze the PATH from the shell that set the
+/// schedule: that is the environment the user just proved the steps work in.
+fn scheduler_path() -> String {
+    std::env::var("PATH")
+        .ok()
+        .filter(|p| !p.is_empty())
+        .unwrap_or_else(|| "/usr/bin:/bin:/usr/sbin:/sbin".to_string())
+}
+
+/// Minimal XML escaping for values interpolated into the plist.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Install a system schedule for a workflow.
 pub fn install(workflow_name: &str, cron_expr: &str) -> Result<()> {
     if cfg!(target_os = "macos") {
@@ -94,6 +115,7 @@ fn install_launchd(workflow_name: &str, cron_expr: &str) -> Result<()> {
     let calendar = cron_to_calendar_interval(cron_expr);
     let log_dir = dirs::home_dir().unwrap_or_default().join(".mur/logs");
     std::fs::create_dir_all(&log_dir)?;
+    let path_env = xml_escape(&scheduler_path());
 
     let plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -108,6 +130,11 @@ fn install_launchd(workflow_name: &str, cron_expr: &str) -> Result<()> {
     <string>run</string>
     <string>{workflow_name}</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>{path_env}</string>
+  </dict>
   <key>StartCalendarInterval</key>
 {calendar}
   <key>StandardOutPath</key>
@@ -121,6 +148,7 @@ fn install_launchd(workflow_name: &str, cron_expr: &str) -> Result<()> {
         label = label,
         mur = mur,
         workflow_name = workflow_name,
+        path_env = path_env,
         calendar = calendar,
         log_dir = log_dir.display(),
     );
@@ -194,9 +222,18 @@ pub struct SystemSchedule {
 fn install_crontab(workflow_name: &str, cron_expr: &str) -> Result<()> {
     let mur = mur_binary();
     let tag = format!("{}{}", CRON_TAG_PREFIX, workflow_name);
+    // cron runs the command through /bin/sh with a bare PATH; prefix the real
+    // one so steps can reach Homebrew/mise binaries (see `scheduler_path`).
+    // Quoted — a PATH entry containing a space would otherwise split the
+    // command and cron would try to exec the wrong token.
     let entry = format!(
-        "{} {} run {} >> ~/.mur/logs/schedule-{}.log 2>&1 {}",
-        cron_expr, mur, workflow_name, workflow_name, tag
+        "{} PATH=\"{}\" {} run {} >> ~/.mur/logs/schedule-{}.log 2>&1 {}",
+        cron_expr,
+        scheduler_path(),
+        mur,
+        workflow_name,
+        workflow_name,
+        tag
     );
 
     // Read existing crontab
@@ -354,6 +391,24 @@ fn list_crontab() -> Vec<(String, String)> {
 #[cfg(test)]
 mod p2_tests {
     use super::*;
+
+    #[test]
+    fn scheduler_path_prefers_the_installing_shells_path() {
+        // SAFETY: nextest runs each test in its own process.
+        unsafe { std::env::set_var("PATH", "/opt/homebrew/bin:/usr/bin:/bin") };
+        assert_eq!(scheduler_path(), "/opt/homebrew/bin:/usr/bin:/bin");
+
+        // An empty PATH must not produce an empty PATH= in the plist/crontab —
+        // that would leave the scheduled run unable to find anything at all.
+        unsafe { std::env::set_var("PATH", "") };
+        assert_eq!(scheduler_path(), "/usr/bin:/bin:/usr/sbin:/sbin");
+    }
+
+    #[test]
+    fn xml_escape_protects_the_plist() {
+        assert_eq!(xml_escape("/a&b/bin:/c<d>"), "/a&amp;b/bin:/c&lt;d&gt;");
+        assert_eq!(xml_escape("/usr/bin:/bin"), "/usr/bin:/bin");
+    }
 
     #[test]
     fn calendar_interval_round_trips_cron() {

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -4,6 +4,7 @@ use mur_common::pattern::*;
 use std::io::{self, Write};
 
 use crate::evolve;
+use crate::retrieve::skill_candidates::LoadedSkill;
 use crate::store::workflow_yaml::WorkflowYamlStore;
 
 /// Confirm before executing a workflow resolved by fuzzy match (semantic / keyword
@@ -42,6 +43,67 @@ fn confirm_fuzzy_run(
         eprintln!("Aborted.");
     }
     ok
+}
+
+/// Exact-name lookup for a workflow skill that can run unattended: `category:
+/// Workflow` with a `content.procedure` to execute.
+///
+/// `workflow run` and `workflow schedule set` share this so a name that can be
+/// scheduled is a name that will actually run. Deliberately exact-match only —
+/// the fuzzy paths in `cmd_workflow_run` need a human to confirm, which a cron
+/// or launchd fire has no way to obtain.
+fn find_workflow_skill(mur_dir: &std::path::Path, name: &str) -> Option<LoadedSkill> {
+    crate::retrieve::skill_candidates::load_skill_candidates(&mur_dir.join("skills"), mur_dir)
+        .ok()?
+        .into_iter()
+        .find(|s| {
+            s.manifest.name == name
+                && s.manifest.category == mur_common::skill::types::Category::Workflow
+                && s.manifest.content.procedure.is_some()
+        })
+}
+
+/// Execute a workflow skill's DAG procedure.
+async fn run_workflow_skill(
+    mur_dir: &std::path::Path,
+    skill: &LoadedSkill,
+    yes: bool,
+    channel: Option<String>,
+    channel_new: bool,
+) -> Result<()> {
+    let Some(procedure) = &skill.manifest.content.procedure else {
+        eprintln!(
+            "Skill `{}` is category:Workflow but has no `content.procedure`",
+            skill.manifest.name
+        );
+        return Ok(());
+    };
+    // Resolve channel_id: --channel-new creates a fresh channel,
+    // --channel uses an existing one.
+    let channel_id = if channel_new {
+        let svc = mur_channel::ChannelService::open(mur_dir)?;
+        let ch = svc.create_for_workflow(&skill.manifest.name)?;
+        eprintln!("# channel: {}", ch.id);
+        Some(ch.id)
+    } else {
+        channel
+    };
+    let opts = crate::executor::dag::DagExecOptions {
+        yes,
+        device_id: "cli".to_string(),
+        trigger: "manual",
+        channel_id,
+        run_id: format!("run-{}", uuid::Uuid::now_v7()),
+        run_kind: Some(crate::run_status::RunKind::Workflow),
+        run_label: skill.manifest.name.clone(),
+        ..Default::default()
+    };
+    let output =
+        crate::executor::dag::execute_dag(mur_dir, &skill.manifest.name, procedure, &opts).await?;
+    if output.exit_code != 0 {
+        std::process::exit(output.exit_code);
+    }
+    Ok(())
 }
 
 /// Run a workflow — output as executable prompt for AI consumption.
@@ -91,6 +153,19 @@ pub(crate) async fn cmd_workflow_run(
             if output.exit_code != 0 {
                 std::process::exit(output.exit_code);
             }
+        }
+        return Ok(());
+    }
+
+    // Exact workflow-skill match, BEFORE the fuzzy searches below. A scheduled
+    // run has no TTY, so if semantic search claimed this name first the fuzzy
+    // confirm would refuse it and the fire would be a silent no-op.
+    let mur_dir = crate::paths::mur_root(None);
+    if let Some(skill) = find_workflow_skill(&mur_dir, query) {
+        if prompt {
+            eprintln!("# {} — {}", skill.manifest.name, skill.manifest.description);
+        } else {
+            run_workflow_skill(&mur_dir, &skill, yes, channel, channel_new).await?;
         }
         return Ok(());
     }
@@ -154,81 +229,29 @@ pub(crate) async fn cmd_workflow_run(
             }
         }
         None => {
-            // Fallback: scan skills directory for a category:Workflow skill.
-            // (This is a new search path; failure here prints the old
-            // "available workflows" message.)
-            let mur_dir = crate::paths::mur_root(None);
-            let skills_dir = mur_dir.join("skills");
-            if skills_dir.exists() {
-                let candidates =
-                    crate::retrieve::skill_candidates::load_skill_candidates(&skills_dir, &mur_dir)
-                        .unwrap_or_default();
-                if let Some(matched) = candidates.iter().find(|s| {
-                    s.manifest.name == query
-                        || s.manifest.name.contains(query)
-                        || query.contains(&s.manifest.name)
-                }) {
-                    if prompt {
-                        eprintln!(
-                            "# {} — {}",
-                            matched.manifest.name, matched.manifest.description
-                        );
-                        return Ok(());
-                    }
-                    // Confirm before executing a non-exact (fuzzy) skill match.
-                    if matched.manifest.name != query
-                        && !confirm_fuzzy_run(
-                            query,
-                            &matched.manifest.name,
-                            "skill match",
-                            None,
-                            yes,
-                        )
-                    {
-                        return Ok(());
-                    }
-                    // Only execute Workflow-category skills.
-                    if matched.manifest.category == mur_common::skill::types::Category::Workflow {
-                        if let Some(procedure) = &matched.manifest.content.procedure {
-                            // Resolve channel_id: --channel-new creates a fresh channel,
-                            // --channel uses an existing one.
-                            let channel_id = if channel_new {
-                                let svc = mur_channel::ChannelService::open(&mur_dir)?;
-                                let ch = svc.create_for_workflow(&matched.manifest.name)?;
-                                eprintln!("# channel: {}", ch.id);
-                                Some(ch.id)
-                            } else {
-                                channel
-                            };
-                            let opts = crate::executor::dag::DagExecOptions {
-                                yes,
-                                device_id: "cli".to_string(),
-                                trigger: "manual",
-                                channel_id,
-                                run_id: format!("run-{}", uuid::Uuid::now_v7()),
-                                run_kind: Some(crate::run_status::RunKind::Workflow),
-                                run_label: matched.manifest.name.clone(),
-                                ..Default::default()
-                            };
-                            let output = crate::executor::dag::execute_dag(
-                                &mur_dir,
-                                &matched.manifest.name,
-                                procedure,
-                                &opts,
-                            )
-                            .await?;
-                            if output.exit_code != 0 {
-                                std::process::exit(output.exit_code);
-                            }
-                        } else {
-                            eprintln!(
-                                "Skill `{}` is category:Workflow but has no `content.procedure`",
-                                matched.manifest.name
-                            );
-                        }
-                        return Ok(());
-                    }
+            // Fuzzy fallback: a category:Workflow skill whose name overlaps the
+            // query. Exact matches already returned above.
+            let candidates = crate::retrieve::skill_candidates::load_skill_candidates(
+                &mur_dir.join("skills"),
+                &mur_dir,
+            )
+            .unwrap_or_default();
+            if let Some(matched) = candidates.iter().find(|s| {
+                s.manifest.category == mur_common::skill::types::Category::Workflow
+                    && (s.manifest.name.contains(query) || query.contains(&s.manifest.name))
+            }) {
+                if prompt {
+                    eprintln!(
+                        "# {} — {}",
+                        matched.manifest.name, matched.manifest.description
+                    );
+                    return Ok(());
                 }
+                if !confirm_fuzzy_run(query, &matched.manifest.name, "skill match", None, yes) {
+                    return Ok(());
+                }
+                run_workflow_skill(&mur_dir, matched, yes, channel, channel_new).await?;
+                return Ok(());
             }
 
             // No skill match either.
@@ -932,8 +955,16 @@ pub(crate) fn cmd_schedule_list() -> Result<()> {
 
     if !active.is_empty() {
         println!("🔄 Active schedules:\n");
+        // Show the zone the schedule will ACTUALLY fire in, not the stored
+        // label: launchd and crontab both read the cron expression as local
+        // time regardless of what `timezone` says. Entries written before this
+        // was fixed all carry a hardcoded "UTC" that never applied.
+        let local_tz = iana_time_zone::get_timezone().unwrap_or_else(|_| "local".to_string());
         for s in &active {
-            println!("  {} — `{}` ({})", s.workflow, s.cron, s.timezone);
+            println!("  {} — `{}` ({})", s.workflow, s.cron, local_tz);
+            if s.timezone != local_tz {
+                println!("     stored timezone: {} (not used locally)", s.timezone);
+            }
             if !s.user_id.is_empty() {
                 println!("     user: {}", s.user_id);
             }
@@ -988,29 +1019,45 @@ pub(crate) fn cmd_schedule_set(name: &str, cron: &str) -> Result<()> {
         );
     }
 
-    // Verify workflow exists
+    // Verify the name resolves to something the scheduler can actually fire.
+    // A schedule runs `mur run <name>`, which resolves flat workflows AND
+    // exact-named workflow skills — so both are valid here.
     let store = WorkflowYamlStore::default_store()?;
-    let _ = store
-        .get(name)
-        .with_context(|| format!("Workflow '{}' not found", name))?;
+    if store.get(name).is_err()
+        && find_workflow_skill(&crate::paths::mur_root(None), name).is_none()
+    {
+        anyhow::bail!(
+            "Workflow '{}' not found — no ~/.mur/workflows/{}.yaml, and no `category: Workflow` \
+             skill of that name with a `content.procedure`.",
+            name,
+            name
+        );
+    }
 
     // Determine executor: Commander if running, otherwise system cron
     let executor = mur_common::schedule_claim::auto_detect_executor();
 
     let mut schedules = load_schedules()?;
 
+    // Both executors interpret the cron expression in LOCAL time: launchd's
+    // StartCalendarInterval and crontab both do. Record the real IANA zone —
+    // labelling every schedule "UTC" told users their `20 23 * * *` fired at
+    // 23:20 UTC when it actually fires at 23:20 local, an 8-hour lie in +08:00.
+    let timezone = iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string());
+
     // Update existing or add new
     if let Some(existing) = schedules.iter_mut().find(|s| s.workflow == name) {
         existing.cron = cron.to_string();
         existing.enabled = true;
         existing.executor = executor.clone();
+        existing.timezone = timezone;
     } else {
         schedules.push(Schedule {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: String::new(),
             workflow: name.to_string(),
             cron: cron.to_string(),
-            timezone: "UTC".to_string(),
+            timezone,
             enabled: true,
             notify: ScheduleNotify::default(),
             variables: Default::default(),
@@ -1143,6 +1190,102 @@ pub fn create_draft_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The smallest flat workflow YAML that loads. Everything else in
+    /// `KnowledgeBase` carries a serde default — including `schema`, which
+    /// fills in as 3. Pinned as a test because hand-writing this file is
+    /// otherwise a guessing game against a `#[serde(flatten)]` struct.
+    #[test]
+    fn minimal_flat_workflow_yaml_loads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("workflows");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("probe.yaml"),
+            "name: probe\n\
+             description: two shell steps\n\
+             content: what this workflow is for\n\
+             steps:\n\
+             - order: 1\n  description: first\n  command: echo one\n\
+             - order: 2\n  description: second\n  command: echo two\n",
+        )
+        .unwrap();
+
+        let store = WorkflowYamlStore::new(dir).unwrap();
+        let w = store.get("probe").unwrap();
+        assert_eq!(w.steps.len(), 2);
+        assert_eq!(w.base.schema, 3, "schema defaults, it is not required");
+        assert_eq!(w.steps[0].command.as_deref(), Some("echo one"));
+    }
+
+    /// Negative control: what the user actually sees when a required field is
+    /// missing. `#[serde(flatten)]` is known to degrade serde's missing-field
+    /// messages, so assert the message still names the field.
+    #[test]
+    fn missing_required_field_names_the_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("workflows");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("probe.yaml"),
+            "name: probe\ndescription: d\nsteps:\n- order: 1\n  description: s\n",
+        )
+        .unwrap();
+
+        let err = format!(
+            "{:#}",
+            WorkflowYamlStore::new(dir)
+                .unwrap()
+                .get("probe")
+                .unwrap_err()
+        );
+        assert!(
+            err.contains("content"),
+            "error should name the missing field, got: {err}"
+        );
+    }
+
+    /// Write a skill.yaml under `<home>/skills/<name>/`.
+    fn write_skill(home: &std::path::Path, name: &str, category: &str, procedure: bool) {
+        let dir = home.join("skills").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let proc_block = if procedure {
+            "\n  procedure:\n    steps:\n    - description: echo hi\n      id: s1\n      command: echo hi\n"
+        } else {
+            "\n"
+        };
+        std::fs::write(
+            dir.join("skill.yaml"),
+            format!(
+                "name: {name}\nversion: 1.0.0\npublisher: human:test\n\
+                 description: test skill\ncategory: {category}\nprovenance: human\n\
+                 content:\n  abstract: t{proc_block}"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn find_workflow_skill_matches_exact_runnable_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        write_skill(home, "nightly-scan", "workflow", true);
+        write_skill(home, "no-procedure", "workflow", false);
+        write_skill(home, "not-a-workflow", "context", true);
+
+        // A runnable workflow skill resolves.
+        assert!(find_workflow_skill(home, "nightly-scan").is_some());
+        // category:Workflow without a procedure has nothing to execute.
+        assert!(find_workflow_skill(home, "no-procedure").is_none());
+        // Other categories are not workflows.
+        assert!(find_workflow_skill(home, "not-a-workflow").is_none());
+        // Exact only — a schedule fires without a TTY, and a fuzzy match
+        // would be refused at run time, making the schedule a silent no-op.
+        assert!(find_workflow_skill(home, "nightly").is_none());
+        assert!(find_workflow_skill(home, "nightly-scan-extra").is_none());
+        // Missing skills dir is not an error.
+        assert!(find_workflow_skill(tmp.path().join("nope").as_path(), "x").is_none());
+    }
 
     #[test]
     fn create_draft_workflow_persists_draft() {

--- a/mur-core/src/skills/mur_workflow_author.yaml
+++ b/mur-core/src/skills/mur_workflow_author.yaml
@@ -32,6 +32,29 @@ content:
       workflow or trigger a workflow skill by name.
     - `mur workflow list` — enumerate saved flat workflows.
 
+    ## Flat workflow schema
+    `mur workflow new` WRITES every field of the struct, so a generated
+    file looks like it has a dozen required keys. It does not. Only these
+    are required — everything else (`schema`, which fills in as 3,
+    `tier`, `importance`, `tags`, `evidence`, timestamps, …) has a
+    default:
+    ```
+    name: probe                     # must match the filename stem
+    description: two shell steps
+    content: what this workflow is for
+    steps:
+      - order: 1                    # 1-based; order + description required
+        description: first
+        command: echo one           # optional: omit for a prompt-only step
+      - order: 2
+        description: second
+        command: echo two
+    ```
+    Save as `~/.mur/workflows/<name>.yaml`. A missing required field is
+    reported by name (`missing field \`content\``), so read the error
+    rather than guessing — and note `steps` uses `order` + `description`,
+    NOT the DAG procedure's `id` + `kind`.
+
     ## DAG procedure schema
     A workflow-skill DAG procedure is expressed as:
     ```
@@ -51,11 +74,17 @@ content:
     agent over A2A (see the delegation companion doc).
 
     ## Schedule
-    Flat workflows and workflow skills can both be scheduled:
-    - `mur workflow schedule <name> --cron "<expr>"` — recurring runs.
-    - `mur workflow schedule <name> --at <time>` — one-shot run.
-    Scheduled runs execute non-interactively; any approval node in a
-    scheduled workflow skill still pauses and waits, so scheduling a
+    Flat workflows and workflow skills can both be scheduled, by EXACT
+    name. Cron only — there is no one-shot `--at`:
+    - `mur workflow schedule set <name> "<cron expr>"` — recurring runs.
+    - `mur workflow schedule {list | remove <name> | enable <name> |
+      disable <name>}`.
+    A schedule fires `mur run <name>`, which resolves an exact flat
+    workflow or an exact `category: Workflow` skill. A near-miss name
+    resolves by fuzzy search instead, and fuzzy matches are refused
+    without a TTY — so a typo in a schedule is a silent no-op, not an
+    error. Scheduled runs execute non-interactively; any approval node in
+    a scheduled workflow skill still pauses and waits, so scheduling a
     workflow with unresolved HITL gates just defers the wait, not the
     approval itself.
 


### PR DESCRIPTION
Three defects on the schedule path, all the same shape: **two interfaces disagreeing about one fact.**

## 1. `schedule set` rejected workflow skills

`cmd_schedule_set` verified the name against `WorkflowYamlStore` only:

```rust
let _ = store.get(name).with_context(|| format!("Workflow '{}' not found", name))?;
```

But a schedule installs `mur run <name>` (`system_schedule.rs` — crontab entry and plist `ProgramArguments`), and `cmd_workflow_run` resolves `category: Workflow` skills fine. The same name behaved two different ways:

```
$ mur workflow schedule set malware-file-scan-quarantine "0 3 * * *"
Error: Workflow 'malware-file-scan-quarantine' not found

$ mur workflow run malware-file-scan-quarantine --prompt
# malware-file-scan-quarantine — …
```

Extracted `find_workflow_skill()` and shared it, so a name that can be scheduled is a name that will run.

**Second, quieter defect on the same path:** `cmd_workflow_run` matched skills only *after* semantic and keyword search. A scheduled fire has no TTY, so a name claimed by semantic search hit `confirm_fuzzy_run`, which refuses non-interactively — `exit 0`, nothing run, no error in the log. Exact skill lookup now precedes both fuzzy searches. The lookup is deliberately exact-only: a cron fire has no way to answer a confirm prompt.

## 2. `(UTC)` was a hardcoded lie

`timezone: "UTC".to_string()` on every schedule, and `schedule list` printed it. Grep found exactly two consumers — sync upload and that display line. **No execution path reads the field.** launchd and crontab both interpret the expression in local time.

Verified with a launchd probe rather than trusting the docs:

```
plist says: Hour=23 Minute=50   (local wall clock)
FIRED local=2026-08-25 23:50:03 CST
FIRED utc  =2026-08-25 15:50:03
```

`man 5 crontab` agrees structurally: its BUGS section describes DST shifts "at 2AM local time" — UTC has no DST.

The label caused real damage: a user read "(UTC)", shifted a working `20 23 * * *` by their +08:00 offset, and moved a schedule due in six minutes to the next afternoon. Now records the real IANA zone and displays the zone that will actually fire; entries still carrying the old label get one extra line (`stored timezone: UTC (not used locally)`).

## 3. Scheduled runs got a bare PATH

The same probe printed what launchd actually hands the job:

```
PATH=/usr/bin:/bin:/usr/sbin:/sbin
```

No `/opt/homebrew/bin` — so a step calling `mysql`, `gh`, or `node` fails at fire time while working perfectly by hand. The plist now carries `EnvironmentVariables.PATH` and the crontab entry a quoted `PATH="…"`, frozen from the shell that set the schedule: the environment the user just proved the steps work in. Quoted because a real PATH contains `Application Support`; unquoted, cron would split the command.

## Docs

`mur_workflow_author` documented `mur workflow schedule <name> --cron "<expr>"` and `--at <time>`. Neither flag exists — the CLI is `schedule set <name> "<cron>"`, and there is no one-shot scheduling at all.

It also left users to reverse-engineer the flat-workflow schema from `mur workflow new` output. That output serializes every `KnowledgeBase` field, so it looks like a dozen required keys; in fact only `name`/`description`/`content` and each step's `order`/`description` are required (`schema` defaults to 3). The minimal file is now documented and pinned by a test.

## Verification

- 41 workflow/schedule tests pass; `clippy --lib --tests` clean.
- New tests: exact-vs-fuzzy skill lookup (4 negative cases), PATH fallback, XML escaping, minimal flat-workflow YAML, and that a missing required field is still named in the error.
- End-to-end in an isolated `HOME`: skill schedules successfully, a nonexistent name still fails with a message naming both search paths, `timezone: Asia/Taipei` on disk, plist carries the full PATH. Probe job unloaded and test home removed; real `~/Library/LaunchAgents` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
