### PR TITLE
fix(skill): repair three defects on the skill install/remove path

### DIFF
--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -89,7 +89,9 @@ pub fn skill_show(query: String) -> Result<String, String> {
 
 #[tauri::command]
 pub fn skill_add(source: String) -> Result<(), String> {
-    agent_admin::skill::add(&agent_name(), &source).map_err(err)
+    agent_admin::skill::add(&agent_name(), &source)
+        .map(|_id| ())
+        .map_err(err)
 }
 
 #[tauri::command]

--- a/mur-core/src/agent_admin/skill.rs
+++ b/mur-core/src/agent_admin/skill.rs
@@ -7,7 +7,10 @@ use crate::cmd::agent;
 
 // ─── mutators ─────────────────────────────────────────────────────
 
-pub fn add(name: &str, source: &str) -> Result<()> {
+/// Install a skill onto an agent; returns the installed id
+/// (`skills/<manifest name>`), which is not necessarily derived from the
+/// source filename.
+pub fn add(name: &str, source: &str) -> Result<String> {
     agent::cmd_skill_add(name, source)
 }
 

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -84,7 +84,14 @@ pub fn cmd_skill_list(name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn cmd_skill_add(name: &str, source: &str) -> Result<()> {
+/// Install a skill onto an agent. Returns the installed skill's id
+/// (`skills/<manifest name>`) — the same string written into `profile.skills`.
+///
+/// Callers must not re-derive this id: the subdir and the profile entry are
+/// named from the MANIFEST's `name`, which need not match the source
+/// filename. The Hub used to compute `skills/<file basename>` for its result
+/// and so reported an id no profile ever contained.
+pub fn cmd_skill_add(name: &str, source: &str) -> Result<String> {
     let src = PathBuf::from(source);
     if !src.exists() {
         bail!("skill source '{source}' not found");
@@ -141,9 +148,10 @@ pub fn cmd_skill_add(name: &str, source: &str) -> Result<()> {
 
     let skill_id = format!("skills/{skill_name}");
     if !profile.skills.iter().any(|s| s == &skill_id) {
-        profile.skills.push(skill_id);
+        profile.skills.push(skill_id.clone());
     }
-    save_profile(&path, &mut profile)
+    save_profile(&path, &mut profile)?;
+    Ok(skill_id)
 }
 
 /// Convert a legacy path-style skill ref (`profile.skills`) into a structured
@@ -560,5 +568,57 @@ updated_at: \"2026-04-22T10:00:00+08:00\"
         let p: _AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
         assert!(!p.skills.iter().any(|s| s == "skills/concierge"));
         assert!(!home.join("agents/mur/skills/concierge").exists());
+    }
+}
+
+#[cfg(test)]
+mod add_id_tests {
+    use super::*;
+
+    /// The installed id comes from the MANIFEST's `name`, never the source
+    /// filename — the two need not match. The Hub used to compute
+    /// `skills/<basename>` for its own result and so reported an id that no
+    /// profile contained. Returning the real id removes the second derivation.
+    #[test]
+    fn add_returns_the_id_it_registered_not_the_filename() {
+        let home = tempfile::tempdir().unwrap();
+        let agent_dir = home.path().join("agents").join("a1");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.name = "a1".into();
+        save_profile(&agent_dir.join("profile.yaml"), &mut profile).unwrap();
+
+        // Filename and manifest name deliberately disagree.
+        let src = home.path().join("totally-different-filename.md");
+        std::fs::write(
+            &src,
+            "---\nname: real-skill-name\nversion: 1.0.0\npublisher: human:test\n\
+             description: id derivation probe\ncategory: context\n---\n\n\
+             # real-skill-name\n\nbody\n",
+        )
+        .unwrap();
+
+        // SAFETY: nextest runs each test in its own process.
+        unsafe { std::env::set_var("MUR_HOME", home.path()) };
+
+        let id = cmd_skill_add("a1", src.to_str().unwrap()).expect("add should succeed");
+        assert_eq!(id, "skills/real-skill-name");
+        assert_ne!(id, "skills/totally-different-filename.md");
+
+        // The profile holds exactly what was returned.
+        let (_, saved) = load_profile_for_edit("a1").unwrap();
+        assert!(
+            saved.skills.contains(&id),
+            "profile.skills {:?} should contain the returned id {id}",
+            saved.skills
+        );
+        // And the files landed under that same name.
+        assert!(
+            agent_dir
+                .join("skills")
+                .join("real-skill-name")
+                .join("skill.yaml")
+                .is_file()
+        );
     }
 }

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -269,16 +269,17 @@ pub fn cmd_remove(name: &str) -> Result<()> {
     local::remove_installed(&home, name).map_err(|e| anyhow!("failed to remove '{name}': {e}"))?;
 
     // Best-effort: remove the skill's embedding from LanceDB.
-    let _ = tokio::runtime::Handle::try_current().map(|handle| {
-        handle.block_on(async {
-            let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
-            let index_dir = home.join("lance");
-            if let Ok(store) =
-                crate::store::vector::factory::get_vector_store(&cfg, &index_dir).await
-            {
-                let _ = crate::skill_index::delete(name, &*store).await;
-            }
-        })
+    //
+    // Driven on an isolated runtime: `mur` runs its whole CLI inside a tokio
+    // runtime, so `Handle::current().block_on()` here panicked with "Cannot
+    // start a runtime from within a runtime" — AFTER the files were already
+    // deleted, so the removal looked like a crash and printed no confirmation.
+    let _ = crate::cmd::skill_install::block_on_isolated(|| async {
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        let index_dir = home.join("lance");
+        if let Ok(store) = crate::store::vector::factory::get_vector_store(&cfg, &index_dir).await {
+            let _ = crate::skill_index::delete(name, &*store).await;
+        }
     });
 
     println!("removed: {name}");
@@ -1149,5 +1150,34 @@ content:
             "context must survive yaml→md→yaml on disk"
         );
         assert_eq!(roundtripped.tags, original.tags);
+    }
+}
+
+#[cfg(test)]
+mod remove_tests {
+    use super::*;
+
+    /// `mur` drives its whole CLI inside a tokio runtime, so the embedding
+    /// cleanup in `cmd_remove` must not call `Handle::block_on` — that panics
+    /// with "Cannot start a runtime from within a runtime", and it panicked
+    /// AFTER the files were deleted, so the user saw a crash and no
+    /// confirmation for an operation that had actually succeeded.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remove_inside_a_tokio_runtime_does_not_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("skills").join("probe-skill");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("skill.yaml"),
+            "name: probe-skill\nversion: 1.0.0\npublisher: human:test\n\
+             description: probe\ncategory: context\ncontent:\n  abstract: a\n  context: b\n",
+        )
+        .unwrap();
+
+        // SAFETY: nextest runs each test in its own process.
+        unsafe { std::env::set_var("MUR_HOME", tmp.path()) };
+
+        cmd_remove("probe-skill").expect("remove must succeed inside a runtime");
+        assert!(!dir.exists(), "skill dir should be gone");
     }
 }

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -516,7 +516,7 @@ pub fn cmd_update_cli(name: &str) -> Result<()> {
 /// where `Handle::block_on` panics ("Cannot start a runtime from within a
 /// runtime"). The future is built and driven entirely on the worker thread, so
 /// it need not be `Send`; only the captured references cross the boundary.
-fn block_on_isolated<B, F, T>(build: B) -> Result<T>
+pub(crate) fn block_on_isolated<B, F, T>(build: B) -> Result<T>
 where
     B: FnOnce() -> F + Send,
     F: std::future::Future<Output = T>,

--- a/mur-core/src/cmd/skill_resolver.rs
+++ b/mur-core/src/cmd/skill_resolver.rs
@@ -2,7 +2,9 @@
 //! semver constraint matching, leaves-first install ordering.
 
 use anyhow::Result;
-use mur_common::skill::{Constraint, ConstraintError, SkillManifest, parse_canonical, validate};
+use mur_common::skill::{
+    Constraint, ConstraintError, SkillManifest, parse_canonical, parse_markdown, validate,
+};
 use semver::Version;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -98,7 +100,23 @@ fn load_root(input: &ResolverInput, src: ResolveSource<'_>) -> Result<ResolvedNo
 
 fn load_from_path(path: &Path) -> Result<ResolvedNode, ResolveError> {
     let text = std::fs::read_to_string(path).map_err(|e| ResolveError::Other(e.into()))?;
-    let m = parse_canonical(&text).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
+    // Pick the parser by extension, matching `mur agent skill add`: `.yaml`/
+    // `.yml` are canonical manifests, anything else is markdown-with-frontmatter.
+    // Without this, `mur skill install foo.md` failed with the canonical
+    // parser's "missing field `content`" — a message about the YAML schema for
+    // a file that was never YAML — while the per-agent install of the same file
+    // succeeded.
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let parsed = if ext == "yaml" || ext == "yml" {
+        parse_canonical(&text)
+    } else {
+        parse_markdown(&text)
+    };
+    let m = parsed.map_err(|e| ResolveError::BadManifest(e.to_string()))?;
     validate(&m).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
     let v = Version::parse(&m.version)
         .map_err(|e| ResolveError::BadManifest(format!("version: {e}")))?;
@@ -172,6 +190,42 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    /// A `.md` skill file must resolve, not die on the canonical parser.
+    /// `mur agent skill add` has always accepted markdown; `mur skill install`
+    /// rejected the same file with "missing field `content`" — a YAML-schema
+    /// error about a file that was never YAML.
+    #[test]
+    fn local_markdown_source_resolves() {
+        let tmp = tempdir().unwrap();
+        let md = tmp.path().join("my-file.md");
+        fs::write(
+            &md,
+            "---\nname: from-markdown\nversion: 1.0.0\npublisher: human:test\n\
+             description: markdown source\ncategory: context\n---\n\n\
+             # from-markdown\n\nbody text\n",
+        )
+        .unwrap();
+
+        let node = load_from_path(&md).expect("markdown source should resolve");
+        // Named from the manifest, not the filename ("my-file").
+        assert_eq!(node.name, "from-markdown");
+        assert_eq!(node.version.to_string(), "1.0.0");
+    }
+
+    /// Negative control: `.yaml` still goes through the canonical parser, so a
+    /// real YAML schema error is still reported as one.
+    #[test]
+    fn local_yaml_source_still_uses_canonical_parser() {
+        let tmp = tempdir().unwrap();
+        let y = tmp.path().join("broken.yaml");
+        fs::write(&y, "name: broken\nversion: 1.0.0\n").unwrap();
+        let err = load_from_path(&y).expect_err("incomplete yaml must fail");
+        assert!(
+            matches!(err, ResolveError::BadManifest(_)),
+            "expected BadManifest, got: {err}"
+        );
+    }
 
     fn write_skill(reg_dir: &Path, name: &str, version: &str, requires: &[(&str, &str)]) {
         let vdir = reg_dir.join("skills").join(name).join("versions");

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1727,7 +1727,12 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                         println!("Installed {id} onto '{name}'. Restart the agent to load it.");
                     }
                 } else {
-                    cmd::agent::cmd_skill_add(&name, &source)?
+                    // Same confirmation as the URL branch above — a local-file
+                    // install used to print nothing at all, so the user had no
+                    // way to see the id it registered (which comes from the
+                    // manifest name, not the filename).
+                    let id = cmd::agent::cmd_skill_add(&name, &source)?;
+                    println!("Installed {id} onto '{name}'. Restart the agent to load it.");
                 }
             }
             AgentSkillAction::Remove { name, skill_id } => {

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -27,14 +27,11 @@ pub fn agent_skill_install(
     name: String,
     source_path: String,
 ) -> Result<SkillInstallResult, String> {
-    cmd_skill_add(&name, &source_path).map_err(|e| format!("{e:#}"))?;
-    // Mirror `cmd_skill_add`'s id derivation: the source basename, registered
-    // under `skills/<basename>`. Computed only after a successful add.
-    let installed_id = std::path::Path::new(&source_path)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .map(|b| format!("skills/{b}"))
-        .unwrap_or_else(|| source_path.clone());
+    // Use the id `cmd_skill_add` actually registered. It is named from the
+    // MANIFEST's `name`, which need not match the source filename — deriving
+    // it here from the basename reported ids (`skills/my-file.md`) that no
+    // profile ever contained.
+    let installed_id = cmd_skill_add(&name, &source_path).map_err(|e| format!("{e:#}"))?;
     let detail = get_agent_detail(name)?;
     Ok(SkillInstallResult {
         detail,


### PR DESCRIPTION
Found while probing how a Hub-installed local skill relates to the global copy of the same name (see #1033 for the sibling batch). All three sit on the paths a user takes to put a skill onto an agent.

## 1. `mur skill remove` deleted the skill, then crashed

```
$ mur skill remove panicprobe-tmp
thread 'mur-main' panicked at mur-core/src/cmd/skill_cmd.rs:273:16:
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is
being used to drive asynchronous tasks.
thread 'main' panicked at mur-core/src/main.rs:137:10:
mur-main thread panicked: Any { .. }
--- exit=101 ---
  (the skill directory was already gone)
```

`mur` drives its whole CLI inside a tokio runtime, so `Handle::current().block_on()` in the embedding cleanup always panics. It panicked *after* `remove_installed` and *before* `println!("removed: …")`, so a removal that fully succeeded presented as a crash with no confirmation.

This crate already had the right tool — `skill_install::block_on_isolated`, whose doc comment names this exact hazard ("Safe to call from inside an existing tokio runtime, where `Handle::block_on` panics"). `cmd_remove` now uses it; the helper is widened to `pub(crate)`.

## 2. `mur skill install foo.md` refused a file that `mur agent skill add` accepts

```
$ mur skill install foo.md
Error: manifest parse: yaml parse: missing field `content` at line 2 column 1
```

A YAML-schema complaint about a file that was never YAML. `skill_resolver::load_from_path` always used `parse_canonical`, while `cmd_skill_add` has always picked the parser by extension. Same file, same intent, two answers. The resolver now picks by extension too.

## 3. The Hub reported an installed id that no profile contained

Both the subdir and the `profile.skills` entry are named from the **manifest's** `name`, which need not match the source filename. `agent_skill_install` re-derived `skills/<file basename>` for its own result — its comment even claimed to "Mirror `cmd_skill_add`'s id derivation", which it did not.

Observed directly: installing `my-local-skill.md` whose manifest says `name: skilltest-probe` produced

```
~/.mur/agents/<agent>/skills/skilltest-probe/skill.yaml
profile.yaml:  skills: [skills/skilltest-probe]
```

while the Hub's result reported `skills/my-local-skill.md`.

`cmd_skill_add` now returns the id it registered and every caller uses it, so there is one derivation instead of two.

## Also

A local-file `mur agent skill add` printed **nothing at all**, while the URL branch beside it printed `Installed <id> onto '<agent>'. Restart the agent to load it.` Both print it now — which is also how a user sees that the id comes from the manifest, not the filename.

## Verification

Run locally with the same commands CI uses:

| Crate | Command | Result |
|---|---|---|
| mur-core | `clippy --all-targets` | clean |
| mur-core | 273 skill/resolver tests | pass |
| mur-hub-gui | `clippy --all-targets -- -D warnings` | clean |
| mur-hub-gui | `cargo test` | 120 + 1 pass, 1 ignored |
| mur-agent-gui | `clippy --lib -- -D warnings` | clean |
| mur-agent-gui | `cargo test --lib` | 91 pass |
| all three manifests | `fmt --check` | clean |

New tests: markdown source resolves + `.yaml` still uses the canonical parser; `cmd_remove` inside a multi-thread runtime completes without panicking; the returned id equals what lands in `profile.skills` and differs from the filename.

**Both new behaviours were confirmed to fail with the fix reverted** — the markdown test fails on the canonical parser, and the remove test panics at the same line as the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
