### PR TITLE
docs(readme): schedules that fire when they say they will

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,14 @@ Agent** wizard offers the same catalog as a source.
   `--max-iterations 0` is not zero, and a cron expression that can never fire is
   not a schedule. Unattended auto-run still needs an explicit budget, and
   `mur fleet stop` still ends everything.
+- **Schedules that fire when they say they will** — `mur workflow schedule set`
+  takes a flat workflow *or* a workflow skill, and resolves the name against
+  both when you create the schedule, so a name it accepts is a name that will
+  run. The listed zone is the one launchd and cron actually use — local, not a
+  hardcoded `UTC` label that had people shift a working schedule by their own
+  offset. And the job inherits the `PATH` of the shell that created it, so a
+  step calling `mysql` or `gh` reaches the binaries you just tested it against
+  rather than the four directories a scheduler hands out.
 - **Approvals that wait for you, not the other way round** — a run nobody is
   watching used to spend the full five-minute approval window discovering
   exactly that, then fail the step and kill the request, so approving it the


### PR DESCRIPTION
Documentation follow-up for #1033 (merged). One bullet in the 🔐 section.

## What it records

`mur workflow schedule set` now takes a workflow skill as well as a flat workflow, and resolves the name against both when the schedule is created — so a name it accepts is a name that will actually fire. The listed zone is the local one launchd and cron really use, not the hardcoded `UTC` label that had people shift a working schedule by their own offset. And the job inherits the `PATH` of the shell that created it, instead of the four directories a scheduler hands out.

## What it doesn't

- **No command-tree change.** `workflow … schedule` was already there; #1033 added no commands.
- **No entry for #1034.** Those three are repairs to surfaces already documented as working that way — a rejected file format now accepted, a crash removed, an id corrected. There is no new capability or flag for a reader to learn, so they get no README bullet and no docs page.
- **No product-page card.** The product page's only scheduling mention is the fleet loop, a different mechanism, and untouched by either PR.

## Companion PR

The docs site gets a new **Scheduling workflows** page (local time, PATH, exact-name resolution, the minimal flat-workflow file, and the command table) — separate PR in `mur-server`, since merging there publishes to app.mur.run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
