### PR TITLE
chore(release): bump workspace version to 2.71.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.0"
+version = "2.71.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6727,6 +6727,7 @@ dependencies = [
  "heed",
  "hex",
  "hostname",
+ "iana-time-zone",
  "keyring",
  "lancedb",
  "libc",
@@ -6784,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.0"
+version = "2.71.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.1. Patch — everything since 2.71.0 is a fix or a docs change.

**Merging this PR IS the release**: `tag.yml` tags the merge commit `v2.71.1` and dispatches `release.yml`, which publishes to crates.io. There is no gate after this one.

## What ships

**#1033 — `fix(schedule)`: workflow skills can be scheduled, and the schedule stops lying about when it fires**

- `mur workflow schedule set` accepts a `category: Workflow` skill, not just a flat workflow. It previously rejected them as "not found" even though a schedule fires `mur run <name>`, which resolves skills fine.
- Exact skill lookup now precedes the fuzzy searches. A scheduled fire has no TTY, so a name claimed by semantic search hit the fuzzy-confirm and was refused — exit 0, nothing run, no error.
- `timezone` was hardcoded to `"UTC"` on every schedule and printed by `schedule list`, while launchd and cron both fire in **local** time. Users read the label and shifted working schedules by their UTC offset. Now records the real IANA zone and displays the one that will actually fire.
- Scheduled jobs inherit the `PATH` of the shell that created them, instead of the bare `/usr/bin:/bin:/usr/sbin:/sbin` a scheduler hands out — so a step calling `mysql`/`gh`/`node` no longer fails at fire time while working by hand.

**#1034 — `fix(skill)`: three defects on the skill install/remove path**

- `mur skill remove` deleted the skill and then panicked (`Cannot start a runtime from within a runtime`, exit 101) — a successful removal presenting as a crash.
- `mur skill install foo.md` was refused while `mur agent skill add <agent> foo.md` accepted the same file.
- The Hub reported an installed id derived from the source filename; the profile records one derived from the manifest name. `cmd_skill_add` now returns the id it registered.

**#1035 — `docs(readme)`** — one bullet recording the schedule changes.

## Version choice

Patch rather than minor: all three commits are `fix`/`docs`. Scheduling a workflow skill is arguably new capability, but the documented behaviour already claimed it worked — this makes the implementation match the contract rather than extending it. Say the word if you'd rather cut 2.72.0.

## Prior verification

Both fix PRs merged with full CI green (#1033: 12 pass / 1 skipping; #1034: 13/13 pass, including all three Hub GUI platforms). Both were additionally verified locally against the same commands CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
