### PR TITLE
fix(ci): gate the Llama-Guard nightly on a runner that actually exists

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -313,13 +313,32 @@ jobs:
           git push origin HEAD:main || true
 
   # ── Llama-Guard nightly re-grade ─────────────────────────────────
-  # Grades every JSONL response with Llama-Guard-3-8B running locally
-  # via Ollama. Only runs on self-hosted runners that have Ollama with
-  # llama-guard3:8b pulled. Soft-fails if Ollama is unavailable.
+  # Grades every JSONL response with Llama-Guard-3-8B running locally via
+  # Ollama, on a self-hosted runner that has `llama-guard3:8b` pulled.
+  #
+  # Gated on the `OLLAMA_RUNNER_ONLINE` repository variable, because a job
+  # asking for a runner label nobody has does not fail — it queues, for the
+  # 24h maximum, and every nightly schedule adds another. The eight runs
+  # before this gate went in were all queued/cancelled: the job had never
+  # once executed, while making the workflow look permanently in progress.
+  #
+  # To turn it back on: register a runner with the `self-hosted` + `ollama`
+  # labels, `ollama pull llama-guard3:8b` on it, then set the variable —
+  #   gh variable set OLLAMA_RUNNER_ONLINE --body true
+  # Unset it (or set anything else) when that runner goes away.
+  #
+  # Note there is no soft-fail here despite what this comment used to
+  # claim: `ollama pull` has no `continue-on-error`, so an unreachable
+  # Ollama fails the job. That is the right behaviour now that the gate
+  # means the job only runs when the operator has asserted the runner is
+  # up — a silent pass would hide a broken grader.
   llama-guard-nightly:
     name: Llama-Guard nightly re-grade
     runs-on: [self-hosted, ollama]
-    if: github.event_name == 'schedule' && github.event.schedule == '0 17 * * *'
+    if: >-
+      github.event_name == 'schedule'
+      && github.event.schedule == '0 17 * * *'
+      && vars.OLLAMA_RUNNER_ONLINE == 'true'
     needs: real-llm
     steps:
       - uses: actions/checkout@v6
@@ -336,7 +355,7 @@ jobs:
           merge-multiple: true
       - name: Grade all runners
         run: |
-          find /tmp/eval-results -name "*.jsonl" | while read f; do
+          find /tmp/eval-results -name "*.jsonl" | while read -r f; do
             python3 scripts/eval/llama_guard/grade.py \
               --jsonl "$f" \
               --output "${f%.jsonl}.graded.jsonl"


### PR DESCRIPTION
## The problem

`llama-guard-nightly` asks for `runs-on: [self-hosted, ollama]`. No runner with those labels is registered on this repo.

A job whose labels nobody offers **does not fail** — it queues, up to GitHub's 24h maximum, and the next nightly schedule adds another. Every run on record:

| run | Llama-Guard job |
|---|---|
| 32878551908 | queued |
| 32757197932 | cancelled |
| 32734850754 | skipped |
| 32660975037 | skipped |
| 32654582918 | cancelled |
| 32587527818 | cancelled |
| 32508529315 | cancelled |
| 32398086693 | cancelled |

Zero successes. The job has never executed — it has only ever made B0 Eval look permanently in progress.

## The fix

Gate it on an `OLLAMA_RUNNER_ONLINE` repository variable:

```yaml
    if: >-
      github.event_name == 'schedule'
      && github.event.schedule == '0 17 * * *'
      && vars.OLLAMA_RUNNER_ONLINE == 'true'
```

Unset, the job is `skipped` like any other unmet `if` — no runner is requested, so nothing queues. **That mechanism is already proven in this same workflow**: `fuzz-weekly` and `stub` report `skipped` on the nights their conditions do not hold.

Re-enabling is three steps, now written into the comment above the job:

```bash
# 1. register a runner with the `self-hosted` + `ollama` labels
# 2. ollama pull llama-guard3:8b   (on that runner)
gh variable set OLLAMA_RUNNER_ONLINE --body true
```

## Also in this diff

**A comment that was lying.** It claimed the job "soft-fails if Ollama is unavailable". It does not — `ollama pull` carries no `continue-on-error`, so an unreachable Ollama fails the job. I corrected the comment rather than adding the soft-fail: now that the gate means the job only runs when an operator has asserted the runner is up, a silent pass would hide a broken grader.

**`read f` → `read -r f`** (SC2162), in the same job.

## Not changed

The grading capability is untouched — `scripts/eval/llama_guard/grade.py` and its manual recipe in `docs/cookbook/b2-red-team-fuzz.md` both stay, so the grader can be run by hand at any time.

The `label "ollama" is unknown` actionlint finding is left alone: it needs an `.github/actionlint.yaml` declaring custom runner labels, which is a separate change. Both actionlint findings here pre-date this PR — verified by linting main's copy of the file.

## Verification

| Check | Result |
|---|---|
| YAML parses (PyYAML) | ok |
| Composed `if` | the three clauses ANDed, as intended |
| Other jobs' `if` | unchanged (`stub`, `real-llm`, `fuzz-weekly` all identical) |
| actionlint | 1 finding, down from 2 on main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)