### PR TITLE
docs(architecture): macOS MCP children ARE sandboxed — #1007 missed this file

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -362,7 +362,7 @@ mcp_requirements:
 
 ### Per-Server MCP Egress
 
-By default an agent's outbound network policy (`entitlements.network.outbound`) applies to the whole agent; MCP server subprocesses inherit the OS sandbox (port-level on Linux; unconfined on macOS — `sandbox/child.rs`). A single MCP server can additionally be scoped to a **host allowlist**:
+By default an agent's outbound network policy (`entitlements.network.outbound`) applies to the whole agent; MCP server subprocesses inherit the agent's sandbox in full — Landlock/seccomp on Linux, a seatbelt sandbox across `fork`+`exec` on macOS (verified empirically; the check is in `mur-agent-runtime/src/sandbox/child.rs`). What does not exist is granularity: no server can be given a *narrower* cage than the agent itself. A single MCP server can additionally be scoped to a **host allowlist**:
 
 ```bash
 mur agent mcp set-network <agent> <server> --allow-host example.com --allow-host '*.api.example.com'
@@ -375,7 +375,7 @@ This sets `McpServerEntry.network` (`mode: restricted|off`, `allow_hosts`). When
 The loopback egress proxy starts **before** the B1 kernel sandbox seals, and its listener port is carved into the sandbox profile as a loopback-only rule (`remote tcp "localhost:PORT"` on macOS SBPL; a port-scoped `NetPort ConnectTcp` rule on Linux Landlock, which cannot scope by host) — otherwise sandboxed MCP children could not dial the proxy their `HTTPS_PROXY` points at and every scoped grant would be silently dead.
 
 - **Isolation:** the proxy env is set ONLY on the policied child's process — never the runtime's. The agent's own LLM clients are built with `.no_proxy()` (`llm::llm_client_builder`), so LLM traffic (and a debug cc-proxy, configured via `base_url`) is never captured by the egress proxy. `NO_PROXY` covers loopback on the child.
-- **Threat model — ADVISORY.** This constrains a *cooperating* tool that honors `HTTP_PROXY`. A tool that ignores it can still reach the network directly, because the OS sandbox filters by port, not host. Airtight containment requires Linux network-namespace isolation + a macOS pre-fork launcher (the `sandbox/child.rs` macOS limitation) — out of scope. Use this for scoping/accident-prevention/audit of trusted tools, not to contain a malicious server.
+- **Threat model — ADVISORY.** This constrains a *cooperating* tool that honors `HTTP_PROXY`. A tool that ignores it can still reach the network directly, because the OS sandbox filters by port, not host. Airtight containment requires Linux network-namespace isolation + a macOS pre-fork launcher (the `mur-agent-runtime/src/sandbox/child.rs` macOS limitation) — out of scope. Use this for scoping/accident-prevention/audit of trusted tools, not to contain a malicious server.
 - **Opt-in:** a server with no `network` policy is spawned exactly as before; with no policied server, no proxy starts.
 
 ### Remote MCP (Streamable HTTP + OAuth 2.1)


### PR DESCRIPTION
## The claim that was wrong

`docs/architecture/runtime-overview.md:365` said MCP server subprocesses run **"unconfined on macOS"**.

That was tested and disproved in **#1007** (`ac22c615` — *"macOS children DO inherit the sandbox — correct #1005"*). That PR corrected the code comment, `mur agent perm show`, `mur agent doctor`, and `docs/architecture/mcp-supply-chain.md` — but not this file.

`child.rs` even lists where the error had spread. This file isn't on that list, which is why it survived.

## Why it matters

It inverts a security property. A reader planning MCP installs would conclude that on macOS the server escapes the agent's cage — and grant entitlements to compensate for a hole that isn't there.

The empirical check is in `child.rs`:

```text
$ sandbox-exec -p '(version 1)(allow default)(deny network-outbound)' \
    /bin/sh -c 'curl -s -m5 -o /dev/null -w "%{http_code}" https://example.com; echo'
000          # blocked, through sh's fork AND curl's exec
```

## The fix

Replaced with what `child.rs` documents: full inheritance on both platforms (Landlock/seccomp on Linux, seatbelt across `fork`+`exec` on macOS), plus the limitation that **is** real — no per-server granularity, because a narrower cage needs a second `sandbox_init` in the child.

Wording taken from `mcp-supply-chain.md`, which was written from that check. **I did not re-run the check myself** — `child.rs` carries a standing warning not to restate either claim without re-running it, and I'm flagging that I relied on the already-corrected sibling doc instead.

## A `mur verify` detail worth knowing

Also expanded both `sandbox/child.rs` references to full repo paths. `mur verify --file` **deduplicates identical claims and reports only the first occurrence**, so fixing just L365 moved the finding to L378 while the total stayed at 31. Fixing both drops it to 30:

```
before:  Total: 169  ✅ 121  ❌ 31
after:   Total: 169  ✅ 122  ❌ 30
```

That's worth remembering when using `mur verify` as a progress signal — an unchanged count does not mean an unchanged file.

## Out of scope

The other 30 stale claims `mur verify` reports in this file (missing paths like `telemetry/`, `credit/ledger.jsonl`, a removed `skill_from_pattern.rs`) are pre-existing and unrelated. `docs/superpowers/plans/2026-06-26-mcp-per-server-egress.md` also still contains the old "unconfined" claim — left alone deliberately, since plans are historical snapshots of what was believed at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)