### PR TITLE
fix(release): ship mur-research-gateway, and stop copying the binary list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
         if: matrix.target == 'aarch64-apple-darwin'
         run: |
           set -euo pipefail
-          for b in mur mur-mcp-server murmurd mur-agent-runtime; do
+          for b in mur mur-mcp-server murmurd mur-agent-runtime mur-research-gateway; do
             p="target/aarch64-apple-darwin/release/$b"
             codesign --force --options runtime --timestamp \
               --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
@@ -193,14 +193,21 @@ jobs:
           # resolve_runtime_target finds the sibling and `brew upgrade` keeps the
           # runtime in sync. Without it, brew CLI users have no runtime and running
           # agents drift on a stale one (the runtime otherwise ships only in the Hub .app).
-          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd mur-agent-runtime
+          #
+          # mur-research-gateway for the same reason: `update::SIBLING_BINARIES`
+          # lists it, so `mur update` looks for it here and warns that it "stays
+          # on the previous version" when it is absent, and deep-research mounts
+          # it as an MCP server by name (`GATEWAY_MCP_COMMAND`) with no fallback
+          # if the binary is missing. It was never in this list, so only
+          # `build.sh --install` ever produced it.
+          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd mur-agent-runtime mur-research-gateway
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe,target/${{ matrix.target }}/release/mur-agent-runtime.exe -DestinationPath ${{ matrix.name }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe,target/${{ matrix.target }}/release/mur-agent-runtime.exe,target/${{ matrix.target }}/release/mur-research-gateway.exe -DestinationPath ${{ matrix.name }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,12 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_SIGNING_CERT }}
           p12-password: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
 
+      # NOTE: this stages only mur, mur-mcp-server and murmurd — no
+      # mur-agent-runtime and no mur-research-gateway, so a .pkg install can
+      # run the CLI but cannot start an agent. That may be deliberate (the
+      # identifier is `run.mur.cli` and postinstall says only "Run 'mur init'"),
+      # but it is worth an explicit decision rather than an accident, since the
+      # tarball above ships both.
       - name: Stage pkg-root
         run: |
           mkdir -p pkg-root/usr/local/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,14 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
+      # The shipped binary set, declared ONCE. The sign loop, the tarball and
+      # the Windows zip below all read this — they used to carry three separate
+      # copies of the list, and every copy drifted at least once: #1027 signed
+      # one of four, and mur-research-gateway was packaged by none of them
+      # while `update::SIBLING_BINARIES` already listed it.
+      # The Homebrew formula is deliberately NOT a fourth copy: it installs
+      # whatever the tarball contains (`bin.install Dir["*"]`).
+      BINARIES: mur mur-mcp-server murmurd mur-agent-runtime mur-research-gateway
     strategy:
       fail-fast: false
       matrix:
@@ -165,14 +173,13 @@ jobs:
       # app. A background agent cannot re-prompt, so the secret silently
       # resolves to nothing (#866).
       #
-      # Keep this list in step with the `tar czf` below — signing a binary that
-      # is not shipped is harmless, but shipping one that is not signed is the
-      # bug this fixes.
+      # Signs $BINARIES, the same list the `tar czf` below ships — shipping a
+      # binary that is not signed is the bug this fixes.
       - name: Sign macOS binaries
         if: matrix.target == 'aarch64-apple-darwin'
         run: |
           set -euo pipefail
-          for b in mur mur-mcp-server murmurd mur-agent-runtime mur-research-gateway; do
+          for b in $BINARIES; do
             p="target/aarch64-apple-darwin/release/$b"
             codesign --force --options runtime --timestamp \
               --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
@@ -198,16 +205,27 @@ jobs:
           # lists it, so `mur update` looks for it here and warns that it "stays
           # on the previous version" when it is absent, and deep-research mounts
           # it as an MCP server by name (`GATEWAY_MCP_COMMAND`) with no fallback
-          # if the binary is missing. It was never in this list, so only
+          # if the binary is missing. It was never packaged here, so only
           # `build.sh --install` ever produced it.
-          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd mur-agent-runtime mur-research-gateway
+          # Unquoted on purpose: $BINARIES is a space-separated list to split.
+          # shellcheck disable=SC2086
+          tar czf ../../../${{ matrix.name }}.tar.gz $BINARIES
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe,target/${{ matrix.target }}/release/mur-agent-runtime.exe,target/${{ matrix.target }}/release/mur-research-gateway.exe -DestinationPath ${{ matrix.name }}.zip
+          # Deliberately plain: quote $env:BINARIES into a string before
+          # .Split (`$env:X.Split(...)` is ambiguous to the variable-path
+          # parser) and concatenate rather than interpolate. A `*.exe` glob
+          # would be shorter but would also sweep up stub_gateway.exe and
+          # every other workspace binary.
+          $paths = @()
+          foreach ($b in "$env:BINARIES".Split(' ')) {
+            $paths += "target/${{ matrix.target }}/release/" + $b + ".exe"
+          }
+          Compress-Archive -Path $paths -DestinationPath ${{ matrix.name }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -655,10 +673,11 @@ jobs:
             end
 
             def install
-              bin.install "mur"
-              bin.install "mur-mcp-server"
-              bin.install "murmurd"
-              bin.install "mur-agent-runtime"
+              # Whatever the tarball ships — the `build` job's $BINARIES and
+              # nothing else is in it. Naming them here made the formula a
+              # second copy of that list, and it drifted: mur-research-gateway
+              # was added to the tarball while brew kept discarding it.
+              bin.install Dir["*"]
               bin.install_symlink "mur" => "murmur"
             end
 

--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,12 @@ echo "   Size: $(du -h "$BINARY" | cut -f1)"
 
 # Step 3: Install if requested
 if $INSTALL; then
+  # The binary set, declared once — the sign loop, the install loop and the
+  # PATH-shadow check below all read it. They used to carry three copies of
+  # the same list; release.yml carried three more, and one of those was how
+  # mur-research-gateway ended up shipping from here and nowhere else.
+  BINS="mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime"
+
   # One-time setup for a stable signing identity (avoids TCC re-prompts on every
   # rebuild): ad-hoc signing (-s -) gives each build a fresh CDHash, so macOS
   # treats it as a new binary and re-prompts for removable-volume access every
@@ -86,7 +92,7 @@ if $INSTALL; then
   }
 
   BIN_DIR="$(dirname "$BINARY")"
-  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+  for b in $BINS; do
     sign "$BIN_DIR/$b"
   done
 
@@ -129,7 +135,7 @@ if $INSTALL; then
   # so $INSTALL_DIR must stay one of `standard_exec_dirs()` in
   # mur-agent-runtime/src/exec_dirs.rs. mur-agent-runtime is what agent symlinks
   # resolve to, so a stale copy here means new and restarted agents inherit it.
-  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+  for b in $BINS; do
     install_bin "$BIN_DIR/$b" "$b"
   done
   ln -sfn "$INSTALL_DIR/mur" "$INSTALL_DIR/murmur"
@@ -141,7 +147,7 @@ if $INSTALL; then
   # for every agent sandbox. Name it rather than let the next upgrade look like
   # it did nothing.
   SHADOWED=false
-  for b in mur mur-mcp-server mur-research-gateway murmurd mur-agent-runtime; do
+  for b in $BINS; do
     [ -f "$INSTALL_DIR/$b" ] || continue
     winner="$(command -v "$b" 2>/dev/null || true)"
     if [ -n "$winner" ] && [ "$winner" != "$INSTALL_DIR/$b" ]; then


### PR DESCRIPTION
Found by running `mur update` after 2.71.1 shipped:

```
warning: could not update /Users/david/.local/bin/mur-research-gateway
(archive mur-aarch64-apple-darwin.tar.gz did not contain a `mur-research-gateway`
binary) — it stays on the previous version
```

It never contained one. Confirmed against the real artifact rather than the workflow — the 2.71.1 brew keg holds five files and the gateway is not among them:

```
/opt/homebrew/Cellar/mur/2.71.1/bin:  mur  mur-agent-runtime  mur-mcp-server  murmur  murmurd
```

## Three places in the tree assume it ships

| Where | What it assumes |
|---|---|
| `update::SIBLING_BINARIES` | it is in the archive — `mur update` looks for it and gives up when absent, so it stays on whatever `build.sh` last produced, indefinitely |
| `update::resign` | it is among the binaries whose Developer ID signature must survive an update |
| `deep_research::provision` | mounts it as an MCP server by name (`GATEWAY_MCP_COMMAND`) via `cmd_mcp_add(..., force: true)` — no fallback if the binary is missing |

`provision.rs` even records the assumption that hid this: *"installed on PATH by `build.sh`"*. True for a developer checkout, false for every brew or installer user — who therefore have no gateway at all, and cannot provision `mur deep-research` workers.

## Adding it to the tarball was not enough

The first commit added the gateway to the signing loop, the tarball and the Windows zip. Review of that commit found it did **not** deliver the brew half of its own stated fix:

`mur update` on a Homebrew install shells out to `brew upgrade mur` and returns (`update/mod.rs:26-45`) — `refresh_siblings` never runs — so what lands on disk is exactly what the formula installs, and the formula named four binaries. brew users would have downloaded 8.2 MB more tarball and had brew discard the gateway. Worse, this workflow rewrites `Formula/mur.rb` wholesale on every release, so a hand-fix in the tap would not survive the next one.

## Root cause: the binary set was copied seven times

Three copies in this file, the formula, three in `build.sh` — plus `install.sh` and `install.ps1` in the website repo. Every copy has drifted at least once: #1027 signed one of four, #495 had to add `mur-agent-runtime` to the tar, the zip **and** `bin.install` in a single commit for exactly this reason.

So the set is now declared once and everything derives from it:

| Place | Before | After |
|---|---|---|
| sign loop / `tar czf` / `Compress-Archive` | three separate lists | all read job-level `BINARIES` |
| Homebrew formula | four `bin.install` lines | `bin.install Dir["*"]` — whatever the tarball holds |
| `build.sh` | three separate lists | one `BINS` |

The formula can no longer disagree with what shipped, because it no longer has an opinion about it.

## Verification

| What | How |
|---|---|
| word-splitting under `bash -eo pipefail` | 5 loop iterations, 5-entry tarball (first attempt ran under zsh, which does **not** word-split — that proved nothing and was redone) |
| formula generation | heredoc + all three `sed` passes run end-to-end; result passes `ruby -c`; `Dir["*"]` over the unpacked tarball resolves to all five binaries |
| `build.sh` | `sh -n`, `bash -n`, shellcheck clean; loop still yields 5 |
| workflow | parses as YAML after every edit |
| gateway is actually built | it is a workspace member with a matching `[[bin]]`, and the crate has zero `cfg(unix)`/`cfg(windows)` gates — the three build jobs already compile it on all three targets |

**Not executed locally:** the pwsh packaging step — no pwsh available. It is written in its plainest form (`@()` + `foreach` + `"$env:X".Split(' )` + string concatenation, deliberately avoiding the ambiguous `$env:X.Split(...)` parse). Its failure mode is a loud job failure, not a silently wrong zip: GitHub's pwsh runs with `$ErrorActionPreference = 'Stop'` and `Compress-Archive` errors on a missing path.

`release.yml` only runs on a tag, so PR CI cannot exercise any of this. The first real proof is the next release's archive.

## Companion PR

mur-run/mur.run-website#8 fixes the same drift in `install.sh` / `install.ps1`, which hard-coded the same four names and silently dropped the gateway. Without it, `curl | sh` users stay broken even though the archive now carries the binary.

## Still not addressed, deliberately

- **The `.pkg` stages only three binaries** — no `mur-agent-runtime`, no gateway, so a PKG install can run the CLI but cannot start an agent. Its identifier is `run.mur.cli` and its postinstall says only *"Run 'mur init'"*, so a CLI-only package may be intentional. The third commit records this in place rather than changing it.
- **`mur update` cannot refresh siblings on Windows at all** — `SIBLING_BINARIES` / `refresh_siblings` are `#[cfg(unix)]`, so only `mur.exe` is swapped. Pre-existing for all four existing siblings; a `mur-core` change with its own test surface, not a packaging one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)