### PR TITLE
chore(release): bump workspace version to 2.71.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.1"
+version = "2.71.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.1"
+version = "2.71.2"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
> **Merging this PR IS the release.** `tag.yml` tags the merge commit as `v2.71.2` and dispatches `release.yml` automatically — there is no later gate, and the crates.io publish is irreversible (yank-only). Review this as the release approval.

## What ships

The first release whose archive actually contains `mur-research-gateway`.

| PR | Change |
|---|---|
| #1041 | Gateway added to the macOS signing loop, the Unix tarball and the Windows zip. Three copies of the binary list collapsed into one job-level `BINARIES`. The Homebrew formula stops naming binaries — `bin.install Dir["*"]` installs whatever the tarball holds, so it can no longer disagree with what shipped. |
| #1043 | Guards that set against its consumer: `BINARIES` must be a superset of `update::resign::SIGN_TARGETS`, checked on every PR by the existing `nextest` job. |
| mur-run/mur.run-website#8 | Already live. Both installers install what the archive contains instead of four hardcoded names. |

## Why it matters

Until now `update::SIBLING_BINARIES` listed a binary no archive ever carried. Consequences on every non-`build.sh` install:

- `mur update` warned that `mur-research-gateway` *"stays on the previous version"* — indefinitely, because it was never there to begin with.
- `mur deep-research` could not provision workers at all: it mounts the gateway as an MCP server by name (`GATEWAY_MCP_COMMAND`) with no fallback.

## Version choice

Patch, not minor: the gateway was always *supposed* to be in the archive — three places in the tree already assumed it. This is the fix, not a new capability.

## Checks done before opening

- Both lock files moved with the version — the root one and `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace crate's version and breaks the Hub build when it disagrees. Neither retains a `2.71.1` entry (12 and 6 occurrences of `2.71.2` respectively, 0 of `2.71.1`).
- `validate-version` simulated locally with the job's own extraction command: `CARGO_VERSION = 2.71.2`, matching the `v2.71.2` tag it will be checked against.

## First real proof

`release.yml` runs only on a tag, so nothing before this point can prove the packaging works. The things to check after the run: the tarball contains five binaries, all five carry a Developer ID signature, and `brew upgrade mur` lands a `mur-research-gateway` next to `mur`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)