### PR TITLE
fix: four CLI surfaces that disagreed with reality

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -105,10 +105,16 @@ pub fn verify_mcp_supply_chain(
                 Ok(_) => {
                     return Err(format!(
                         "B0 rule 6: vendored MCP `{}` ({}@{}) no longer matches the tree \
-                         installed at approval time — re-run `mur agent mcp vendor <agent> {}` \
-                         to reinstall and re-approve, or `mur agent mcp remove <agent> {}` \
+                         installed at approval time — re-run `mur agent mcp vendor {} {}` \
+                         to reinstall and re-approve, or `mur agent mcp remove {} {}` \
                          to uninstall.",
-                        entry.name, pkg.name, pkg.version, entry.name, entry.name,
+                        entry.name,
+                        pkg.name,
+                        pkg.version,
+                        profile.name,
+                        entry.name,
+                        profile.name,
+                        entry.name,
                     ));
                 }
                 Err(reason) => {
@@ -127,7 +133,7 @@ pub fn verify_mcp_supply_chain(
         }
         let Some(expected) = &entry.binary_sha256 else {
             // Pre-M9 entry — skip silently; the cookbook documents
-            // `mur agent mcp pin <name>` as the migration verb.
+            // `mur agent mcp pin <name> <server-id>` as the migration verb.
             continue;
         };
         // An interpreter-launched server (`npx @scope/pkg`, `python -m …`) pins
@@ -170,10 +176,16 @@ pub fn verify_mcp_supply_chain(
             Err(crate::hooks::b0_helpers::PinDriftReason::BinaryDrift { .. }) => {
                 return Err(format!(
                     "B0 rule 6: MCP `{}` changed since install — \
-                     run `mur agent mcp inspect {}` to review the \
-                     drift and `mur agent mcp pin {}` to re-approve, \
-                     or `mur agent mcp remove {}` to uninstall.",
-                    entry.name, entry.name, entry.name, entry.name,
+                     run `mur agent mcp inspect {} --server {}` to review the \
+                     drift and `mur agent mcp pin {} {}` to re-approve, \
+                     or `mur agent mcp remove {} {}` to uninstall.",
+                    entry.name,
+                    profile.name,
+                    entry.name,
+                    profile.name,
+                    entry.name,
+                    profile.name,
+                    entry.name,
                 ));
             }
             Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryMissing { .. })

--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -72,8 +72,23 @@ fn binary_drift_fails_startup_with_inspect_hint() {
 
     let msg = verify_mcp_supply_chain(&[], &profile).expect_err("drift should fail startup");
     assert!(msg.contains("B0 rule 6"), "got {msg}");
-    assert!(msg.contains("mur agent mcp inspect weather"), "got {msg}");
-    assert!(msg.contains("mur agent mcp pin weather"), "got {msg}");
+    assert!(
+        msg.contains("mur agent mcp inspect agent_a --server weather"),
+        "got {msg}"
+    );
+    assert!(
+        msg.contains("mur agent mcp pin agent_a weather"),
+        "got {msg}"
+    );
+    assert!(
+        msg.contains("mur agent mcp remove agent_a weather"),
+        "got {msg}"
+    );
+    // Regression: dropping <NAME> makes every hint exit 2 when pasted.
+    assert!(
+        !msg.contains("mcp pin weather"),
+        "agent name missing: {msg}"
+    );
 }
 
 #[test]
@@ -169,7 +184,11 @@ fn vendored_package_refuses_startup_when_the_tree_changed() {
         .expect_err("a changed vendored tree must refuse startup");
     assert!(msg.contains("vendored MCP `fetch-mcp`"), "got {msg}");
     assert!(msg.contains("@yawlabs/fetch-mcp@0.3.6"), "got {msg}");
-    assert!(msg.contains("mur agent mcp vendor"), "got {msg}");
+    assert!(
+        msg.contains("mur agent mcp vendor agent_a fetch-mcp"),
+        "got {msg}"
+    );
+    assert!(!msg.contains("<agent>"), "placeholder left in hint: {msg}");
 }
 
 /// Deleting the install must not lock the user out of their own agent: the

--- a/mur-common/src/skill/event_log.rs
+++ b/mur-common/src/skill/event_log.rs
@@ -96,6 +96,12 @@ pub fn event_log_path(mur_home: &Path, skill_name: &str) -> PathBuf {
     if let Some(fleet) = skill_name.strip_prefix("fleet:") {
         return mur_home.join("fleets").join(fleet).join("events.jsonl");
     }
+    // Same for an ephemeral fan-out (`parallel_jobs`): a run, not a skill.
+    // Not `runs/` — that store is keyed by run_id (`runs/<run_id>/run.json`),
+    // and a name dropped in there would be the same category error again.
+    if let Some(job) = skill_name.strip_prefix("job:") {
+        return mur_home.join("jobs").join(job).join("events.jsonl");
+    }
     mur_home
         .join("skills")
         .join(skill_name)
@@ -284,6 +290,31 @@ mod tests {
         // The regression: a manifest-less dir here is what `mur skill list`
         // told the user to `mur skill remove`.
         assert!(!tmp.path().join("skills/fleet:builder").exists());
+    }
+
+    #[test]
+    fn ephemeral_job_ledger_stays_out_of_the_skill_store() {
+        let tmp = tempdir().unwrap();
+        record_run(
+            tmp.path(),
+            "job:parallel-jobs",
+            "cli",
+            &RunRecord {
+                success: true,
+                duration_ms: Some(10),
+                exit_code: Some(0),
+                stderr: None,
+                failed_step: None,
+                trigger: "agent",
+                env_class_override: None,
+            },
+        )
+        .unwrap();
+        assert!(tmp.path().join("jobs/parallel-jobs/events.jsonl").exists());
+        // `runs/` belongs to the run_status store, keyed by run_id.
+        assert!(!tmp.path().join("runs").exists());
+        assert!(!tmp.path().join("skills/parallel-jobs").exists());
+        assert!(!tmp.path().join("skills/job:parallel-jobs").exists());
     }
 
     #[test]

--- a/mur-common/src/skill/event_log.rs
+++ b/mur-common/src/skill/event_log.rs
@@ -89,6 +89,13 @@ impl SkillEvent {
 }
 
 pub fn event_log_path(mur_home: &Path, skill_name: &str) -> PathBuf {
+    // A fleet run is ledgered under the same call, but `fleet:<name>` is not a
+    // skill id. Writing it into skills/ minted a manifest-less directory that
+    // `mur skill list` then flagged as invalid and told the user to
+    // `mur skill remove` — i.e. to delete the fleet's own run history.
+    if let Some(fleet) = skill_name.strip_prefix("fleet:") {
+        return mur_home.join("fleets").join(fleet).join("events.jsonl");
+    }
     mur_home
         .join("skills")
         .join(skill_name)
@@ -254,6 +261,30 @@ pub fn resolve_manifest_lww(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn fleet_run_ledger_stays_out_of_the_skill_store() {
+        let tmp = tempdir().unwrap();
+        record_run(
+            tmp.path(),
+            "fleet:builder",
+            "cli",
+            &RunRecord {
+                success: true,
+                duration_ms: Some(10),
+                exit_code: Some(0),
+                stderr: None,
+                failed_step: None,
+                trigger: "manual",
+                env_class_override: None,
+            },
+        )
+        .unwrap();
+        assert!(tmp.path().join("fleets/builder/events.jsonl").exists());
+        // The regression: a manifest-less dir here is what `mur skill list`
+        // told the user to `mur skill remove`.
+        assert!(!tmp.path().join("skills/fleet:builder").exists());
+    }
 
     #[test]
     fn record_run_classifies_and_appends() {

--- a/mur-common/src/skill/local.rs
+++ b/mur-common/src/skill/local.rs
@@ -17,7 +17,11 @@ pub fn list_installed(mur_home: &Path) -> Result<Vec<String>, StoreError> {
         .filter_map(|e| {
             let e = e.ok()?;
             if e.file_type().ok()?.is_dir() {
-                e.file_name().to_str().map(|s| s.to_string())
+                let name = e.file_name().to_str()?.to_string();
+                // ponytail: skip, don't migrate. Pre-fix fleet runs ledgered to
+                // skills/fleet:<name>/ (see event_log_path); those directories
+                // hold run history, never a manifest, and are not skills.
+                (!name.starts_with("fleet:")).then_some(name)
             } else {
                 None
             }
@@ -191,6 +195,17 @@ tags: [test, {name}]
         write_to_dir(&global_skill_dir(dir.path(), "rm-me"), &sample("rm-me")).unwrap();
         remove_installed(dir.path(), "rm-me").unwrap();
         assert!(list_installed(dir.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_installed_ignores_legacy_fleet_ledgers() {
+        let dir = tempdir().unwrap();
+        write_to_dir(&global_skill_dir(dir.path(), "real"), &sample("real")).unwrap();
+        // Pre-fix debris: a run ledger, no manifest.
+        let legacy = dir.path().join("skills").join("fleet:builder");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("events.jsonl"), "{}\n").unwrap();
+        assert_eq!(list_installed(dir.path()).unwrap(), vec!["real"]);
     }
 
     #[test]

--- a/mur-common/src/skill/local.rs
+++ b/mur-common/src/skill/local.rs
@@ -200,6 +200,13 @@ tags: [test, {name}]
         assert!(list_installed(dir.path()).unwrap().is_empty());
     }
 
+    // Unix-only, and not as a workaround: the filter keys on a `fleet:` name
+    // prefix, so exercising it means creating a directory whose name contains a
+    // colon. Windows reads `:` as the start of an NTFS alternate data stream, so
+    // `create_dir_all` fails there with ERROR_DIRECTORY (os error 267). The same
+    // rule means the debris this skips can never exist on Windows either, so
+    // there is no coverage to lose — the filter is inert on that platform.
+    #[cfg(unix)]
     #[test]
     fn list_installed_ignores_legacy_fleet_ledgers() {
         let dir = tempdir().unwrap();

--- a/mur-common/src/skill/local.rs
+++ b/mur-common/src/skill/local.rs
@@ -21,6 +21,9 @@ pub fn list_installed(mur_home: &Path) -> Result<Vec<String>, StoreError> {
                 // ponytail: skip, don't migrate. Pre-fix fleet runs ledgered to
                 // skills/fleet:<name>/ (see event_log_path); those directories
                 // hold run history, never a manifest, and are not skills.
+                // The other pre-fix offender, a bare `parallel-jobs`, is left
+                // visible on purpose: `mur skill remove` is the right advice
+                // for an ephemeral fan-out log nothing reads.
                 (!name.starts_with("fleet:")).then_some(name)
             } else {
                 None

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -279,7 +279,7 @@ pub fn binary_status(entry: &mur_common::agent::McpServerEntry) -> InspectStatus
 /// Print pinned vs current state for one MCP entry. Returns the
 /// exit-code-shaped status; `cmd_mcp_inspect` lifts that to
 /// `std::process::exit` after running through the dispatch.
-pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
+pub fn inspect_one(agent: &str, entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
     println!("MCP server: {}", entry.name);
     println!("  command:        {}", entry.command);
     if !entry.args.is_empty() {
@@ -345,8 +345,8 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
         } else {
             println!("  status:         TREE DRIFT");
             println!(
-                "  hint:           `mur agent mcp vendor <agent> {}` to reinstall and re-approve",
-                entry.name,
+                "  hint:           `mur agent mcp vendor {} {}` to reinstall and re-approve",
+                agent, entry.name,
             );
             InspectStatus::BinaryDrift
         };
@@ -355,8 +355,8 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
     let Some(expected) = &entry.binary_sha256 else {
         println!("  pin status:     <unpinned> (pre-M9 entry)");
         println!(
-            "  hint:           run `mur agent mcp pin {}` to start enforcing rule 6",
-            entry.name,
+            "  hint:           run `mur agent mcp pin {} {}` to start enforcing rule 6",
+            agent, entry.name,
         );
         return InspectStatus::MissingPin;
     };
@@ -402,7 +402,10 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
         println!("  pinned descr:   {d}");
         println!("                  (pass --probe to verify against live MCP)");
     } else {
-        println!("  pinned descr:   <none — re-pin with `mur agent mcp pin` to capture>");
+        println!(
+            "  pinned descr:   <none — re-pin with `mur agent mcp pin {} {}` to capture>",
+            agent, entry.name,
+        );
     }
 
     if actual.eq_ignore_ascii_case(expected) {
@@ -411,9 +414,9 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
     } else {
         println!("  status:         BINARY DRIFT");
         println!(
-            "  hint:           `mur agent mcp pin {}` to re-approve, \
-             or `mur agent mcp remove {}` to uninstall",
-            entry.name, entry.name,
+            "  hint:           `mur agent mcp pin {} {}` to re-approve, \
+             or `mur agent mcp remove {} {}` to uninstall",
+            agent, entry.name, agent, entry.name,
         );
         InspectStatus::BinaryDrift
     }
@@ -424,12 +427,13 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
 /// Lights up the `DescriptionDrift` and `BothDrifted` exit codes that
 /// M9.4 reserved.
 pub async fn inspect_one_probed(
+    agent: &str,
     entry: &mur_common::agent::McpServerEntry,
     timeout: std::time::Duration,
 ) -> InspectStatus {
     // Run the binary-side inspect synchronously first so its output
     // appears before the probe results in the user-facing report.
-    let binary_status = inspect_one(entry);
+    let binary_status = inspect_one(agent, entry);
 
     // Skip the probe entirely if the entry has no pinned description
     // hash — there's nothing to compare against.
@@ -458,9 +462,9 @@ pub async fn inspect_one_probed(
                 println!(
                     "  hint:           the MCP's tools/list changed since install; \
                      review the new tool descriptions then \
-                     `mur agent mcp pin {}` to re-approve, \
-                     or `mur agent mcp remove {}` to uninstall",
-                    entry.name, entry.name,
+                     `mur agent mcp pin {} {}` to re-approve, \
+                     or `mur agent mcp remove {} {}` to uninstall",
+                    agent, entry.name, agent, entry.name,
                 );
                 match binary_status {
                     InspectStatus::Clean => InspectStatus::DescriptionDrift,
@@ -510,11 +514,14 @@ pub fn cmd_mcp_inspect(
         }
         let status = if probe {
             tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current()
-                    .block_on(inspect_one_probed(entry, probe_timeout()))
+                tokio::runtime::Handle::current().block_on(inspect_one_probed(
+                    name,
+                    entry,
+                    probe_timeout(),
+                ))
             }) as u8
         } else {
-            inspect_one(entry) as u8
+            inspect_one(name, entry) as u8
         };
         worst = worst.max(status);
 
@@ -938,7 +945,7 @@ mod tests {
             ),
             ..Default::default()
         };
-        assert_eq!(inspect_one(&entry), InspectStatus::Clean);
+        assert_eq!(inspect_one("a1", &entry), InspectStatus::Clean);
     }
 
     #[test]
@@ -954,7 +961,7 @@ mod tests {
             ),
             ..Default::default()
         };
-        assert_eq!(inspect_one(&entry), InspectStatus::BinaryDrift);
+        assert_eq!(inspect_one("a1", &entry), InspectStatus::BinaryDrift);
     }
 
     #[test]
@@ -968,7 +975,7 @@ mod tests {
             // No pin → pre-M9 entry.
             ..Default::default()
         };
-        assert_eq!(inspect_one(&entry), InspectStatus::MissingPin);
+        assert_eq!(inspect_one("a1", &entry), InspectStatus::MissingPin);
     }
 
     #[test]
@@ -980,7 +987,7 @@ mod tests {
             binary_sha256: Some("deadbeef".repeat(8)),
             ..Default::default()
         };
-        assert_eq!(inspect_one(&entry), InspectStatus::BinaryMissing);
+        assert_eq!(inspect_one("a1", &entry), InspectStatus::BinaryMissing);
     }
 
     #[test]

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -1,99 +1,98 @@
 use anyhow::Result;
-// KnowledgeBase removed: was only used by cmd_analyze (now deleted)
-use mur_common::pattern::*;
 
 use crate::store::yaml::YamlStore;
 
+/// `mur stats` — a roll-up of the skill store.
+///
+/// Reported Patterns until workflow-engine v2 removed that pipeline, after
+/// which it printed a wall of zeroes on a machine with 74 skills installed.
+/// Skills are the knowledge object now, so they are what it counts.
 pub(crate) fn cmd_stats() -> Result<()> {
-    use mur_common::knowledge::Maturity;
+    use mur_common::skill::{LifecycleState, SkillStats, local};
 
-    let store = YamlStore::default_store()?;
-    let patterns = store.list_all()?;
+    let home = crate::cmd::agent::resolve_mur_home()?;
+    let names = local::list_installed(&home)?;
+    let total = names.len();
 
-    let total = patterns.len();
-    let mut session_count = 0;
-    let mut project_count = 0;
-    let mut core_count = 0;
-    let mut active_count = 0;
-    let mut deprecated_count = 0;
-    let mut archived_count = 0;
-    let mut draft_count = 0;
-    let mut emerging_count = 0;
-    let mut stable_count = 0;
-    let mut canonical_count = 0;
-    let mut total_importance = 0.0;
-    let mut total_effectiveness = 0.0;
-    let mut tracked_count = 0u64;
-    let mut total_injections = 0u64;
+    // ponytail: 6 counters beat deriving Ord on a shared enum for one report.
+    let mut counts = [0usize; 6];
+    let slot = |st: LifecycleState| match st {
+        LifecycleState::Draft => 0,
+        LifecycleState::Emerging => 1,
+        LifecycleState::Stable => 2,
+        LifecycleState::Canonical => 3,
+        LifecycleState::Deprecated => 4,
+        _ => 5, // Archived and the terminal post-sweep state
+    };
+    let mut runs = 0u64;
+    let mut successes = 0u64;
+    let mut used = 0usize;
+    let mut top: Option<(String, u64)> = None;
 
-    for p in &patterns {
-        match p.tier {
-            Tier::Session => session_count += 1,
-            Tier::Project => project_count += 1,
-            Tier::Core => core_count += 1,
-        }
-        match p.lifecycle.status {
-            LifecycleStatus::Active => active_count += 1,
-            LifecycleStatus::Deprecated => deprecated_count += 1,
-            LifecycleStatus::Archived => archived_count += 1,
-        }
-        match p.maturity {
-            Maturity::Draft => draft_count += 1,
-            Maturity::Emerging => emerging_count += 1,
-            Maturity::Stable => stable_count += 1,
-            Maturity::Canonical => canonical_count += 1,
-        }
-        total_importance += p.importance;
-        total_injections += p.evidence.injection_count;
-        if p.evidence.injection_count > 0 {
-            tracked_count += 1;
-            total_effectiveness += p.evidence.effectiveness();
+    for name in &names {
+        // No stats file = installed but never run, which is exactly Draft.
+        let st = SkillStats::load(&SkillStats::path(&home, name))
+            .ok()
+            .flatten();
+        let Some(st) = st else {
+            counts[slot(LifecycleState::Draft)] += 1;
+            continue;
+        };
+        counts[slot(st.lifecycle_state)] += 1;
+        runs += st.usage_count;
+        successes += st.success_count;
+        if st.usage_count > 0 {
+            used += 1;
+            if top.as_ref().is_none_or(|(_, n)| st.usage_count > *n) {
+                top = Some((name.clone(), st.usage_count));
+            }
         }
     }
 
-    let avg_importance = if total > 0 {
-        total_importance / total as f64
-    } else {
-        0.0
-    };
-    let avg_effectiveness = if tracked_count > 0 {
-        total_effectiveness / tracked_count as f64
-    } else {
-        0.0
+    let pct = |n: usize| {
+        if total > 0 {
+            n as f64 / total as f64 * 100.0
+        } else {
+            0.0
+        }
     };
 
-    println!("📊 MUR Core v2 Statistics");
-    println!("─────────────────────────");
-    println!("Total patterns:     {}", total);
+    println!("📊 MUR Skill Statistics");
+    println!("───────────────────────");
+    println!("Total skills:       {total}");
     println!();
-    println!("By tier:");
-    println!("  📝 Session:       {}", session_count);
-    println!("  📁 Project:       {}", project_count);
-    println!("  ⭐ Core:          {}", core_count);
+    println!("By lifecycle:");
+    // Padding is baked into the labels: `{:<w}` counts chars, and every one of
+    // these emoji is one char that renders two columns wide.
+    for (i, label) in [
+        "📝 Draft          ",
+        "🌱 Emerging       ",
+        "✅ Stable         ",
+        "⭐ Canonical      ",
+        "⚠️ Deprecated     ",
+        "📦 Archived       ",
+    ]
+    .iter()
+    .enumerate()
+    {
+        println!("  {label}{}", counts[i]);
+    }
     println!();
-    println!("By status:");
-    println!("  ✅ Active:        {}", active_count);
-    println!("  ⚠️  Deprecated:    {}", deprecated_count);
-    println!("  📦 Archived:      {}", archived_count);
-    println!();
+    println!("Usage:");
+    println!("  Total runs:       {runs}");
     println!(
-        "By maturity:        Draft: {} | Emerging: {} | Stable: {} | Canonical: {}",
-        draft_count, emerging_count, stable_count, canonical_count
-    );
-    println!();
-    println!("Avg importance:     {:.0}%", avg_importance * 100.0);
-    println!("Total injections:   {}", total_injections);
-    println!(
-        "Tracked patterns:   {} / {} ({:.0}%)",
-        tracked_count,
-        total,
-        if total > 0 {
-            tracked_count as f64 / total as f64 * 100.0
+        "  Success rate:     {:.0}%",
+        if runs > 0 {
+            successes as f64 / runs as f64 * 100.0
         } else {
             0.0
         }
     );
-    println!("Avg effectiveness:  {:.0}%", avg_effectiveness * 100.0);
+    println!("  Ever used:        {used} / {total} ({:.0}%)", pct(used));
+    match top {
+        Some((name, n)) => println!("  Most used:        {name} ({n} runs)"),
+        None => println!("  Most used:        —"),
+    }
 
     Ok(())
 }
@@ -276,23 +275,21 @@ pub(crate) fn cmd_doctor() -> Result<()> {
         println!("❌ MUR directory not found. Run `mur init` first.");
     }
 
-    // Check skills
-    let skills_dir = mur_dir.join("skills");
-    let skill_count = if skills_dir.exists() {
-        std::fs::read_dir(&skills_dir)?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().is_dir())
-            .count()
-    } else {
-        0
-    };
+    // Check skills. Counted through the same helper `mur skill list` uses, so
+    // the two surfaces cannot disagree about what a skill is.
+    let skill_count = mur_common::skill::local::list_installed(&mur_dir)
+        .map(|n| n.len())
+        .unwrap_or(0);
     if skill_count > 0 {
         println!("✅ Skills (installed): {skill_count}");
         if skill_count < 5 {
             println!("  ⚠ Few skills installed. Run `mur skill install <name>` to add more.");
         }
     } else {
-        println!("  ⚠ No skills found in {}", skills_dir.display());
+        println!(
+            "  ⚠ No skills found in {}",
+            mur_dir.join("skills").display()
+        );
     }
 
     // Check LLM config

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -140,7 +140,9 @@ pub async fn run_parallel_jobs(
         max_concurrency,
         ..Default::default()
     };
-    let out = execute_dag(mur_home, "parallel-jobs", &proc, &opts)
+    // `job:` keeps the run ledger out of the skill store — this fan-out is
+    // ephemeral and owns no skill.yaml. See `skill::event_log::event_log_path`.
+    let out = execute_dag(mur_home, "job:parallel-jobs", &proc, &opts)
         .await
         .map_err(|e| anyhow::anyhow!("parallel_jobs run on channel {channel_id} failed: {e}"))?;
     Ok((channel_id, out))


### PR DESCRIPTION
Found by sweeping the read-only path of every top-level `mur` command. Four independent bugs, one shared shape: **the same fact reported two different ways by two different surfaces.**

### 1. `mur stats` counted a subsystem that no longer exists

It still aggregated Patterns, removed by workflow-engine v2. On a machine with 65 skills installed it printed `Total patterns: 0` and every counter zero — a top-level command that was 100% uninformative.

Now counts skills: lifecycle spread, total runs, success rate, ever-used, most-used.

`mur doctor` hand-rolled its own `read_dir` over `~/.mur/skills` rather than calling `list_installed`, which is why it answered **74** where `mur skill list` answered **65**. Both go through the one helper now.

This implements the unchecked Step 2 of `docs/superpowers/plans/2026-05-31-cli-reorganization-plan.md`.

### 2. Fleet runs were ledgered into the skill store — and the cleanup advice was destructive

`mur fleet run` calls the DAG executor with `fleet:<name>` as the ledger key, and `event_log_path` put that under `skills/`. Every fleet that had run owned a manifest-less `~/.mur/skills/fleet:<name>/`, which `mur skill list` then flagged:

```
fleet:builder  [Sandboxed]  ⚠ invalid: no readable manifest (run `mur skill remove fleet:builder`)
```

Following that advice deletes the fleet's own run history. Nine such directories on the reporting machine.

Ledgers now go to `~/.mur/fleets/<name>/events.jsonl`, beside the `fleet.yaml` they belong to. `list_installed` skips the directories the old path created — skipping rather than migrating, because nothing reads them and a migration would be more code than the bug.

Two latent effects fall out of the same root, since `fleet:` entries reached every `list_installed` consumer: `fleet export` scoped them in as skills, and `skill sweep` scored them against the skill lifecycle.

### 3. Every MCP drift hint was un-pasteable

```
$ mur agent mcp inspect dr_worker_1 --server research-gateway
  status: BINARY DRIFT
  hint:   `mur agent mcp pin research-gateway` …

$ mur agent mcp pin research-gateway
error: the following required arguments were not provided: <SERVER_ID>   # exit 2
```

`pin` / `remove` / `vendor` all take `<NAME> <SERVER_ID>`; `inspect` takes `<NAME> --server <id>`. `mur doctor` printed the correct form all along.

The runtime's rule-6 refusal had the same defect, and that one matters most — it is the only instruction a bricked agent's owner ever sees, and it named a command that cannot run. It has the profile in hand, so no signature change; the inspect path threads the agent name it already resolved.

### 4. `parallel_jobs` had the same ledger bug, and deleting it did not stick

Surfaced by the reporter noticing `parallel-jobs` still listed as an invalid skill after the fleet directories were dealt with. `executor/jobs.rs` passed the bare key `parallel-jobs` to `execute_dag`, so every fan-out recreated `~/.mur/skills/parallel-jobs/` — deleting it only bought one run's peace.

The key is now `job:parallel-jobs`, routed to `~/.mur/jobs/<name>/`. Deliberately **not** `~/.mur/runs/`: that store is keyed by run_id (`runs/<run_id>/run.json`), so a name dropped in there would be the same category error one directory over. A test asserts `runs/` stays untouched.

No list filter for the legacy bare directory, unlike the `fleet:` case — there the directory held a fleet's own run history and `mur skill remove` was destructive advice; here it is an ephemeral fan-out log nothing reads, so removing it is exactly right and the entry can stay visible.

## Verification

- `mur-core` 5575 passed · `mur-common` 954 passed · `mur-agent-runtime` suites green
- clippy `--all-targets -D warnings` clean, `cargo fmt` clean
- Four new regression tests, each **mutation-verified**: removing the fix makes the test FAIL, restoring it makes it PASS
- Run against a real `~/.mur`: doctor 74 → 65, `skill list` shows zero `fleet:` entries (the genuinely broken skills still surface, correctly), and the hint now reads `mur agent mcp pin dr_worker_1 research-gateway`
- `mur stats`' all-zero output was cross-checked against disk — all 49 `stats.json` really are `draft` / `usage_count: 0`, so it is reporting truth, not a new lie

No user-facing docs reference `mur stats`, so the docs checklist has nothing to update here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)