### PR TITLE
fix(hub): localise the Home inbox card strings

### DIFF
--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -818,7 +818,9 @@ async fn execute_step(
                 .unwrap_or_else(|| "intent".into()),
             tool_input: input.clone(),
             step_or_call_id: sid.clone(),
-            agent_id: "mur".into(),
+            // The gate is only reached on the LOCAL path — delegate steps return
+            // above — so the asker is the router itself, not the step's agent.
+            agent_id: ROUTER_AGENT.into(),
             summary: step.description.clone(),
         };
         let decision = crate::hitl::gate::gate(

--- a/mur-hub-gui/ui/src/components/home/useInbox.ts
+++ b/mur-hub-gui/ui/src/components/home/useInbox.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useAgents } from "../../context/AgentContext";
+import { translate, useT } from "../../i18n";
 import { mergeInbox, type InboxItem } from "./inbox";
 
 const POLL_INTERVAL_MS = 30_000;
@@ -57,7 +58,7 @@ function parseTs(value: unknown): number | null {
 }
 
 /** Pure adapter: `RawHitl` -> `InboxItem`. Returns null on malformed input (fail-open). */
-export function hitlToItem(raw: RawHitl): InboxItem | null {
+export function hitlToItem(raw: RawHitl, lang: string): InboxItem | null {
   if (!raw || typeof raw !== "object") return null;
   const { channel_id, hitl_id, agent, summary, risk, ts } = raw;
   if (
@@ -77,14 +78,14 @@ export function hitlToItem(raw: RawHitl): InboxItem | null {
     kind: "hitl",
     id: `${channel_id}:${hitl_id}`,
     ts: tsValue,
-    title: `${agent}: approval needed`,
-    subtitle: summary || `Risk: ${risk}`,
+    title: translate(lang, "home.inbox.hitlTitle", { agent }),
+    subtitle: summary || translate(lang, "home.inbox.hitlRisk", { risk }),
     payload: raw,
   };
 }
 
 /** Pure adapter: `RawInstall` -> `InboxItem`. Returns null on malformed input (fail-open). */
-export function installToItem(raw: RawInstall): InboxItem | null {
+export function installToItem(raw: RawInstall, lang: string): InboxItem | null {
   if (!raw || typeof raw !== "object") return null;
   const { install_type, id, publisher, requested_at } = raw;
   if (
@@ -101,14 +102,14 @@ export function installToItem(raw: RawInstall): InboxItem | null {
     kind: "install",
     id,
     ts: tsValue,
-    title: `Install request: ${install_type}`,
-    subtitle: `From ${publisher}`,
+    title: translate(lang, "home.inbox.installTitle", { type: install_type }),
+    subtitle: translate(lang, "home.inbox.installFrom", { publisher }),
     payload: raw,
   };
 }
 
 /** Pure adapter: `RawCompanionEvent` -> `InboxItem`. Returns null on malformed input (fail-open). */
-export function companionToItem(raw: RawCompanionEvent): InboxItem | null {
+export function companionToItem(raw: RawCompanionEvent, lang: string): InboxItem | null {
   if (!raw || typeof raw !== "object") return null;
   const { id, situation, body, generated_at } = raw;
   if (typeof id !== "string" || !id || typeof body !== "string") return null;
@@ -118,14 +119,17 @@ export function companionToItem(raw: RawCompanionEvent): InboxItem | null {
     kind: "companion",
     id,
     ts: tsValue,
-    title: situation && typeof situation === "string" ? situation : "MUR companion message",
+    title:
+      situation && typeof situation === "string"
+        ? situation
+        : translate(lang, "home.inbox.companionTitle"),
     subtitle: body,
     payload: raw,
   };
 }
 
 /** Pure adapter: `RawBlockedItem` -> `InboxItem`. Returns null on malformed input (fail-open). */
-export function blockedToItem(raw: RawBlockedItem): InboxItem | null {
+export function blockedToItem(raw: RawBlockedItem, lang: string): InboxItem | null {
   if (!raw || typeof raw !== "object") return null;
   const { name, local_version, latest_version } = raw;
   if (
@@ -140,8 +144,11 @@ export function blockedToItem(raw: RawBlockedItem): InboxItem | null {
     kind: "upgrade_blocked",
     id: name,
     ts: 0,
-    title: `Skill "${name}" upgrade blocked`,
-    subtitle: `Local ${local_version} modified; latest is ${latest_version}`,
+    title: translate(lang, "home.inbox.upgradeTitle", { name }),
+    subtitle: translate(lang, "home.inbox.upgradeSubtitle", {
+      local: local_version,
+      latest: latest_version,
+    }),
     payload: raw,
   };
 }
@@ -158,6 +165,7 @@ function filterNulls<T>(items: (T | null)[]): T[] {
  */
 export function useInbox(): { items: InboxItem[]; refresh: () => void } {
   const { agents } = useAgents();
+  const { lang } = useT();
   const [hitlItems, setHitlItems] = useState<InboxItem[]>([]);
   const [installItems, setInstallItems] = useState<InboxItem[]>([]);
   const [companionItems, setCompanionItems] = useState<InboxItem[]>([]);
@@ -167,15 +175,15 @@ export function useInbox(): { items: InboxItem[]; refresh: () => void } {
 
   const refreshHitl = useCallback(() => {
     invoke<RawHitl[]>("hitl_pending_list")
-      .then((raw) => setHitlItems(filterNulls(raw.map(hitlToItem))))
+      .then((raw) => setHitlItems(filterNulls(raw.map((r) => hitlToItem(r, lang)))))
       .catch(() => {});
-  }, []);
+  }, [lang]);
 
   const refreshInstall = useCallback(() => {
     invoke<RawInstall[]>("install_inbox_list")
-      .then((raw) => setInstallItems(filterNulls(raw.map(installToItem))))
+      .then((raw) => setInstallItems(filterNulls(raw.map((r) => installToItem(r, lang)))))
       .catch(() => {});
-  }, []);
+  }, [lang]);
 
   const refreshCompanion = useCallback(() => {
     Promise.all(
@@ -183,15 +191,17 @@ export function useInbox(): { items: InboxItem[]; refresh: () => void } {
         invoke<RawCompanionEvent[]>("companion_bridge_pending", { agent }).catch(() => []),
       ),
     )
-      .then((perAgent) => setCompanionItems(filterNulls(perAgent.flat().map(companionToItem))))
+      .then((perAgent) =>
+        setCompanionItems(filterNulls(perAgent.flat().map((r) => companionToItem(r, lang)))),
+      )
       .catch(() => {});
-  }, []);
+  }, [lang]);
 
   const refreshBlocked = useCallback(() => {
     invoke<RawBlockedItem[]>("skill_upgrade_status")
-      .then((raw) => setBlockedItems(filterNulls(raw.map(blockedToItem))))
+      .then((raw) => setBlockedItems(filterNulls(raw.map((r) => blockedToItem(r, lang)))))
       .catch(() => {});
-  }, []);
+  }, [lang]);
 
   const refresh = useCallback(() => {
     refreshHitl();
@@ -201,8 +211,7 @@ export function useInbox(): { items: InboxItem[]; refresh: () => void } {
   }, [refreshHitl, refreshInstall, refreshCompanion, refreshBlocked]);
 
   useEffect(() => {
-    refresh();
-
+    // No initial refresh() here — the [lang] effect below covers mount too.
     const unlistenHitl = listen("hitl-approval-needed", () => refreshHitl());
     const interval = setInterval(() => {
       refreshInstall();
@@ -213,8 +222,16 @@ export function useInbox(): { items: InboxItem[]; refresh: () => void } {
       unlistenHitl.then((fn) => fn()).catch(() => {});
       clearInterval(interval);
     };
+    // Re-subscribe on a language switch: the listener and the interval close
+    // over the refresh callbacks, which bake `lang` into the card strings. With
+    // `[]` the poll would keep restoring the pre-switch language.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [lang]);
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lang]);
 
   const agentIdentityKey = agents
     .map((a) => a.name)

--- a/mur-hub-gui/ui/src/components/home/useInboxAdapters.test.ts
+++ b/mur-hub-gui/ui/src/components/home/useInboxAdapters.test.ts
@@ -21,7 +21,7 @@ describe("hitlToItem", () => {
   };
 
   it("maps a valid record", () => {
-    const item = hitlToItem(valid);
+    const item = hitlToItem(valid, "en");
     expect(item).not.toBeNull();
     expect(item?.kind).toBe("hitl");
     expect(item?.id).toBe("chan-1:hitl-1");
@@ -29,10 +29,19 @@ describe("hitlToItem", () => {
     expect(item?.title).toContain("quill");
   });
 
+  it("localises the title", () => {
+    expect(hitlToItem(valid, "zh-TW")?.title).toBe("quill：需要核准");
+  });
+
+  it("falls back to the risk tier when there is no summary", () => {
+    const item = hitlToItem({ ...valid, summary: "" }, "en");
+    expect(item?.subtitle).toBe("Risk: write");
+  });
+
   it("returns null for a malformed record", () => {
-    expect(hitlToItem({} as RawHitl)).toBeNull();
-    expect(hitlToItem(null as unknown as RawHitl)).toBeNull();
-    expect(hitlToItem({ ...valid, hitl_id: undefined } as unknown as RawHitl)).toBeNull();
+    expect(hitlToItem({} as RawHitl, "en")).toBeNull();
+    expect(hitlToItem(null as unknown as RawHitl, "en")).toBeNull();
+    expect(hitlToItem({ ...valid, hitl_id: undefined } as unknown as RawHitl, "en")).toBeNull();
   });
 });
 
@@ -47,7 +56,7 @@ describe("installToItem", () => {
   };
 
   it("maps a valid record", () => {
-    const item = installToItem(valid);
+    const item = installToItem(valid, "en");
     expect(item).not.toBeNull();
     expect(item?.kind).toBe("install");
     expect(item?.id).toBe("req-1");
@@ -56,9 +65,9 @@ describe("installToItem", () => {
   });
 
   it("returns null for a malformed record", () => {
-    expect(installToItem({} as RawInstall)).toBeNull();
-    expect(installToItem(undefined as unknown as RawInstall)).toBeNull();
-    expect(installToItem({ ...valid, id: 5 } as unknown as RawInstall)).toBeNull();
+    expect(installToItem({} as RawInstall, "en")).toBeNull();
+    expect(installToItem(undefined as unknown as RawInstall, "en")).toBeNull();
+    expect(installToItem({ ...valid, id: 5 } as unknown as RawInstall, "en")).toBeNull();
   });
 });
 
@@ -74,7 +83,7 @@ describe("companionToItem", () => {
   };
 
   it("maps a valid record", () => {
-    const item = companionToItem(valid);
+    const item = companionToItem(valid, "en");
     expect(item).not.toBeNull();
     expect(item?.kind).toBe("companion");
     expect(item?.id).toBe("evt-1");
@@ -83,10 +92,10 @@ describe("companionToItem", () => {
   });
 
   it("returns null for a malformed record", () => {
-    expect(companionToItem({} as RawCompanionEvent)).toBeNull();
-    expect(companionToItem(null as unknown as RawCompanionEvent)).toBeNull();
+    expect(companionToItem({} as RawCompanionEvent, "en")).toBeNull();
+    expect(companionToItem(null as unknown as RawCompanionEvent, "en")).toBeNull();
     expect(
-      companionToItem({ ...valid, generated_at: "not-a-date" } as RawCompanionEvent),
+      companionToItem({ ...valid, generated_at: "not-a-date" } as RawCompanionEvent, "en"),
     ).toBeNull();
   });
 });
@@ -100,7 +109,7 @@ describe("blockedToItem", () => {
   };
 
   it("maps a valid record", () => {
-    const item = blockedToItem(valid);
+    const item = blockedToItem(valid, "en");
     expect(item).not.toBeNull();
     expect(item?.kind).toBe("upgrade_blocked");
     expect(item?.id).toBe("my-skill");
@@ -108,8 +117,8 @@ describe("blockedToItem", () => {
   });
 
   it("returns null for a malformed record", () => {
-    expect(blockedToItem({} as RawBlockedItem)).toBeNull();
-    expect(blockedToItem(undefined as unknown as RawBlockedItem)).toBeNull();
-    expect(blockedToItem({ ...valid, name: "" } as RawBlockedItem)).toBeNull();
+    expect(blockedToItem({} as RawBlockedItem, "en")).toBeNull();
+    expect(blockedToItem(undefined as unknown as RawBlockedItem, "en")).toBeNull();
+    expect(blockedToItem({ ...valid, name: "" } as RawBlockedItem, "en")).toBeNull();
   });
 });

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -804,4 +804,11 @@ export const en = {
   "home.upgrade.dismiss": "Dismiss",
   "home.hitl.approve": "Approve",
   "home.hitl.deny": "Deny",
+  "home.inbox.hitlTitle": "{agent}: approval needed",
+  "home.inbox.hitlRisk": "Risk: {risk}",
+  "home.inbox.installTitle": "Install request: {type}",
+  "home.inbox.installFrom": "From {publisher}",
+  "home.inbox.companionTitle": "MUR companion message",
+  "home.inbox.upgradeTitle": "Skill \"{name}\" upgrade blocked",
+  "home.inbox.upgradeSubtitle": "Local {local} modified; latest is {latest}",
 } as const;

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -806,4 +806,11 @@ export const zhTW: Table = {
   "home.upgrade.dismiss": "忽略",
   "home.hitl.approve": "核准",
   "home.hitl.deny": "拒絕",
+  "home.inbox.hitlTitle": "{agent}：需要核准",
+  "home.inbox.hitlRisk": "風險等級：{risk}",
+  "home.inbox.installTitle": "安裝請求：{type}",
+  "home.inbox.installFrom": "來自 {publisher}",
+  "home.inbox.companionTitle": "MUR 夥伴訊息",
+  "home.inbox.upgradeTitle": "技能「{name}」無法升級",
+  "home.inbox.upgradeSubtitle": "本機 {local} 已修改；最新版是 {latest}",
 };


### PR DESCRIPTION
## Problem

The "Needs you" section's chrome goes through i18n, but the cards inside it did not. Every adapter in `useInbox.ts` built its title and subtitle as a hardcoded English template literal, so a zh-TW Hub rendered `mur: approval needed` under `需要你處理`.
Seven strings were affected: the HITL title and its risk fallback, the install title and publisher line, the companion default title, and the blocked-upgrade title and subtitle.

## Change

- Seven `home.inbox.*` keys added to both translation tables.
- `lang` threaded into the four pure adapters; they call `translate()` instead of interpolating English.
- `dag.rs`: the duplicated `"mur"` literal swapped for the `ROUTER_AGENT` constant the file already imports (CLAUDE.md rule 1). Same value — and the correct one: delegate steps `return` above the gate, so only the router's own local steps reach it.

### Why the effect deps changed

`lang` is a plain string that only changes on a language switch, so the refresh callbacks can depend on it without per-render churn. But the `hitl-approval-needed` listener and the 30s poll interval close over those callbacks, which bake `lang` into the card strings — left at `[]`, the next poll would restore the pre-switch language. Both now re-subscribe on `lang`. The mount effect's initial `refresh()` moved into the `[lang]` effect so mount still fetches exactly once.

## What this does NOT fix

A HITL card's subtitle is the workflow step's own `description:` — `dag.rs` sets `summary: step.description.clone()`. That is author text, not UI copy, and no translation table can reach it. A step written in English stays English in a zh-TW Hub.

## Verification

- `npm test` — 22 files, 185 passed
- Negative control on the new i18n test: flipping the expected zh string to the old English one fails with `expected 'quill：需要核准' to be 'quill: approval needed'` — the test bites.
- `npx tsc --noEmit` clean; `eslint` clean on the changed files (the 6 repo-wide warnings are pre-existing, in `PanelWindow.tsx` / `WizardModal.tsx`)
- `cargo check -p mur-core` and `cargo fmt --check -p mur-core` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
