### PR TITLE
fix(agent): `remove --purge` was leaving the private key behind

### DIFF
--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -975,8 +975,9 @@ pub fn cmd_remove(name: &str, purge: bool, force: bool) -> Result<()> {
     }
 
     if purge {
-        fs::remove_dir_all(&agent_home)
-            .with_context(|| format!("remove_dir_all {}", agent_home.display()))?;
+        if let Some(key_dir) = purge_agent_state(&agent_home)? {
+            println!("Removed private key {}", key_dir.display());
+        }
         println!("Purged agent '{name}'");
     } else {
         println!(
@@ -985,6 +986,36 @@ pub fn cmd_remove(name: &str, purge: bool, force: bool) -> Result<()> {
         );
     }
     Ok(())
+}
+
+/// Remove everything `--purge` promises: the agent home **and** the private key
+/// that has lived outside it since #850 option (c) moved keys to
+/// `<mur_home>/keys/<name>/`. Returns the key directory removed, if any, so the
+/// caller can report it.
+///
+/// Removing only the agent home is what this fixes: `--purge` says it deletes
+/// the agent's data, but a 32-byte Ed25519 private key kept outliving its
+/// agent. Those orphans are invisible — nothing enumerates them — and they
+/// accumulate silently, one per purge.
+///
+/// The key goes FIRST on purpose. If it fails the agent home is still intact
+/// and the command can be retried; the reverse order fails into exactly the
+/// state being fixed — a key with no agent to own it.
+fn purge_agent_state(agent_home: &Path) -> Result<Option<PathBuf>> {
+    // `private_key_dir` returns its argument unchanged for directories that are
+    // not an agent home (commander, publisher, the host key). Comparing guards
+    // against deleting the agent home twice in that case.
+    let key_dir = mur_common::identity::private_key_dir(agent_home);
+    let removed = if key_dir != agent_home && key_dir.is_dir() {
+        fs::remove_dir_all(&key_dir)
+            .with_context(|| format!("remove_dir_all {}", key_dir.display()))?;
+        Some(key_dir)
+    } else {
+        None
+    };
+    fs::remove_dir_all(agent_home)
+        .with_context(|| format!("remove_dir_all {}", agent_home.display()))?;
+    Ok(removed)
 }
 
 pub fn cmd_rename(old: &str, new: &str) -> Result<()> {
@@ -1227,6 +1258,56 @@ mod tests_remove_unread_guard {
         write_inbox_unread(tmp.path(), "msg-002");
         write_inbox_acked(tmp.path(), "msg-003");
         assert_eq!(count_unread_companion_inbox(tmp.path()), 2);
+    }
+}
+
+#[cfg(test)]
+mod tests_purge_removes_private_key {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// The regression: `--purge` deleted the agent home and left
+    /// `<mur_home>/keys/<name>/identity.key` behind. Nothing enumerates that
+    /// tree, so the orphans were only found by counting `keys/` against
+    /// `agents/` by hand.
+    #[test]
+    fn purge_removes_the_key_that_lives_outside_the_agent_home() {
+        let tmp = TempDir::new().unwrap();
+        let agent_home = tmp.path().join("agents").join("gone");
+        let key_dir = tmp.path().join("keys").join("gone");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        std::fs::create_dir_all(&key_dir).unwrap();
+        std::fs::write(key_dir.join("identity.key"), b"not-a-real-key").unwrap();
+
+        let removed = purge_agent_state(&agent_home).unwrap();
+
+        assert_eq!(removed.as_deref(), Some(key_dir.as_path()));
+        assert!(!agent_home.exists(), "agent home survived the purge");
+        assert!(!key_dir.exists(), "private key outlived its agent");
+    }
+
+    /// An agent whose key was never created must still purge cleanly rather
+    /// than failing on a missing directory.
+    #[test]
+    fn purge_succeeds_when_the_agent_never_had_a_key() {
+        let tmp = TempDir::new().unwrap();
+        let agent_home = tmp.path().join("agents").join("keyless");
+        std::fs::create_dir_all(&agent_home).unwrap();
+
+        assert!(purge_agent_state(&agent_home).unwrap().is_none());
+        assert!(!agent_home.exists());
+    }
+
+    /// A directory that is not under `agents/` maps to itself, and must not be
+    /// removed twice — `private_key_dir` deliberately passes those through.
+    #[test]
+    fn purge_does_not_double_remove_a_non_agent_directory() {
+        let tmp = TempDir::new().unwrap();
+        let stray = tmp.path().join("commander");
+        std::fs::create_dir_all(&stray).unwrap();
+
+        assert!(purge_agent_state(&stray).unwrap().is_none());
+        assert!(!stray.exists());
     }
 }
 


### PR DESCRIPTION
`--purge` documents itself as *"Also delete the agent's data directory"*, and it did exactly that — the agent home and nothing else. Since #850 option (c) moved private keys out of the agents tree to `<mur_home>/keys/<name>/`, **every purge has orphaned a 32-byte Ed25519 private key.**

## How it surfaced

Cleaning up four dead deep-research workers. `mur agent remove --purge` reported success for all four — agent homes gone, launchd plists gone, `launchctl` entries gone, runtime symlinks gone. But:

```
~/.mur/keys/dr_worker_1   ~/.mur/keys/dr_worker_2
~/.mur/keys/dr_worker_3   ~/.mur/keys/dr_worker_4
```

A fifth orphan, `skilltest_tmp`, predated that cleanup by a day — so this leaks **once per purge**, not just in one session. Nothing enumerates that tree, which is why it went unnoticed: the only way to see it is to count `keys/` against `agents/` by hand.

## The fix

Extracted the deletion into `purge_agent_state`, which removes the key directory and then the agent home.

**The key goes first deliberately.** If it fails, the agent home is still intact and the command can be retried; the reverse order fails into exactly the state being fixed — a key with no agent to own it.

Reuses `mur_common::identity::private_key_dir` rather than rebuilding the path, so there is still one definition of where keys live. That helper returns its argument unchanged for directories that are *not* an agent home (commander, publisher, the host key), so the equality check keeps those from being removed twice.

## Verification

| Test | Covers |
|---|---|
| `purge_removes_the_key_that_lives_outside_the_agent_home` | the regression |
| `purge_succeeds_when_the_agent_never_had_a_key` | missing key dir must not fail the purge |
| `purge_does_not_double_remove_a_non_agent_directory` | the `private_key_dir` passthrough case |

The two pre-existing `agent_lifecycle` integration tests (`remove_purge_deletes_dir`, `remove_deletes_symlink_but_keeps_dir_without_purge`) still pass.

**Negative control:** disabling the key removal fails the first test on exactly the assertion that should catch it —

```
assertion `left == right` failed
  left: None
 right: Some(".../keys/gone")
```

— so the test would have caught the original bug rather than merely describing it.

`cargo clippy -p mur-core --all-targets --locked -- -D warnings` and `cargo fmt --check` both exit 0.

## Note for existing installs

This fixes future purges; it does not sweep up orphans already on disk. Anyone can find theirs by comparing the two directories:

```sh
for k in ~/.mur/keys/*/; do n=$(basename "$k"); [ -d ~/.mur/agents/"$n" ] || echo "orphan: $n"; done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)