### PR TITLE
chore(release): bump workspace version to 2.71.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.2"
+version = "2.71.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.2"
+version = "2.71.3"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
> **Merging this PR IS the release.** `tag.yml` tags the merge commit as `v2.71.3` and dispatches `release.yml` automatically — there is no later gate, and the crates.io publish is irreversible (yank-only).

## What ships

Three fixes, all of them cases where a surface disagreed with what was actually on disk.

| PR | Change |
|---|---|
| #1045 | Four CLI surfaces that disagreed with reality — `mur stats` and `doctor` count skills the same way, every MCP drift hint is runnable exactly as printed, and the `parallel_jobs` ledger stays out of the skill store. |
| #1046 | The Hub's Home inbox card strings are localised. |
| #1047 | `mur agent remove --purge` was leaving the agent's private key behind. |

## On #1047

Since #850 moved private keys to `<mur_home>/keys/<name>/`, **every purge orphaned a 32-byte Ed25519 key** — and nothing enumerates that tree, so nothing ever noticed. Found by counting `keys/` against `agents/` by hand after removing four dead deep-research workers; a fifth orphan from the previous day proved it had been leaking longer than one session.

**This fixes future purges only.** Orphans already on disk are not swept up. Existing installs can list theirs with:

```sh
for k in ~/.mur/keys/*/; do n=$(basename "$k"); [ -d ~/.mur/agents/"$n" ] || echo "orphan: $n"; done
```

## Checks done before opening

- Both lock files moved with the version — the root one and `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace crate's version and breaks the Hub build when it disagrees. `2.71.3` appears 12 and 6 times respectively; **0** occurrences of `2.71.2` remain in either.
- `validate-version` simulated locally with the job's own extraction command: `CARGO_VERSION = 2.71.3`, matching the `v2.71.3` tag it will be checked against.

## Carried forward from v2.71.2

That release was the first whose archive actually contained `mur-research-gateway`, verified against the real artifact: five binaries in both the tarball and the Windows zip, all five carrying a Developer ID signature with the hardened-runtime flag, sha256 agreeing across the download, the Homebrew formula and `checksums.txt`. The guard added in #1043 keeps that set pinned to `update::resign::SIGN_TARGETS` on every PR, so this release inherits that check rather than re-proving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)