### PR TITLE
fix(agent): saved memories never reached the prompt

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/memory_reload.rs
+++ b/mur-agent-runtime/src/protocol/methods/memory_reload.rs
@@ -1,0 +1,44 @@
+//! A2A method: `memory/reload` — rebuild the live skill/memory set from disk.
+//!
+//! The out-of-process half of the one reload mechanism. `remember` calls
+//! [`RuntimeSkills::reload`] directly because it runs inside this process;
+//! murmur's `/remember` and `/forget` run in the CLI process and dial this
+//! instead. Same function, two callers — deliberately not two reload paths,
+//! which is how the two halves of a fact start disagreeing.
+//!
+//! Modelled on `model/set`: the CLI changes state on disk, then tells the
+//! running agent, rather than either side polling or watching.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
+use crate::skills::RuntimeSkills;
+
+pub struct MemoryReloadHandler {
+    skills: Arc<RuntimeSkills>,
+}
+
+impl MemoryReloadHandler {
+    pub fn new(skills: Arc<RuntimeSkills>) -> Self {
+        Self { skills }
+    }
+}
+
+#[async_trait]
+impl MethodHandler for MemoryReloadHandler {
+    async fn handle(
+        &self,
+        _params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
+        let count = self
+            .skills
+            .reload()
+            .map_err(|e| HandlerError::Internal(format!("reload skills: {e:#}")))?;
+        tracing::info!(count, "memory/reload: live skill set rebuilt");
+        Ok(json!({ "skills": count, "effective": "next-turn" }))
+    }
+}

--- a/mur-agent-runtime/src/protocol/methods/mod.rs
+++ b/mur-agent-runtime/src/protocol/methods/mod.rs
@@ -1,6 +1,7 @@
 //! A2A method handlers.
 pub mod card;
 pub mod channel_delegate;
+pub mod memory_reload;
 pub mod message_send;
 pub mod model_set;
 pub mod skills;

--- a/mur-agent-runtime/src/skills/injector.rs
+++ b/mur-agent-runtime/src/skills/injector.rs
@@ -1,7 +1,7 @@
-use mur_common::config::SkillsConfig;
+use mur_common::config::{MemoryConfig, SkillsConfig};
 use mur_common::skill::TriggerKind;
 use mur_common::skill::loader::LoadedSkill;
-use mur_common::skill::types::{HostId, Priority};
+use mur_common::skill::types::{Category, HostId, Priority};
 use std::collections::HashSet;
 
 fn priority_val(p: &Priority) -> u8 {
@@ -20,9 +20,15 @@ pub struct InjectionResult {
     pub budget_skipped: bool,
 }
 
+// ponytail: 8 args, one over clippy's threshold. The honest fix is bundling
+// `active_fleet`/`active_project`/`active_team` into one `Scope` struct — they
+// always travel together — but that is mechanical churn across every call site
+// and belongs in its own commit, not this bug fix.
+#[allow(clippy::too_many_arguments)]
 pub fn inject_layer2(
     skills: &[LoadedSkill],
     cfg: &SkillsConfig,
+    mem: &MemoryConfig,
     context_fill_ratio: f64,
     recently_fired: &HashSet<String>,
     active_fleet: Option<&str>,
@@ -40,8 +46,9 @@ pub fn inject_layer2(
         }
     }
 
-    // Filter: must have at least one `SessionStart` trigger.
-    let mut candidates: Vec<&LoadedSkill> = skills
+    // Host + scope + not-on-demand. Split below into memories (always-on) and
+    // trigger-gated skills.
+    let visible: Vec<&LoadedSkill> = skills
         .iter()
         .filter(|s| {
             s.manifest.hosts.is_empty()
@@ -49,12 +56,6 @@ pub fn inject_layer2(
                     .hosts
                     .iter()
                     .any(|h| matches!(h, HostId::All | HostId::MurAgent))
-        })
-        .filter(|s| {
-            s.manifest
-                .triggers
-                .iter()
-                .any(|t| matches!(t.kind, TriggerKind::SessionStart))
         })
         // Scope: fleet/project-scoped skills inject only when the active scope
         // matches (fail-closed); user/enterprise always pass. active_project is
@@ -72,6 +73,35 @@ pub fn inject_layer2(
             )
         })
         .filter(|s| s.manifest.visibility != mur_common::skill::manifest::Visibility::OnDemand)
+        .collect();
+
+    // Memories (`Category::Note`, written by the `remember` tool, `/remember`
+    // and `mur notes create`) are always-on: the user stated them outright, so
+    // they carry no `SessionStart` trigger and must not compete for skill
+    // slots. Without this split they were written to disk and never reached a
+    // prompt — the agent ignored its own saved rules and reported an empty
+    // memory when asked.
+    // ponytail: capped by max_skills_in_prompt, same as skills; give notes
+    // their own config knob only if a real memory list starves.
+    let mut notes: Vec<&LoadedSkill> = visible
+        .iter()
+        .copied()
+        .filter(|s| s.manifest.category == Category::Note)
+        .collect();
+    notes.sort_by(|a, b| a.name.cmp(&b.name));
+    let mut mem_dropped = notes.len().saturating_sub(mem.max_in_prompt);
+    notes.truncate(mem.max_in_prompt);
+
+    // Filter: must have at least one `SessionStart` trigger.
+    let mut candidates: Vec<&LoadedSkill> = visible
+        .into_iter()
+        .filter(|s| s.manifest.category != Category::Note)
+        .filter(|s| {
+            s.manifest
+                .triggers
+                .iter()
+                .any(|t| matches!(t.kind, TriggerKind::SessionStart))
+        })
         .collect();
 
     // Sort: trust desc, recent-fired boost, then priority asc, then name for determinism.
@@ -104,8 +134,38 @@ pub fn inject_layer2(
         .max(100);
 
     let mut spent = 0usize;
-    let mut lines = Vec::new();
     let mut names = Vec::new();
+
+    // Memories draw on their OWN character budget. Sharing the skill budget
+    // would mean saving a memory silently evicts a bound skill.
+    let mut mem_spent = 0usize;
+    let mut mem_lines = Vec::new();
+    for s in notes {
+        let body = s
+            .manifest
+            .content
+            .note
+            .as_deref()
+            .unwrap_or(&s.manifest.content.r#abstract);
+        let line = format!("- {}: {}", s.name, body.trim());
+        if mem_spent + line.len() + 1 > mem.max_chars {
+            mem_dropped += 1;
+            continue;
+        }
+        mem_spent += line.len() + 1;
+        mem_lines.push(line);
+        names.push(s.name.clone());
+    }
+    // No silent caps: a memory the user saved and cannot see in the prompt is
+    // indistinguishable from one that was never saved.
+    if mem_dropped > 0 {
+        mem_lines.push(format!(
+            "- ({mem_dropped} more memories not shown here — the user can list \
+             them all with /memories)"
+        ));
+    }
+
+    let mut lines = Vec::new();
     for s in candidates {
         let line = format!(
             "[Skill: {} ({:?})] {}",
@@ -120,11 +180,29 @@ pub fn inject_layer2(
         lines.push(line);
         names.push(s.name.clone());
     }
-    if lines.is_empty() {
+    if lines.is_empty() && mem_lines.is_empty() {
         return InjectionResult::default();
     }
+    let mut system_addendum = String::new();
+    if !lines.is_empty() {
+        system_addendum.push_str(&format!(
+            "\n--- Bound Skills ---\n{}\n---\n",
+            lines.join("\n")
+        ));
+    }
+    // Memory goes LAST, for two independent reasons that agree: standing user
+    // instructions win the recency end of a long prompt, and a block that
+    // changes when a memory is saved invalidates less of the cached prefix
+    // sitting in front of it.
+    if !mem_lines.is_empty() {
+        system_addendum.push_str(&format!(
+            "\n--- Memory (durable facts and rules you saved for this user; \
+             /memories lists them, /forget <name> removes one) ---\n{}\n---\n",
+            mem_lines.join("\n")
+        ));
+    }
     InjectionResult {
-        system_addendum: format!("\n--- Bound Skills ---\n{}\n---\n", lines.join("\n")),
+        system_addendum,
         injected_names: names,
         budget_skipped: false,
     }
@@ -133,6 +211,62 @@ pub fn inject_layer2(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The exact artifact the `remember` tool writes — built by the production
+    /// note builder, not a hand-rolled yaml — must reach the prompt even though
+    /// notes carry no `SessionStart` trigger. Negative control: an ordinary
+    /// trigger-less skill still stays out.
+    #[test]
+    fn memory_notes_inject_without_a_session_start_trigger() {
+        use mur_common::skill::note::{NoteSpec, note_manifest};
+
+        let note = LoadedSkill {
+            name: "reply-in-zh-tw".into(),
+            manifest: note_manifest(&NoteSpec {
+                name: "reply-in-zh-tw",
+                description: "使用者要求一律以繁體中文回覆",
+                body: "以後所有回覆都用繁體中文。",
+                kind: mur_common::skill::lifecycle::NoteKind::Rule,
+                publisher: "agent:mur",
+            }),
+            // Reality check: a `remember`-written note is never in the trust
+            // store, so the loader gives it Sandboxed. Asserting on Verified
+            // would have tested a state that never occurs.
+            trust: TrustLevel::Sandboxed,
+            scope: SkillScope::Agent,
+            content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
+        };
+        assert!(
+            note.manifest.triggers.is_empty(),
+            "precondition: the real note artifact has no triggers"
+        );
+        let untriggered_skill = loaded("plain", "not a memory", TrustLevel::Verified, "");
+
+        let r = inject_layer2(
+            &[note, untriggered_skill],
+            &SkillsConfig::default(),
+            &MemoryConfig::default(),
+            0.0,
+            &HashSet::new(),
+            None,
+            None,
+            None,
+        );
+        assert!(
+            r.system_addendum.contains("以後所有回覆都用繁體中文"),
+            "memory body must be injected, got: {}",
+            r.system_addendum
+        );
+        assert!(
+            r.injected_names.contains(&"reply-in-zh-tw".to_string()),
+            "memory must be reported as injected"
+        );
+        assert!(
+            !r.injected_names.contains(&"plain".to_string()),
+            "negative control: a trigger-less non-note skill must stay out"
+        );
+    }
     use mur_common::skill::loader::SkillScope;
     use mur_common::skill::parse_canonical;
     use mur_common::skill::types::TrustLevel;
@@ -183,6 +317,7 @@ content:
             inject_layer2(
                 &skills,
                 &SkillsConfig::default(),
+                &MemoryConfig::default(),
                 0.0,
                 &HashSet::new(),
                 None,
@@ -211,6 +346,7 @@ content:
         let result = inject_layer2(
             &[s],
             &SkillsConfig::default(),
+            &MemoryConfig::default(),
             0.0,
             &HashSet::new(),
             None,
@@ -244,6 +380,7 @@ content:
             inject_layer2(
                 &skills,
                 &SkillsConfig::default(),
+                &MemoryConfig::default(),
                 0.0,
                 &HashSet::new(),
                 active_fleet,
@@ -272,6 +409,7 @@ content:
         let result = inject_layer2(
             &[s],
             &SkillsConfig::default(),
+            &MemoryConfig::default(),
             0.0,
             &HashSet::new(),
             None,
@@ -299,6 +437,7 @@ content:
         let result = inject_layer2(
             &[a, b],
             &SkillsConfig::default(),
+            &MemoryConfig::default(),
             0.0,
             &HashSet::new(),
             None,
@@ -325,7 +464,16 @@ content:
             }),
             ..SkillsConfig::default()
         };
-        let result = inject_layer2(&[s], &cfg, 0.85, &HashSet::new(), None, None, None);
+        let result = inject_layer2(
+            &[s],
+            &cfg,
+            &MemoryConfig::default(),
+            0.85,
+            &HashSet::new(),
+            None,
+            None,
+            None,
+        );
         assert!(result.budget_skipped);
         assert!(result.injected_names.is_empty());
     }
@@ -346,7 +494,16 @@ content:
             max_skills_in_prompt: 2,
             ..SkillsConfig::default()
         };
-        let result = inject_layer2(&skills, &cfg, 0.0, &HashSet::new(), None, None, None);
+        let result = inject_layer2(
+            &skills,
+            &cfg,
+            &MemoryConfig::default(),
+            0.0,
+            &HashSet::new(),
+            None,
+            None,
+            None,
+        );
         assert_eq!(result.injected_names.len(), 2);
     }
 
@@ -373,6 +530,7 @@ content:
             inject_layer2(
                 &skills,
                 &SkillsConfig::default(),
+                &MemoryConfig::default(),
                 0.0,
                 &HashSet::new(),
                 None,
@@ -407,6 +565,7 @@ content:
         let result = inject_layer2(
             &[s],
             &SkillsConfig::default(),
+            &MemoryConfig::default(),
             0.0,
             &HashSet::new(),
             None,
@@ -438,6 +597,7 @@ content:
         let result = inject_layer2(
             &[a, b],
             &SkillsConfig::default(),
+            &MemoryConfig::default(),
             0.0,
             &fired,
             None,

--- a/mur-agent-runtime/src/skills/mod.rs
+++ b/mur-agent-runtime/src/skills/mod.rs
@@ -2,17 +2,280 @@ pub mod injector;
 pub mod sandbox_map;
 pub mod trigger_matcher;
 
-use mur_common::skill::loader::LoadedSkill;
+use mur_common::skill::loader::{LoadedSkill, SkillScope};
 use trigger_matcher::RegisteredTrigger;
 
-pub struct RuntimeSkills {
+/// Drop notes the user has forgotten (`/forget` → `LifecycleState::Destroyed`).
+///
+/// Nothing in the runtime used to read lifecycle state, which was harmless only
+/// because notes never reached a prompt at all. Now that they do, `/forget`'s
+/// promise ("it will no longer be injected") needs an actual enforcement point.
+/// Mirrors `mur-core`'s `/memories` listing: agent-scoped notes key their stats
+/// under the agent home, global ones under the central store.
+///
+/// Startup-only cost: one small stats read per note, on the same snapshot the
+/// rest of the skill set is built from.
+pub fn drop_forgotten_notes(
+    mur_home: &std::path::Path,
+    agent: &str,
+    loaded: Vec<LoadedSkill>,
+) -> Vec<LoadedSkill> {
+    use mur_common::skill::stats::SkillStats;
+    loaded
+        .into_iter()
+        .filter(|s| {
+            if mur_common::skill::lifecycle::note_kind(&s.manifest).is_none() {
+                return true; // not a note — lifecycle gating is the note story
+            }
+            let path = match s.scope {
+                SkillScope::Agent => SkillStats::path_agent(mur_home, agent, &s.name),
+                SkillScope::Global => SkillStats::path(mur_home, &s.name),
+            };
+            SkillStats::load(&path).ok().flatten().is_none_or(|st| {
+                st.lifecycle_state != mur_common::skill::stats::LifecycleState::Destroyed
+            })
+        })
+        .collect()
+}
+
+/// The whole skill pipeline in one place: load, drop forgotten notes, apply the
+/// profile's denylist. Startup and reload MUST go through this — two copies of
+/// a load pipeline is how the two halves of a fact start disagreeing.
+pub fn load_for_agent(
+    mur_home: &std::path::Path,
+    agent: &str,
+    enabled: &(dyn Fn(&str) -> bool + Send + Sync),
+) -> Vec<LoadedSkill> {
+    drop_forgotten_notes(
+        mur_home,
+        agent,
+        mur_common::skill::loader::load_all(mur_home, agent),
+    )
+    .into_iter()
+    .filter(|s| enabled(&s.name))
+    .collect()
+}
+
+/// One immutable view of the skill set. Readers clone the `Arc` and hold no
+/// lock — `assemble_system_prompt` runs inside an async task, and a guard held
+/// across an `.await` is a deadlock waiting to happen.
+pub struct SkillsSnapshot {
     pub loaded: Vec<LoadedSkill>,
     pub triggers: Vec<RegisteredTrigger>,
 }
 
-impl RuntimeSkills {
-    pub fn build(loaded: Vec<LoadedSkill>) -> Self {
+impl SkillsSnapshot {
+    fn new(loaded: Vec<LoadedSkill>) -> Self {
         let triggers = trigger_matcher::register_from(&loaded);
         Self { loaded, triggers }
+    }
+}
+
+/// Everything [`RuntimeSkills::reload`] needs to rebuild the set from disk.
+/// Absent in tests, which build a fixed set and never reload.
+struct ReloadSource {
+    mur_home: std::path::PathBuf,
+    agent: String,
+    enabled: Box<dyn Fn(&str) -> bool + Send + Sync>,
+}
+
+/// The live skill set.
+///
+/// Used to be a plain `Vec` built once at boot and never rebuilt, which made
+/// the `remember` tool's own promise ("effective next turn") false: the note
+/// reached the disk and the process kept serving the boot-time snapshot until
+/// a restart. One reload mechanism now serves both triggers — the in-process
+/// `remember` tool and the out-of-process `memory/reload` A2A method that
+/// murmur's `/remember` and `/forget` dial. Deliberately not a filesystem
+/// watcher: a new dependency and a thread to answer a question two callers
+/// already know the answer to.
+pub struct RuntimeSkills {
+    current: std::sync::RwLock<std::sync::Arc<SkillsSnapshot>>,
+    source: Option<ReloadSource>,
+}
+
+impl RuntimeSkills {
+    /// Fixed set, no reload source. Reloading one of these is an error rather
+    /// than a silent no-op.
+    pub fn build(loaded: Vec<LoadedSkill>) -> Self {
+        Self {
+            current: std::sync::RwLock::new(std::sync::Arc::new(SkillsSnapshot::new(loaded))),
+            source: None,
+        }
+    }
+
+    /// Attach the inputs that make this set reloadable from disk.
+    pub fn reloadable(
+        mut self,
+        mur_home: impl Into<std::path::PathBuf>,
+        agent: impl Into<String>,
+        enabled: Box<dyn Fn(&str) -> bool + Send + Sync>,
+    ) -> Self {
+        self.source = Some(ReloadSource {
+            mur_home: mur_home.into(),
+            agent: agent.into(),
+            enabled,
+        });
+        self
+    }
+
+    /// Current view. Cheap: one `Arc` clone.
+    pub fn snapshot(&self) -> std::sync::Arc<SkillsSnapshot> {
+        self.current
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Rebuild from disk. Returns how many skills the new set holds.
+    pub fn reload(&self) -> anyhow::Result<usize> {
+        let src = self
+            .source
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("this skill set was built without a reload source"))?;
+        let loaded = load_for_agent(&src.mur_home, &src.agent, src.enabled.as_ref());
+        let n = loaded.len();
+        *self.current.write().unwrap_or_else(|e| e.into_inner()) =
+            std::sync::Arc::new(SkillsSnapshot::new(loaded));
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod reload_tests {
+    use super::*;
+    use mur_common::skill::note::{NoteSpec, note_manifest};
+    use mur_common::skill::stats::{LifecycleState, SkillStats};
+
+    fn write_note(home: &std::path::Path, name: &str, body: &str) {
+        let dir = mur_common::skill::store::agent_skill_dir(home, "a1").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let m = note_manifest(&NoteSpec {
+            name,
+            description: "d",
+            body,
+            kind: mur_common::skill::lifecycle::NoteKind::Rule,
+            publisher: "agent:a1",
+        });
+        mur_common::skill::store::write_to_dir(&dir, &m).unwrap();
+        std::fs::write(
+            SkillStats::path_agent(home, "a1", name),
+            serde_json::to_string(&SkillStats::new(name, "1.0.0", "", chrono::Utc::now())).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn reloadable(home: &std::path::Path) -> RuntimeSkills {
+        let loaded = load_for_agent(home, "a1", &|_| true);
+        RuntimeSkills::build(loaded).reloadable(home, "a1", Box::new(|_| true))
+    }
+
+    /// The whole point of #4: a memory written to disk AFTER boot is visible to
+    /// the next prompt without a restart.
+    #[test]
+    fn reload_picks_up_a_memory_written_after_boot() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "first", "one");
+        let skills = reloadable(home);
+        assert_eq!(skills.snapshot().loaded.len(), 1);
+
+        write_note(home, "second", "two");
+        assert_eq!(
+            skills.snapshot().loaded.len(),
+            1,
+            "the old snapshot must not change under the reader's feet"
+        );
+        assert_eq!(skills.reload().unwrap(), 2);
+        let snap = skills.snapshot();
+        let names: Vec<&str> = snap.loaded.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"second"), "{names:?}");
+    }
+
+    /// `/forget` writes Destroyed from another process; a reload must honour it.
+    #[test]
+    fn reload_drops_a_memory_forgotten_after_boot() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "gone", "x");
+        let skills = reloadable(home);
+        assert_eq!(skills.snapshot().loaded.len(), 1);
+
+        let path = SkillStats::path_agent(home, "a1", "gone");
+        let mut st = SkillStats::load(&path).unwrap().unwrap();
+        st.lifecycle_state = LifecycleState::Destroyed;
+        std::fs::write(&path, serde_json::to_string(&st).unwrap()).unwrap();
+
+        assert_eq!(skills.reload().unwrap(), 0);
+        assert!(skills.snapshot().loaded.is_empty());
+    }
+
+    /// A set built without a source is honest about it rather than silently
+    /// pretending the reload happened.
+    #[test]
+    fn reload_without_a_source_is_an_error() {
+        assert!(RuntimeSkills::build(vec![]).reload().is_err());
+    }
+}
+
+#[cfg(test)]
+mod forgotten_tests {
+    use super::*;
+    use mur_common::skill::note::{NoteSpec, note_manifest};
+    use mur_common::skill::stats::{LifecycleState, SkillStats};
+    use mur_common::skill::types::TrustLevel;
+
+    fn note(name: &str) -> LoadedSkill {
+        LoadedSkill {
+            name: name.into(),
+            manifest: note_manifest(&NoteSpec {
+                name,
+                description: "d",
+                body: "b",
+                kind: mur_common::skill::lifecycle::NoteKind::Rule,
+                publisher: "agent:a1",
+            }),
+            trust: TrustLevel::Sandboxed,
+            scope: SkillScope::Agent,
+            content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
+        }
+    }
+
+    /// `/forget` sets `Destroyed`; a forgotten note must not survive into the
+    /// skill snapshot the prompt is built from. Live note is the control.
+    #[test]
+    fn forgotten_note_is_dropped_live_note_survives() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let dir = mur_common::skill::store::agent_skill_dir(home, "a1");
+        std::fs::create_dir_all(dir.join("gone")).unwrap();
+        std::fs::create_dir_all(dir.join("kept")).unwrap();
+
+        for (name, state) in [
+            ("gone", LifecycleState::Destroyed),
+            ("kept", LifecycleState::Draft),
+        ] {
+            let mut st = SkillStats::new(name, "1.0.0", "", chrono::Utc::now());
+            st.lifecycle_state = state;
+            std::fs::write(
+                SkillStats::path_agent(home, "a1", name),
+                serde_json::to_string(&st).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let kept = drop_forgotten_notes(home, "a1", vec![note("gone"), note("kept")]);
+        let names: Vec<&str> = kept.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["kept"], "only the forgotten note is dropped");
+    }
+
+    /// A note with no stats file at all (never written, or a global note) is
+    /// live — absence must not read as Destroyed.
+    #[test]
+    fn note_without_stats_is_kept() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let kept = drop_forgotten_notes(tmp.path(), "a1", vec![note("fresh")]);
+        assert_eq!(kept.len(), 1);
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -435,6 +435,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         hook_cancel,
         runtime_skills,
         skills_cfg,
+        memory_cfg,
     ) = crate::supervisor_runner::prepare_runtime(&agent_home, &profile, socket_enabled).await?;
 
     // 5. Acquire running.lock
@@ -468,6 +469,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
             egress_proxy,
             runtime_skills.clone(),
             skills_cfg.clone(),
+            memory_cfg.clone(),
             &hook_chain,
             &hook_ctx,
             &hook_cancel,
@@ -490,6 +492,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         &profile.inner.name,
         profile.inner.identity.key_version,
         model_switch.map(|h| (h, agent_home.join("profile.yaml"))),
+        runtime_skills.clone(),
     ));
 
     // 7. Transports
@@ -954,6 +957,7 @@ fn build_dispatcher(
         Arc<crate::llm::switchable::ModelSwitchHandle>,
         std::path::PathBuf,
     )>,
+    runtime_skills: Arc<crate::skills::RuntimeSkills>,
 ) -> Dispatcher {
     let mut d = Dispatcher::new();
     d.register("agent/card", Box::new(CardHandler::new(profile.clone())));
@@ -1019,6 +1023,12 @@ fn build_dispatcher(
             )),
         );
     }
+    // murmur `/remember` and `/forget` run in the CLI process; this is how they
+    // tell the running agent its memory set changed.
+    d.register(
+        "memory/reload",
+        Box::new(crate::protocol::methods::memory_reload::MemoryReloadHandler::new(runtime_skills)),
+    );
     d
 }
 

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -152,6 +152,7 @@ pub fn build_runner(
     base_system_prompt: Option<String>,
     skills: Arc<RuntimeSkills>,
     skills_cfg: SkillsConfig,
+    memory_cfg: mur_common::config::MemoryConfig,
     hook_chain: Option<Arc<HookChain>>,
     hook_ctx: Option<HookCtx>,
     hook_cancel: Option<CancellationToken>,
@@ -168,6 +169,7 @@ pub fn build_runner(
         .with_system_prompt(base_system_prompt)
         .with_skills(skills)
         .with_skills_cfg(skills_cfg)
+        .with_memory_cfg(memory_cfg)
         .with_hitl_timeout_secs(hitl_timeout_secs)
         .with_tools(tools)
         .with_tools_policy(tools_policy)
@@ -200,6 +202,7 @@ pub async fn build_provider_runner(
     egress_proxy: Option<crate::sandbox::egress_proxy::EgressProxyHandle>,
     runtime_skills: Arc<RuntimeSkills>,
     skills_cfg: SkillsConfig,
+    memory_cfg: mur_common::config::MemoryConfig,
     hook_chain: &HookChain,
     hook_ctx: &HookCtx,
     hook_cancel: &CancellationToken,
@@ -363,6 +366,7 @@ pub async fn build_provider_runner(
                     mur_home: mur_home.clone(),
                     agent_name: profile.inner.name.clone(),
                     identity: identity.clone(),
+                    skills: runtime_skills.clone(),
                 }),
             );
         }
@@ -393,6 +397,7 @@ pub async fn build_provider_runner(
             system_prompt_with_memory.clone(),
             runtime_skills.clone(),
             skills_cfg.clone(),
+            memory_cfg.clone(),
             Some(Arc::new(hook_chain.clone())),
             Some(hook_ctx.clone()),
             Some(hook_cancel.clone()),
@@ -577,6 +582,7 @@ pub(crate) async fn prepare_runtime(
     CancellationToken,
     Arc<RuntimeSkills>,
     SkillsConfig,
+    mur_common::config::MemoryConfig,
 )> {
     let (writer, notif_rx) = TelemetryWriter::new(
         agent_home.join("telemetry"),
@@ -690,9 +696,14 @@ pub(crate) async fn prepare_runtime(
     // swallows into `Config::default()` — so every `skills:` setting the user
     // wrote was silently ignored here. Compare the correct call above, which
     // joins "config.yaml".
-    let skills_cfg =
-        mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).skills;
-    let loaded = mur_common::skill::loader::load_all(&mur_home, &profile.inner.name);
+    let prompt_cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml"));
+    let skills_cfg = prompt_cfg.skills.clone();
+    let memory_cfg = prompt_cfg.memory.clone();
+    let loaded = crate::skills::drop_forgotten_notes(
+        &mur_home,
+        &profile.inner.name,
+        mur_common::skill::loader::load_all(&mur_home, &profile.inner.name),
+    );
     // #717: surface profile.yaml skill refs that don't resolve, distinguishing
     // missing (ref written but files never installed) from malformed (files
     // exist but no longer parse) so the log names the actual root cause.
@@ -721,11 +732,20 @@ pub(crate) async fn prepare_runtime(
             ),
         }
     }
-    let loaded: Vec<_> = loaded
-        .into_iter()
-        .filter(|s| profile.inner.skill_enabled(&s.name))
-        .collect();
-    let runtime_skills = Arc::new(RuntimeSkills::build(loaded));
+    // The profile denylist, captured once so reloads apply the same gate the
+    // boot load did. Cloned out of the profile because a reload can fire long
+    // after this borrow ends.
+    // The whole profile, not a hand-picked subset: `skill_enabled` reads a
+    // denylist AND an add-on group's enabled flag today, and rebuilding a
+    // partial `AgentProfile` here would silently stop gating on whatever it
+    // learns to read next. Boot-time snapshot, like every other profile read
+    // in the runtime — editing profile.yaml still needs a restart.
+    let gate_profile = profile.inner.clone();
+    let enabled: Box<dyn Fn(&str) -> bool + Send + Sync> =
+        Box::new(move |name: &str| gate_profile.skill_enabled(name));
+    let loaded: Vec<_> = loaded.into_iter().filter(|s| enabled(&s.name)).collect();
+    let runtime_skills =
+        Arc::new(RuntimeSkills::build(loaded).reloadable(&mur_home, &profile.inner.name, enabled));
 
     Ok((
         writer,
@@ -737,6 +757,7 @@ pub(crate) async fn prepare_runtime(
         hook_cancel,
         runtime_skills,
         skills_cfg,
+        memory_cfg,
     ))
 }
 

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -157,6 +157,7 @@ pub struct TaskRunner {
     last_activity_at: Arc<AtomicI64>,
     skills: Option<Arc<RuntimeSkills>>,
     skills_cfg: SkillsConfig,
+    memory_cfg: mur_common::config::MemoryConfig,
     recently_fired: Mutex<VecDeque<(u64, String)>>,
     turn_counter: AtomicU64,
     cumulative_input_tokens: AtomicU64,
@@ -303,6 +304,7 @@ impl TaskRunner {
             last_activity_at: Arc::new(AtomicI64::new(0)),
             skills: None,
             skills_cfg: SkillsConfig::default(),
+            memory_cfg: Default::default(),
             recently_fired: Mutex::new(VecDeque::new()),
             turn_counter: AtomicU64::new(0),
             cumulative_input_tokens: AtomicU64::new(0),
@@ -437,6 +439,11 @@ impl TaskRunner {
         self
     }
 
+    pub fn with_memory_cfg(mut self, cfg: mur_common::config::MemoryConfig) -> Self {
+        self.memory_cfg = cfg;
+        self
+    }
+
     pub fn with_skills_cfg(mut self, cfg: SkillsConfig) -> Self {
         self.skills_cfg = cfg;
         self
@@ -536,6 +543,9 @@ impl TaskRunner {
         let Some(skills) = &self.skills else {
             return (base, vec![]);
         };
+        // One snapshot for the whole assembly: a reload landing mid-function
+        // must not give the injector and the trigger matcher different sets.
+        let skills = skills.snapshot();
 
         let turn = self
             .turn_counter
@@ -580,6 +590,7 @@ impl TaskRunner {
         let injection = inject_layer2(
             &skills.loaded,
             &self.skills_cfg,
+            &self.memory_cfg,
             ctx_fill,
             &recently,
             active_fleet,
@@ -1173,10 +1184,13 @@ impl TaskRunner {
                     let skill_events: Vec<Event> = fired
                         .iter()
                         .filter_map(|name| {
-                            let loaded = self
-                                .skills
-                                .as_ref()
-                                .and_then(|s| s.loaded.iter().find(|l| &l.name == name))?;
+                            let loaded = self.skills.as_ref().and_then(|s| {
+                                s.snapshot()
+                                    .loaded
+                                    .iter()
+                                    .find(|l| &l.name == name)
+                                    .cloned()
+                            })?;
                             Some(Event::SkillExecuted {
                                 trace_id: task_id.to_string(),
                                 task_id: task_id.to_string(),
@@ -3403,6 +3417,7 @@ mod tests {
             None,
             Arc::new(RuntimeSkills::build(vec![])),
             SkillsConfig::default(),
+            Default::default(),
             None,
             None,
             None,
@@ -3910,6 +3925,48 @@ mod tests {
         const _: () = assert!(RATE_LIMIT_BACKOFF_BASE.as_millis() >= 1);
         let max_delay = rate_limit_backoff_delay(MAX_RATE_LIMIT_RETRIES);
         assert!(max_delay <= std::time::Duration::from_secs(60));
+    }
+
+    /// The user's actual failure mode, at the last mile before the LLM: a
+    /// saved memory must appear in the system prompt the model receives.
+    /// Tested here rather than only in the injector because the injector
+    /// returning the right string proves nothing if the addendum never
+    /// reaches `assemble_system_prompt`'s output.
+    #[test]
+    fn saved_memory_reaches_the_system_prompt() {
+        use mur_common::skill::loader::{LoadedSkill, SkillScope};
+        use mur_common::skill::note::{NoteSpec, note_manifest};
+        use mur_common::skill::types::TrustLevel;
+
+        let note = LoadedSkill {
+            name: "reply-in-zh-tw".into(),
+            manifest: note_manifest(&NoteSpec {
+                name: "reply-in-zh-tw",
+                description: "reply in Traditional Chinese",
+                body: "ALWAYS-REPLY-IN-ZH-TW",
+                kind: mur_common::skill::lifecycle::NoteKind::Rule,
+                publisher: "agent:mur",
+            }),
+            // What the loader really assigns an agent-written note: it is
+            // never in the trust store, so it loads Sandboxed.
+            trust: TrustLevel::Sandboxed,
+            scope: SkillScope::Agent,
+            content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
+        };
+        let runner = TaskRunner::new_stub_echo()
+            .with_system_prompt(Some("BASE PROMPT".into()))
+            .with_skills(Arc::new(RuntimeSkills::build(vec![note])));
+
+        let (sys, _fired) = runner.assemble_system_prompt("hello", None, None);
+        assert!(
+            sys.contains("ALWAYS-REPLY-IN-ZH-TW"),
+            "the saved memory must reach the model's system prompt; got:\n{sys}"
+        );
+        assert!(
+            sys.starts_with("BASE PROMPT"),
+            "the agent's own prompt still leads"
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/tools/remember.rs
+++ b/mur-agent-runtime/src/tools/remember.rs
@@ -55,6 +55,10 @@ pub struct RememberTool {
     /// identity after the sandbox applies). Signs the memory proposal at the
     /// drop so review can verify who proposed it (P2c-2).
     pub identity: std::sync::Arc<mur_common::identity::AgentIdentity>,
+    /// The live skill set, reloaded after a write so the note is in the very
+    /// next prompt. Without this the tool's own "effective next turn" was a
+    /// lie: the boot-time snapshot served until a restart.
+    pub skills: std::sync::Arc<crate::skills::RuntimeSkills>,
 }
 
 #[async_trait::async_trait]
@@ -124,12 +128,23 @@ impl ToolExecutor for RememberTool {
         }
 
         let dir = agent_skill_dir(&self.mur_home, &self.agent_name).join(&name);
-        if dir.join("skill.yaml").exists() {
-            return Err(ToolError::InvalidInput(format!(
-                "memory '{name}' already exists — pick a different name, or tell the user to \
-                 inspect it with /memories"
-            )));
+        // Restating a preference is reinforcement, not a name collision. The
+        // old hard error turned a perfectly correct user action ("以後都用中文")
+        // into a red failure card, and left the agent reporting a problem
+        // where there was none. Upsert instead.
+        let existing = mur_common::skill::read_from_dir(&dir).ok();
+        if existing.as_ref().is_some_and(|m| {
+            m.content.note.as_deref() == Some(content.as_str()) && m.description == description
+        }) {
+            // Byte-identical restatement: no write, and no second federation
+            // proposal for a memory the reviewer has already seen.
+            return Ok(format!(
+                "'{name}' is already remembered with exactly this content — nothing changed. \
+                 Tell the user in ONE line, in their language, that it was already saved."
+            )
+            .into());
         }
+        let updating = existing.is_some();
 
         // Same canonical shape as `mur notes create` / TUI `/remember` —
         // one builder (mur_common::skill::note), agent-local write target.
@@ -146,9 +161,22 @@ impl ToolExecutor for RememberTool {
             .map_err(|e| ToolError::Execution(format!("write memory note: {e}")))?;
 
         // Fresh stats: Draft, zero usage. Written next to the manifest so the
-        // lifecycle sweep and loader see a complete agent-local skill.
-        let stats = SkillStats::new(&name, "1.0.0", "", chrono::Utc::now());
+        // lifecycle sweep and loader see a complete agent-local skill. On an
+        // update the existing stats stay: restating a preference must not
+        // reset the usage history that earned it its maturity — and a note the
+        // user had forgotten is deliberately revived, since re-saying it is
+        // the clearest possible instruction to bring it back.
         let stats_path = SkillStats::path_agent(&self.mur_home, &self.agent_name, &name);
+        let revive = updating
+            .then(|| SkillStats::load(&stats_path).ok().flatten())
+            .flatten()
+            .map(|mut st| {
+                st.lifecycle_state = mur_common::skill::stats::LifecycleState::Draft;
+                st.lifecycle_changed_at = chrono::Utc::now();
+                st
+            });
+        let stats =
+            revive.unwrap_or_else(|| SkillStats::new(&name, "1.0.0", "", chrono::Utc::now()));
         let json = serde_json::to_string(&stats)
             .map_err(|e| ToolError::Execution(format!("serialize stats: {e}")))?;
         std::fs::write(&stats_path, json)
@@ -170,10 +198,22 @@ impl ToolExecutor for RememberTool {
             tracing::warn!(error = %e, "memory proposal drop failed (agent-local copy is safe)");
         }
 
+        // Make it true. The set this process injects from is a snapshot; without
+        // this the note sat on disk until a restart while the tool claimed it
+        // was live. Best-effort: the note is already durable, so a reload
+        // failure downgrades the promise rather than failing the save.
+        let effective = match self.skills.reload() {
+            Ok(_) => "effective from your next turn",
+            Err(e) => {
+                tracing::warn!(error = %e, "memory saved but the live skill set did not reload");
+                "saved, but it will only take effect after the agent restarts"
+            }
+        };
+        let verb = if updating { "updated" } else { "remembered" };
         Ok(format!(
-            "remembered '{name}' (kind={kind:?}, state=Draft, agent-local; effective next \
-             turn; queued for the user's `mur session out` review). Now tell the user in \
-             ONE line, in their language, what you saved and that /forget {name} undoes it."
+            "{verb} '{name}' (kind={kind:?}, agent-local; {effective}; queued for the \
+             user's `mur session out` review). Now tell the user in ONE line, in their \
+             language, what you saved and that /forget {name} undoes it."
         )
         .into())
     }
@@ -188,6 +228,7 @@ mod tests {
             mur_home: home.to_path_buf(),
             agent_name: "w1".into(),
             identity: std::sync::Arc::new(mur_common::identity::AgentIdentity::generate()),
+            skills: std::sync::Arc::new(crate::skills::RuntimeSkills::build(vec![])),
         }
     }
 
@@ -248,13 +289,68 @@ mod tests {
         );
     }
 
+    /// Restating the SAME preference is reinforcement, not an error. This
+    /// replaces `duplicate_name_is_a_clear_error`, which encoded the bug: the
+    /// user saying "以後都用中文" twice got a red failure card.
     #[tokio::test]
-    async fn duplicate_name_is_a_clear_error() {
+    async fn restating_an_identical_memory_succeeds_without_rewriting() {
         let tmp = tempfile::TempDir::new().unwrap();
         let t = tool(tmp.path());
         t.execute(input("dup", "fact")).await.unwrap();
-        let err = t.execute(input("dup", "fact")).await.unwrap_err();
-        assert!(format!("{err:?}").contains("already exists"));
+        let out = t
+            .execute(input("dup", "fact"))
+            .await
+            .expect("restating a memory must not be an error");
+        assert!(format!("{out:?}").contains("already remembered"), "{out:?}");
+    }
+
+    /// Same name, new content: the memory is updated in place rather than
+    /// refused, and the stored note holds the NEW body.
+    #[tokio::test]
+    async fn restating_with_new_content_updates_the_note() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let t = tool(home);
+        t.execute(input("lang", "rule")).await.unwrap();
+
+        let mut changed = input("lang", "rule");
+        changed["content"] = serde_json::json!("always reply in zh-TW, never English");
+        let out = t.execute(changed).await.expect("update must succeed");
+        assert!(format!("{out:?}").contains("updated"), "{out:?}");
+
+        let dir = mur_common::skill::store::agent_skill_dir(home, "w1").join("lang");
+        let m = mur_common::skill::read_from_dir(&dir).unwrap();
+        assert_eq!(
+            m.content.note.as_deref(),
+            Some("always reply in zh-TW, never English"),
+            "the stored note must hold the new body"
+        );
+    }
+
+    /// A forgotten memory that the user states again comes back: re-saying it
+    /// is the clearest instruction there is to revive it.
+    #[tokio::test]
+    async fn restating_a_forgotten_memory_revives_it() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let t = tool(home);
+        t.execute(input("lang", "rule")).await.unwrap();
+
+        let path = SkillStats::path_agent(home, "w1", "lang");
+        let mut st = SkillStats::load(&path).unwrap().unwrap();
+        st.lifecycle_state = mur_common::skill::stats::LifecycleState::Destroyed;
+        std::fs::write(&path, serde_json::to_string(&st).unwrap()).unwrap();
+
+        let mut changed = input("lang", "rule");
+        changed["content"] = serde_json::json!("zh-TW only");
+        t.execute(changed).await.unwrap();
+
+        let after = SkillStats::load(&path).unwrap().unwrap();
+        assert_eq!(
+            after.lifecycle_state,
+            mur_common::skill::stats::LifecycleState::Draft,
+            "a re-stated memory must not stay Destroyed"
+        );
     }
 
     #[tokio::test]

--- a/mur-agent-runtime/src/turn_ledger.rs
+++ b/mur-agent-runtime/src/turn_ledger.rs
@@ -295,7 +295,12 @@ pub fn render(ledger: &TurnLedger) -> String {
         // most useful line here: it is the difference between "changed nine
         // files" and "it works", and leaving the row out lets the reader
         // assume the latter.
-        out.push_str("  ✔ verified   (nothing ran — no evidence this works)\n");
+        // `⚠`, not `✔`: the TUI colours settlement rows by their lead glyph
+        // (`settlement.rs::row_style`), so a success glyph painted this row
+        // GREEN and the parenthetical lost the argument to the colour. Not
+        // `✘` either — verification was not attempted and failed, it was
+        // never run, which is a warning about the evidence, not a failure.
+        out.push_str("  ⚠ verified   nothing ran — no evidence this works\n");
     } else {
         // One line per action: the glyph carries "verified"; a group header
         // would only push the content into a second indent level.
@@ -507,6 +512,13 @@ mod tests {
         // not read as success.
         assert!(card.contains("nothing ran"), "{card}");
         assert!(card.contains("1 file(s)"), "{card}");
+        // The bug was the GLYPH, not the words: `✔` is painted with
+        // `theme.success`, so the row rendered green while denying it works.
+        assert!(
+            card.contains("⚠ verified"),
+            "an unverified turn must not carry the success glyph: {card}"
+        );
+        assert!(!card.contains("✔ verified"), "{card}");
     }
 
     #[test]

--- a/mur-agent-runtime/tests/skill_runtime_e2e.rs
+++ b/mur-agent-runtime/tests/skill_runtime_e2e.rs
@@ -57,11 +57,13 @@ triggers:
     assert_eq!(loaded.len(), 2);
 
     let runtime = RuntimeSkills::build(loaded);
+    let runtime = runtime.snapshot();
 
     // (1) Layer 2 contains house-rules, not find-price (no session_start).
     let inj = inject_layer2(
         &runtime.loaded,
         &SkillsConfig::default(),
+        &mur_common::config::MemoryConfig::default(),
         0.0,
         &HashSet::new(),
         None,

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -352,12 +352,31 @@ impl Default for SnapshotConfig {
 #[serde(default)]
 pub struct MemoryConfig {
     pub capture: CaptureMode,
+    /// How many memories may enter the system prompt per turn. Deliberately
+    /// NOT `skills.max_skills_in_prompt`: sharing that budget means saving a
+    /// memory silently evicts a skill, and five is a plausible number of
+    /// standing preferences for one user to have.
+    #[serde(default = "default_memory_in_prompt")]
+    pub max_in_prompt: usize,
+    /// Character ceiling for the whole memory block, spent before skills.
+    #[serde(default = "default_memory_chars")]
+    pub max_chars: usize,
+}
+
+fn default_memory_in_prompt() -> usize {
+    20
+}
+
+fn default_memory_chars() -> usize {
+    1500
 }
 
 impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
             capture: CaptureMode::AutoAnnounce,
+            max_in_prompt: default_memory_in_prompt(),
+            max_chars: default_memory_chars(),
         }
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -164,6 +164,34 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
+/// Tell the running agent its memory set changed.
+///
+/// `/remember` and `/forget` write to disk from the CLI process; the agent
+/// serves a snapshot, so without this dial the change only took effect on the
+/// next restart. Same `RuntimeSkills::reload` the in-process `remember` tool
+/// calls — one mechanism, two triggers.
+///
+/// Returns a suffix for the confirmation line. A stopped agent, or one built
+/// before `memory/reload` existed, is not an error: the write already landed
+/// and its next start picks it up.
+async fn push_memory_reload(home: &std::path::Path, agent: &str) -> String {
+    let (h, ag) = (home.to_path_buf(), agent.to_string());
+    let res = tokio::task::spawn_blocking(move || {
+        dial_method(
+            &h,
+            &ag,
+            "memory/reload",
+            serde_json::json!({}),
+            DialMode::Auto,
+        )
+    })
+    .await;
+    match res {
+        Ok(Ok(_)) => String::new(),
+        _ => " (the running agent will pick this up on its next start)".into(),
+    }
+}
+
 const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /open (outstanding items)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /model [N|name] (list/switch model)  /login [anthropic|chatgpt] (OAuth health / re-authenticate — unrelated to mur auth login, which signs in to mur.run for the official catalog)  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
@@ -1987,16 +2015,22 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Skill(args) => {
             run_manage(app, move |agent| manage::run_skill(&agent, &args)).await
         }
-        SlashCmd::Remember(args) => {
-            let msg = memory_cmds::remember(&app.home, &app.agent, &args)
-                .unwrap_or_else(|e| format!("remember failed: {e}"));
-            app.push_system(msg);
-        }
+        SlashCmd::Remember(args) => match memory_cmds::remember(&app.home, &app.agent, &args) {
+            Ok(msg) => {
+                let note = push_memory_reload(&app.home, &app.agent).await;
+                app.push_system(format!("{msg}{note}"));
+            }
+            Err(e) => app.push_system(format!("remember failed: {e}")),
+        },
         SlashCmd::Memories => app.push_system(memory_cmds::memories(&app.home, &app.agent)),
         SlashCmd::Forget(target) => {
-            let msg = memory_cmds::forget(&app.home, &app.agent, target.as_deref())
-                .unwrap_or_else(|e| format!("forget failed: {e}"));
-            app.push_system(msg);
+            match memory_cmds::forget(&app.home, &app.agent, target.as_deref()) {
+                Ok(msg) => {
+                    let note = push_memory_reload(&app.home, &app.agent).await;
+                    app.push_system(format!("{msg}{note}"));
+                }
+                Err(e) => app.push_system(format!("forget failed: {e}")),
+            }
         }
         SlashCmd::Skin(name_opt) => match name_opt {
             None => {


### PR DESCRIPTION
## The bug

Three symptoms, reported from one murmur session, all one root cause:

1. A saved `reply-in-zh-tw` rule existed and the agent kept answering in English.
2. Asked "你有記住什麼", the agent said its memory was blank.
3. Asked to save the rule again, `remember` returned `already exists` as a red failure card.

`remember` writes `Category::Note` manifests with `triggers: vec![]`, but
`inject_layer2` filtered candidates down to those carrying at least one
`SessionStart` trigger. Notes were dropped every turn. Memory federation P2a
shipped a write path and a curation path; the runtime never grew a read path.

Verified against a real `~/.mur`: the note loads fine
(`scope=Agent trust=Sandboxed triggers=0 lifecycle=Draft`) and never reaches a
prompt. Dismissed along the way: `knowledge_cache/.snapshot-ref`'s
`skill_count: 0` is the federated cache of *global* skills — per-agent notes are
excluded by design, not a cause.

Two further root causes surfaced while fixing it:

- **`RuntimeSkills` was a boot snapshot, never rebuilt.** So `remember`'s own
  return string ("effective next turn") was false — a memory saved mid-session
  could not take effect until a restart.
- **Nothing in the runtime read `LifecycleState::Destroyed`.** Harmless only
  while notes never injected; fixing injection would have made `/forget`'s
  "it will no longer be injected" a lie.

## The fix

**Notes inject as an always-on block.** They carry no trigger because the user
stated them outright. Own budget (`memory.max_in_prompt`, `memory.max_chars`) —
sharing `skills.max_skills_in_prompt` meant saving a sixth memory silently
evicted a skill. Over budget renders `(N more memories not shown)` rather than
truncating in silence. Placed after bound skills: recency in a long prompt and
prompt-cache prefix stability point the same way.

**One reload mechanism, two triggers**, following the `model/set` precedent
(the CLI changes disk state, then tells the running agent — no polling, no
filesystem watcher). `load_for_agent()` is the single load pipeline shared by
boot and reload. `RuntimeSkills` holds `RwLock<Arc<SkillsSnapshot>>` so readers
clone an `Arc` and never hold a lock across an `.await`. The in-process
`remember` tool calls `reload()` directly; murmur's `/remember` and `/forget`
dial the new `memory/reload` A2A method.

**`remember` upserts.** Restating a preference is reinforcement, not a name
collision. Identical content is a no-op that reports success and drops no second
federation proposal; new content updates in place, keeps existing stats, and
revives a note that had been forgotten.

**`drop_forgotten_notes`** enforces `/forget` at the load boundary, mirroring
`memory_cmds::memories`' scope-aware stats lookup.

## Unrelated UI fix, reported in the same session

The settlement card rendered `✔ verified (nothing ran — no evidence this
works)`. `settlement.rs::row_style` colours rows by lead glyph, so the success
glyph painted that row **green** while its own text denied it. Now `⚠`
(`theme.warn`). Not `✘` — verification was never attempted, which is a warning
about evidence, not a failure. The test now locks the glyph, not just the words.

## Verification

- Regression test at `assemble_system_prompt` — the last mile before the LLM,
  not just the injector's return value. Red on the old path, green on the new.
- Every new test mutation-verified: each was made to fail before being trusted.
- End-to-end probe against the real `~/.mur` confirmed the rule reaches the
  system prompt (probe removed before commit).
- `cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean.

## Not in this PR

`inject_layer2` is one argument over clippy's threshold; marked with an
`#[allow]` and a `ponytail:` note naming the fix (bundle `active_fleet` /
`active_project` / `active_team` into one `Scope` struct). Mechanical churn
across every call site, and it belongs in its own commit.

Takes effect after `./install.sh` and an agent restart — the change is in the
runtime binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
