### PR TITLE
chore(release): bump workspace version to 2.71.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.3"
+version = "2.71.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.3"
+version = "2.71.4"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases the agent-memory fix merged in #1049.

**Merging this PR is the release.** `tag.yml` tags `v2.71.4` on the merge commit
and dispatches `release.yml`, which publishes to crates.io — irreversible, yank
only. This PR is the release approval; there is no later gate.

## What ships

- **Saved memories reach the prompt.** `remember` writes notes with no triggers,
  and `inject_layer2` kept only candidates carrying a `SessionStart` trigger, so
  every note was dropped every turn. Notes now inject as an always-on block with
  their own budget (`memory.max_in_prompt` / `memory.max_chars`) and a visible
  `(N more not shown)` instead of a silent cap.
- **Memories take effect without a restart.** `RuntimeSkills` was a boot snapshot,
  which made `remember`'s own "effective next turn" false. One reload mechanism,
  two triggers: the in-process tool calls `reload()`, and murmur's `/remember`
  and `/forget` dial the new `memory/reload` A2A method.
- **`remember` upserts.** Restating a preference was returning `already exists`
  as a failure card; it is now reinforcement.
- **`/forget` is enforced in the runtime**, which never read `Destroyed` before.
- **Settlement card no longer contradicts itself** — `⚠`, not a green `✔`, when
  nothing ran.

Details and the root-cause walkthrough: #1049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)