### PR TITLE
feat(agent): reload skills when the tree changes on disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Tier half-lives: session=14d, project=90d, core=365d. Scoring floor 0.42 (config
 
 All data at `~/.mur/`:
 
-- `skills/<name>/skill.yaml` — skills (source of truth)
+- `skills/<name>/skill.yaml` — skills (source of truth). A running agent re-reads the tree when its fingerprint changes, so an edit, install, or removal lands on that agent's next turn with no restart and nothing to notify it — see `skills_fingerprint` in `mur-agent-runtime/src/skills/mod.rs` for why this is derived from disk rather than bumped by writers.
 - `workflows/*.yaml` — multi-step workflow definitions
 - `inbox/workflow-proposals/*.yaml` — harvest proposals pending review (`mur out`)
 - `session/recordings/<id>.jsonl` — append-only event log (ambient capture)

--- a/mur-agent-runtime/src/skills/mod.rs
+++ b/mur-agent-runtime/src/skills/mod.rs
@@ -56,6 +56,77 @@ pub fn load_for_agent(
     .collect()
 }
 
+/// Fingerprint of everything [`load_for_agent`] reads, cheap enough to take on
+/// every turn.
+///
+/// Derived from disk rather than bumped by writers, deliberately. A
+/// bump-on-write counter needs every mutation path to remember to bump it —
+/// `mur skill install`, `mur skill remove`, `mur sync`, the Hub, and whatever
+/// is added next — and a forgotten bump is indistinguishable from the staleness
+/// it was meant to close. Reading the tree has no write side to forget: a
+/// `skill.yaml` edited by hand counts, an agent that somehow drifts is back in
+/// sync on its next turn, and there is no read-modify-write to race.
+///
+/// Measured at ~170µs over 67 skills with a warm cache, on a turn that then
+/// spends seconds inside an LLM call. `assemble_system_prompt` already touches
+/// the filesystem once per turn (`active_project_id` walks up for the repo
+/// root), so this is the same class of cost rather than a new one.
+///
+/// Process-local by design: `DefaultHasher` promises nothing across versions
+/// and needs to, since a restart re-reads the tree from scratch anyway.
+fn skills_fingerprint(mur_home: &std::path::Path, agent: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    /// `(len, mtime-nanos)`, or `None` when the file is absent or unreadable —
+    /// itself a state worth noticing, since it is how a deletion shows up.
+    fn stamp(p: &std::path::Path) -> Option<(u64, u128)> {
+        let md = std::fs::metadata(p).ok()?;
+        let m = md
+            .modified()
+            .ok()?
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()?
+            .as_nanos();
+        Some((md.len(), m))
+    }
+
+    let agent_home = mur_home.join("agents").join(agent);
+    let dirs = [
+        mur_common::skill::store::agent_skill_dir(mur_home, agent),
+        agent_home.join("knowledge_cache"),
+        mur_home.join("skills"),
+    ];
+
+    let mut acc: u64 = 0;
+    for dir in &dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue; // absent dir is a legitimate state, not an error
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            let mut h = DefaultHasher::new();
+            e.file_name().hash(&mut h);
+            stamp(&p.join("skill.yaml")).hash(&mut h);
+            // stats.json carries the lifecycle state. A `/forget` in another
+            // process touches nothing else in the tree, so without this the
+            // one mutation the CLI can make to a live agent's memory would be
+            // the one this cannot see.
+            stamp(&p.join("stats.json")).hash(&mut h);
+            // Summed, not chained: `read_dir` order is not guaranteed, and a
+            // reordering must not read as a change.
+            acc = acc.wrapping_add(h.finish());
+        }
+    }
+
+    let mut h = DefaultHasher::new();
+    acc.hash(&mut h);
+    // Trust level orders the injected list and gates loading, so a
+    // `mur skill trust` is a change too — one more stat.
+    stamp(&mur_common::trust::skills::SkillTrustStore::path(mur_home)).hash(&mut h);
+    h.finish()
+}
+
 /// One immutable view of the skill set. Readers clone the `Arc` and hold no
 /// lock — `assemble_system_prompt` runs inside an async task, and a guard held
 /// across an `.await` is a deadlock waiting to happen.
@@ -92,6 +163,8 @@ struct ReloadSource {
 pub struct RuntimeSkills {
     current: std::sync::RwLock<std::sync::Arc<SkillsSnapshot>>,
     source: Option<ReloadSource>,
+    /// Fingerprint the current snapshot was loaded at.
+    fingerprint: std::sync::atomic::AtomicU64,
 }
 
 impl RuntimeSkills {
@@ -101,6 +174,7 @@ impl RuntimeSkills {
         Self {
             current: std::sync::RwLock::new(std::sync::Arc::new(SkillsSnapshot::new(loaded))),
             source: None,
+            fingerprint: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -111,12 +185,46 @@ impl RuntimeSkills {
         agent: impl Into<String>,
         enabled: Box<dyn Fn(&str) -> bool + Send + Sync>,
     ) -> Self {
-        self.source = Some(ReloadSource {
+        let src = ReloadSource {
             mur_home: mur_home.into(),
             agent: agent.into(),
             enabled,
-        });
+        };
+        // Seed it, so the first turn does not reload a set that was just built.
+        self.fingerprint.store(
+            skills_fingerprint(&src.mur_home, &src.agent),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.source = Some(src);
         self
+    }
+
+    /// Reload when the on-disk tree no longer matches the loaded snapshot.
+    ///
+    /// The third trigger on the one reload mechanism — the others being the
+    /// in-process `remember` tool and the `memory/reload` A2A method — and the
+    /// only one that needs no cooperation from whoever changed the files. It is
+    /// what makes `mur skill remove` reach a running agent without a fan-out
+    /// that would have to dial every agent, report partial failure honestly,
+    /// and still miss every agent started afterwards.
+    ///
+    /// Never fails a turn: a failed reload leaves the previous snapshot
+    /// serving and says so in the log.
+    pub fn refresh_if_changed(&self) {
+        let Some(src) = &self.source else {
+            return; // fixed set (tests) — nothing to compare against
+        };
+        let disk = skills_fingerprint(&src.mur_home, &src.agent);
+        if disk == self.fingerprint.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        match self.reload() {
+            Ok(n) => tracing::info!(skills = n, "skill tree changed on disk; reloaded"),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "skill tree changed on disk but the reload failed; serving the previous set"
+            ),
+        }
     }
 
     /// Current view. Cheap: one `Arc` clone.
@@ -133,10 +241,16 @@ impl RuntimeSkills {
             .source
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("this skill set was built without a reload source"))?;
+        // Fingerprint BEFORE loading. If the tree changes while this load is in
+        // flight, the value stored is the older one, so the next turn reloads
+        // again instead of the change being swallowed.
+        let fp = skills_fingerprint(&src.mur_home, &src.agent);
         let loaded = load_for_agent(&src.mur_home, &src.agent, src.enabled.as_ref());
         let n = loaded.len();
         *self.current.write().unwrap_or_else(|e| e.into_inner()) =
             std::sync::Arc::new(SkillsSnapshot::new(loaded));
+        self.fingerprint
+            .store(fp, std::sync::atomic::Ordering::Relaxed);
         Ok(n)
     }
 }
@@ -207,6 +321,94 @@ mod reload_tests {
         std::fs::write(&path, serde_json::to_string(&st).unwrap()).unwrap();
 
         assert_eq!(skills.reload().unwrap(), 0);
+        assert!(skills.snapshot().loaded.is_empty());
+    }
+
+    /// The point of the whole design: a note removed by ANOTHER process — no
+    /// dial, no bump, nothing cooperating — reaches the agent on its next turn.
+    #[test]
+    fn a_note_removed_by_another_process_is_dropped_on_the_next_turn() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "keep", "one");
+        write_note(home, "doomed", "two");
+        let skills = reloadable(home);
+        assert_eq!(skills.snapshot().loaded.len(), 2);
+
+        // Exactly what `mur skill remove` does, from outside this process.
+        std::fs::remove_dir_all(
+            mur_common::skill::store::agent_skill_dir(home, "a1").join("doomed"),
+        )
+        .unwrap();
+
+        skills.refresh_if_changed();
+        let snap = skills.snapshot();
+        let names: Vec<&str> = snap.loaded.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["keep"], "removed note must be gone");
+    }
+
+    /// A note whose body is edited in place — no entry added or removed, so a
+    /// directory mtime alone would miss it.
+    #[test]
+    fn an_edited_note_body_is_picked_up() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "rule", "reply in English");
+        let skills = reloadable(home);
+        write_note(home, "rule", "reply in zh-TW");
+
+        skills.refresh_if_changed();
+        let snap = skills.snapshot();
+        assert_eq!(
+            snap.loaded[0].manifest.content.note.as_deref(),
+            Some("reply in zh-TW")
+        );
+    }
+
+    /// `/forget` in the CLI process writes only stats.json. Nothing else in the
+    /// tree moves, so this is the case a coarser fingerprint would miss.
+    #[test]
+    fn a_forget_from_another_process_is_picked_up() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "gone", "x");
+        let skills = reloadable(home);
+        assert_eq!(skills.snapshot().loaded.len(), 1);
+
+        let path = SkillStats::path_agent(home, "a1", "gone");
+        let mut st = SkillStats::load(&path).unwrap().unwrap();
+        st.lifecycle_state = LifecycleState::Destroyed;
+        std::fs::write(&path, serde_json::to_string(&st).unwrap()).unwrap();
+
+        skills.refresh_if_changed();
+        assert!(skills.snapshot().loaded.is_empty());
+    }
+
+    /// The cost guarantee: an unchanged tree must not rebuild anything. Proven
+    /// by pointer identity — a reload would hand back a different `Arc`.
+    #[test]
+    fn an_unchanged_tree_does_not_reload() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        write_note(home, "steady", "x");
+        let skills = reloadable(home);
+
+        let before = skills.snapshot();
+        for _ in 0..5 {
+            skills.refresh_if_changed();
+        }
+        assert!(
+            std::sync::Arc::ptr_eq(&before, &skills.snapshot()),
+            "an unchanged tree must not rebuild the snapshot"
+        );
+    }
+
+    /// A fixed set has nothing to compare against; refreshing must be a quiet
+    /// no-op rather than an error or a panic.
+    #[test]
+    fn refresh_on_a_fixed_set_is_a_noop() {
+        let skills = RuntimeSkills::build(vec![]);
+        skills.refresh_if_changed();
         assert!(skills.snapshot().loaded.is_empty());
     }
 

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -543,6 +543,10 @@ impl TaskRunner {
         let Some(skills) = &self.skills else {
             return (base, vec![]);
         };
+        // Pick up skills and memories that another process changed on disk
+        // (`mur skill remove`, `mur notes create`, a hand-edited skill.yaml)
+        // before building the prompt.
+        skills.refresh_if_changed();
         // One snapshot for the whole assembly: a reload landing mid-function
         // must not give the injector and the trigger matcher different sets.
         let skills = skills.snapshot();


### PR DESCRIPTION
Closes #1051 — by solving the problem, not by building the fan-out the issue
proposed. The shape changed twice under scrutiny; both revisions are below.

## Why not the push fan-out

Three facts, measured on the reporter's box rather than assumed:

- **23 agents are running.** Every global mutation would mean 23 socket dials.
- **A dial can block for 600 seconds.** `a2a_dial.rs:43`'s
  `DEFAULT_DIAL_IO_TIMEOUT`, correctly tuned for `message/send` where an LLM
  turn legitimately runs for minutes. One wedged agent stalls `mur skill remove`
  for ten minutes, and a shorter timeout just for reloads is more machinery.
- **Partial failure has to be reported honestly.** `removed` printed while three
  of twenty-three agents kept the skill is the same class of lie as a settlement
  card claiming verification that never ran.

And a push never reaches an agent started *after* the mutation. Pull has none of
these by construction.

## Why not the bump-on-write marker either

That was my own first recommendation and it does not survive inspection.

**It races.** Read-increment-write: A writes content, reads 5, bumps to 6. B
writes content, reads 5 (stale), bumps to 6 — no change. An agent that reloaded
at 6 between the two is permanently missing B. Fixable with a nonce, but the
write side has correctness surface I had not priced.

**It can be forgotten.** Every mutation path has to remember to bump —
`mur skill install`, `mur skill remove`, `mur sync`, the Hub, and whatever is
added next. A forgotten bump is indistinguishable from the staleness it was
meant to close, so the fix would ship a permanent new bug class.

## What this does instead

Fingerprint what `load_for_agent` reads — per-entry name, `(len, mtime)` of
`skill.yaml` and `stats.json`, plus the trust store — compare once per turn,
reload on mismatch.

No write side at all. Nothing to wire, nothing to forget, nothing to race. It
covers the Hub, `mur sync`, and a `skill.yaml` edited by hand in vim, none of
which it knows about. And it is self-correcting: an agent that drifts for any
reason is back in sync on its next turn.

`stats.json` is in the fingerprint because a `/forget` in another process
touches nothing else in the tree — without it, the one mutation the CLI can make
to a live agent's memory is the one this cannot see.

## Cost, measured

**~170 µs** over 67 skills with a warm cache, on a turn that then spends seconds
inside an LLM call — 0.005%. `assemble_system_prompt` already walks the
filesystem once per turn (`active_project_id` resolves the repo root and
canonicalizes it), so this is the same class of cost rather than a new one.

## Still one mechanism

Third trigger on the same `RuntimeSkills::reload`, not a second mechanism: the
in-process `remember` tool, the `memory/reload` A2A method, and now a disk
change. Worth saying plainly — this subsumes most of what `memory/reload` was
built for last release. That method still earns its keep as "apply now, do not
wait for my next turn" and as `mur agent dial`'s exemplar, but had I thought
this through first, #1049 would have been smaller.

## Verification

Five tests, each mutation-verified, and the mutations chosen to prove the design
rather than the code:

- Fingerprint reduced to entry names only → the **edit** and **forget** tests
  fail while **remove** still passes. That is exactly the granularity argument:
  a coarser marker catches add/remove and misses in-place edits and lifecycle
  changes.
- `refresh_if_changed` made a no-op → all three disk-change tests fail, both
  no-op tests still pass.
- `an_unchanged_tree_does_not_reload` asserts the cost guarantee by `Arc::ptr_eq`
  — a reload would hand back a different `Arc`.

`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
`mur-agent-runtime` 566 lib tests pass. Full workspace nextest running.

**Not yet verified on a live agent** — this is a runtime binary change, so the
end-to-end check comes after the next release, as it did for #1049.

## Unrelated finding

`mur-agent-runtime::supervisor_startup runtime_starts_and_responds_to_agent_card_over_stdio`
failed once locally under heavy load (clippy + builds + 23 agents), then passed
5/5 in isolation. It waits 5s for a cold-start runtime, so it is a
load-sensitive flake, not a regression — CI passed it on all three platforms for
#1049. Say the word and I will file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
