### PR TITLE
chore(release): bump workspace version to 2.71.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.4"
+version = "2.71.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.4"
+version = "2.71.5"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases #1053 and #1054.

**Merging this PR is the release.** `tag.yml` tags `v2.71.5` on the merge commit
and dispatches `release.yml`, which publishes to crates.io — irreversible, yank
only. This PR is the release approval; there is no later gate.

## What ships

**`mur agent dial <name> <method> [json]`** (#1053) — the runtime registers
twelve A2A methods and the CLI could reach two. `tasks/list`, `tasks/cancel` and
`turn/steer` had no user-space surface at all. Passthrough by design: the unix
socket is the trust boundary, so an allowlist here would add no security and one
more list to go stale.

**Skills and memories reload when the tree changes on disk** (#1054) — a note
removed with `mur skill remove`, a skill installed, or a `skill.yaml` edited by
hand now lands on a running agent's next turn, with no restart and nothing
notifying it. Derived from a ~170µs fingerprint rather than a fan-out that would
have to dial 23 agents (each able to block for 600s), report partial failure
honestly, and still miss every agent started afterwards.

Closes #1051 and #1052.

## Verification

Local `cargo nextest run --workspace`: 7836 passed, 0 failed. Every new test in
both PRs was mutation-verified. The end-to-end check on a live agent runs after
this release, since both changes ship in binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)