### PR TITLE
fix: --restart-agents silent no-op, and a startup test that failed opaquely

### DIFF
--- a/mur-agent-runtime/tests/supervisor_startup.rs
+++ b/mur-agent-runtime/tests/supervisor_startup.rs
@@ -1,7 +1,19 @@
 use std::process::Stdio;
+use std::time::Duration;
 use tempfile::TempDir;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
+
+/// How long the runtime gets to answer `agent/card` from a cold start.
+///
+/// This only bounds a hang. A cold start answers in ~0.11s on an idle machine,
+/// so the number is not a performance assertion and there is nothing to win by
+/// keeping it small — a runtime that never answers still fails the test, just
+/// later. It was 5s, which reads as generous at 45x the idle figure and still
+/// expired at 5.020s during a full `nextest` run with clippy and a release
+/// build alongside. Under `nextest` the whole workspace runs in parallel, so
+/// that contention is this test's normal case, not an exceptional one.
+const CARD_REPLY_BUDGET: Duration = Duration::from_secs(60);
 
 #[tokio::test]
 async fn runtime_starts_and_responds_to_agent_card_over_stdio() {
@@ -26,6 +38,9 @@ async fn runtime_starts_and_responds_to_agent_card_over_stdio() {
         .unwrap();
     let mut stdin = child.stdin.take().unwrap();
     let stdout = child.stdout.take().unwrap();
+    // Held so a startup crash can be reported with the runtime's own words
+    // instead of `called Option::unwrap() on a None value`.
+    let mut stderr = child.stderr.take().unwrap();
     let mut reader = tokio::io::BufReader::new(stdout).lines();
 
     use tokio::io::AsyncWriteExt;
@@ -38,11 +53,24 @@ async fn runtime_starts_and_responds_to_agent_card_over_stdio() {
     // to our agent/card request. Notifications now include the
     // `telemetry/hook_fired` events the A0 hook chain emits on startup.
     let resp = loop {
-        let line = tokio::time::timeout(std::time::Duration::from_secs(5), reader.next_line())
-            .await
-            .unwrap()
-            .unwrap()
-            .unwrap();
+        // Three distinct failures used to collapse into three bare unwraps: a
+        // timeout surfaced as `Elapsed(())`, and a runtime that died during
+        // startup as `Option::unwrap() on a None value` — neither of which
+        // names what went wrong, and the second is the one that most needs to.
+        let line = match tokio::time::timeout(CARD_REPLY_BUDGET, reader.next_line()).await {
+            Err(_) => panic!(
+                "runtime did not answer agent/card within {CARD_REPLY_BUDGET:?} — \
+                 a startup hang, or a cold start starved of CPU"
+            ),
+            Ok(Err(e)) => panic!("reading the runtime's stdout failed: {e}"),
+            Ok(Ok(None)) => {
+                use tokio::io::AsyncReadExt;
+                let mut log = String::new();
+                let _ = stderr.read_to_string(&mut log).await;
+                panic!("runtime exited before answering agent/card. Its stderr:\n{log}");
+            }
+            Ok(Ok(Some(line))) => line,
+        };
         let v: serde_json::Value = serde_json::from_str(&line).unwrap();
         if v.get("id").is_some() {
             break v;

--- a/mur-core/src/update/mod.rs
+++ b/mur-core/src/update/mod.rs
@@ -59,6 +59,16 @@ pub fn run(opts: UpdateOptions) -> Result<()> {
         if let Some(nudge) = hub_staleness_nudge(current) {
             println!("{nudge}");
         }
+        // "Already up to date" is a claim about this binary, not about the
+        // system. Agents can sit on an older build for reasons that have
+        // nothing to do with the CLI's version, and `--restart-agents` is what
+        // someone reaches for then — so consult the flag here instead of
+        // returning past it. The pass reports what it found, including
+        // "No stale agents to restart.", which is the point: a skip the user
+        // asked against should be visible rather than silent.
+        if opts.restart_agents {
+            return resign::restart_agents_only();
+        }
         return Ok(());
     }
 

--- a/mur-core/src/update/resign.rs
+++ b/mur-core/src/update/resign.rs
@@ -61,6 +61,22 @@ pub fn post_upgrade(restart_agents: bool, fresh_runtime: Option<&std::path::Path
     agents_result
 }
 
+/// The agent leg of [`post_upgrade`], without any binary work.
+///
+/// `mur update --restart-agents` on an already-current CLI used to return
+/// before reaching a single agent, so the flag was silently a no-op. The
+/// version of the CLI and the build an agent is *running* are different facts:
+/// a restart that did not take, an agent that was stopped during the previous
+/// update, or a supervisor that never got the signal each leave one behind, and
+/// this is the command someone reaches for in exactly that situation.
+///
+/// Shares `restart_exclusions()` with the post-upgrade path on purpose, so a
+/// user's `update.restart_exclude` cannot be honoured on one route and ignored
+/// on the other.
+pub fn restart_agents_only() -> Result<()> {
+    crate::cmd::agent::restart_stale_excluding(&restart_exclusions())
+}
+
 fn load_config() -> mur_common::config::Config {
     let home = crate::paths::mur_root(None);
     mur_common::config::Config::load_or_default(&home.join("config.yaml"))


### PR DESCRIPTION
Closes #1056 and #1057. Two unrelated fixes, one commit each.

---

## `--restart-agents` was a silent no-op (#1056)

`mur update --restart-agents` returned before reaching a single agent whenever
the installed CLI already matched the latest release. The flag was accepted and
never consulted on that path.

"Already up to date" is a claim about *this binary*, not about the system. The
CLI's version and the build an agent is running are different facts — a restart
that did not take, an agent stopped during the previous update, a supervisor
that never got the signal — and `--restart-agents` is exactly what someone
reaches for then, only to be told success while nothing happened.

The path now runs the same stale-restart pass, which already reports what it
found. **Verified live against the real 23-agent system:**

```
before:  Already up to date (v2.71.5)
after:   Already up to date (v2.71.5)
         No stale agents to restart.
```

`restart_agents_only` shares `restart_exclusions()` with `post_upgrade`, so a
user's `update.restart_exclude` cannot be honoured on one route and ignored on
the other.

**No unit test, deliberately.** The change is "the flag is consulted on this
path", and the path is gated behind a live release lookup. A test I could write
without mocking that would assert a tautology, and this session has spent
enough time on tests that pass while proving nothing. The live run above is the
check. What I did *not* verify is that a genuinely stale agent gets restarted —
that is `restart_stale_excluding`'s pre-existing behaviour, untouched here.

---

## Startup test: room to breathe, and failures that say something (#1057)

The budget only bounds a hang. A cold start answers in **0.11s** on an idle
machine (measured, five runs), so 5s reads as generous at 45× — and it still
expired at 5.020s during a full `nextest` run with clippy and a release build
alongside. Under `nextest` the whole workspace runs in parallel, so that
contention is this test's normal case. 60s costs nothing.

**Ruled out first:** the test pipes the child's stderr and never drains it, so a
startup that out-logged the ~64KB pipe buffer would deadlock — and no timeout
increase would fix that. Measured: startup writes **1037 bytes over 6 lines**.
Not the cause.

The messages mattered more than the number. Three failures collapsed into three
bare unwraps:

| failure | was | now |
|---|---|---|
| timeout | `Elapsed(())` | `runtime did not answer agent/card within 60s — a startup hang, or a cold start starved of CPU` |
| io error | raw error | `reading the runtime's stdout failed: …` |
| child died | `called Option::unwrap() on a None value` | `runtime exited before answering agent/card. Its stderr:` + the log |

That last one is the one that matters. Verified by corrupting the fixture
profile:

```
runtime exited before answering agent/card. Its stderr:
error[profile_invalid]: YAML parse error: mapping values are not allowed in this context at line 1 column 22
```

Both new messages were mutation-verified — a 1ms budget produces the timeout
text, a corrupt profile produces the dump above.

---

`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
full workspace nextest running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
