### PR TITLE
feat(memory): give an agent a way to read its own memories, and notes a remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,9 @@ it knows). Notes come in two kinds with matched decay: `rule` (behavioral
 guidance, fast half-life) and `fact` (environment truth, slow half-life). A
 reserved injection slot keeps fresh notes from being permanently outbid by
 mature skills. Say it again and the note is updated in place rather than
-colliding — and one you had forgotten comes back. Off switch / confirm-first:
+colliding — and one you had forgotten comes back. Ask an agent what it knows and
+it answers from its own `recall`, reading the very set its prompt was built from;
+`mur notes list --agent <name>` shows you the same thing. Off switch / confirm-first:
 `memory.capture` in `~/.mur/config.yaml`.
 
 **None of it waits for a restart.** A note saved mid-chat is in the very next

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -369,6 +369,18 @@ pub async fn build_provider_runner(
                     skills: runtime_skills.clone(),
                 }),
             );
+            // Registered with `remember`, under the same capture gate: an agent
+            // allowed to save memories should be able to read them back, and
+            // one with capture off has none of its own to read.
+            use crate::tools::recall::{RECALL, RecallTool};
+            if resolve_tool_policy(&tools_policy, RECALL) != ToolPolicy::Deny {
+                tool_map.insert(
+                    RECALL.to_string(),
+                    Arc::new(RecallTool {
+                        skills: runtime_skills.clone(),
+                    }),
+                );
+            }
         }
     }
     let tools: Vec<Arc<dyn crate::tools::ToolExecutor>> = tool_map.into_values().collect();

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -6,6 +6,7 @@ pub mod mcp;
 pub mod naming;
 pub mod open_item;
 pub mod read_file;
+pub mod recall;
 pub mod registry;
 pub mod remember;
 pub(crate) mod suggest;

--- a/mur-agent-runtime/src/tools/recall.rs
+++ b/mur-agent-runtime/src/tools/recall.rs
@@ -1,0 +1,188 @@
+//! Built-in `recall` tool: let an agent read its own memories.
+//!
+//! Closes the half of the memory story that injection cannot. Notes reach the
+//! prompt (#1049) but the block is bounded by `memory.max_in_prompt` /
+//! `memory.max_chars`, so an agent with more memories than fit had no way to
+//! see the rest — and the tool whose name matched the job, MCP
+//! `mur_notes_search`, reads the GLOBAL note store and structurally cannot see
+//! an agent's own memories at all.
+//!
+//! Reads the live [`RuntimeSkills`] snapshot rather than the disk. That is the
+//! point: the snapshot is exactly what the prompt was built from, so `recall`
+//! and the injected block can never disagree about what this agent remembers.
+//! A disk read could, and two answers to one question is the failure this
+//! whole area keeps producing.
+
+use std::sync::Arc;
+
+use super::{ToolError, ToolExecutor, ToolOutput};
+use crate::llm::ToolDef;
+use crate::skills::RuntimeSkills;
+
+pub const RECALL: &str = "recall";
+
+pub struct RecallTool {
+    pub skills: Arc<RuntimeSkills>,
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for RecallTool {
+    fn name(&self) -> &str {
+        RECALL
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: RECALL.into(),
+            description: "List what you remember about this user — the durable preferences \
+                and facts you saved with `remember`, plus any shared notes. Use when asked \
+                what you know or remember, or to check before saving something again."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Optional keyword filter. Omit to list everything."
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
+        let query = input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .map(str::to_lowercase);
+
+        let snap = self.skills.snapshot();
+        let mut rows: Vec<String> = snap
+            .loaded
+            .iter()
+            .filter_map(|s| {
+                let kind = mur_common::skill::lifecycle::note_kind(&s.manifest)?;
+                let body = s
+                    .manifest
+                    .content
+                    .note
+                    .as_deref()
+                    .unwrap_or(&s.manifest.content.r#abstract);
+                // Match on the text the user would search for — name, one-line
+                // description, and body — rather than the name alone, which is
+                // a slug and rarely what they remember.
+                if let Some(q) = &query
+                    && !s.name.to_lowercase().contains(q)
+                    && !s.manifest.description.to_lowercase().contains(q)
+                    && !body.to_lowercase().contains(q)
+                {
+                    return None;
+                }
+                let scope = match s.scope {
+                    mur_common::skill::loader::SkillScope::Agent => "mine",
+                    mur_common::skill::loader::SkillScope::Global => "shared",
+                };
+                Some(format!(
+                    "- [{}, {}] {}: {}",
+                    scope,
+                    match kind {
+                        mur_common::skill::lifecycle::NoteKind::Rule => "rule",
+                        mur_common::skill::lifecycle::NoteKind::Fact => "fact",
+                    },
+                    s.name,
+                    body.trim()
+                ))
+            })
+            .collect();
+        rows.sort();
+
+        if rows.is_empty() {
+            return Ok(match &query {
+                Some(q) => format!("nothing remembered matching '{q}'."),
+                None => "nothing remembered yet.".to_string(),
+            }
+            .into());
+        }
+        Ok(format!("{} remembered:\n{}", rows.len(), rows.join("\n")).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::loader::{LoadedSkill, SkillScope};
+    use mur_common::skill::note::{NoteSpec, note_manifest};
+    use mur_common::skill::types::TrustLevel;
+
+    fn note(name: &str, body: &str, scope: SkillScope) -> LoadedSkill {
+        LoadedSkill {
+            name: name.into(),
+            manifest: note_manifest(&NoteSpec {
+                name,
+                description: "d",
+                body,
+                kind: mur_common::skill::lifecycle::NoteKind::Rule,
+                publisher: "agent:a1",
+            }),
+            trust: TrustLevel::Sandboxed,
+            scope,
+            content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
+        }
+    }
+
+    fn tool(loaded: Vec<LoadedSkill>) -> RecallTool {
+        RecallTool {
+            skills: Arc::new(RuntimeSkills::build(loaded)),
+        }
+    }
+
+    /// The gap this closes: an agent could not read its OWN memories. The MCP
+    /// note search reads the global store and structurally cannot see them.
+    #[tokio::test]
+    async fn recall_returns_agent_local_memories_labelled_by_scope() {
+        let t = tool(vec![
+            note("reply-in-zh-tw", "always reply in zh-TW", SkillScope::Agent),
+            note("house-style", "two-space indent", SkillScope::Global),
+        ]);
+        let out = format!("{:?}", t.execute(serde_json::json!({})).await.unwrap());
+        assert!(out.contains("always reply in zh-TW"), "{out}");
+        assert!(out.contains("mine"), "agent-local must be labelled: {out}");
+        assert!(out.contains("shared"), "global must be labelled: {out}");
+    }
+
+    /// Non-notes share the snapshot and must not be reported as memories.
+    #[tokio::test]
+    async fn recall_ignores_skills_that_are_not_notes() {
+        let mut skill = note("a-skill", "body", SkillScope::Global);
+        skill.manifest.category = mur_common::skill::types::Category::Context;
+        let t = tool(vec![skill]);
+        let out = format!("{:?}", t.execute(serde_json::json!({})).await.unwrap());
+        assert!(out.contains("nothing remembered"), "{out}");
+    }
+
+    /// The filter matches the body, not just the slug — a user remembers what
+    /// the note SAYS, rarely what it is called.
+    #[tokio::test]
+    async fn query_matches_the_body_not_only_the_name() {
+        let t = tool(vec![note(
+            "n1",
+            "the cat is called Mochi",
+            SkillScope::Agent,
+        )]);
+        let hit = format!(
+            "{:?}",
+            t.execute(serde_json::json!({"query": "mochi"}))
+                .await
+                .unwrap()
+        );
+        assert!(hit.contains("Mochi"), "body match failed: {hit}");
+        let miss = format!(
+            "{:?}",
+            t.execute(serde_json::json!({"query": "penguin"}))
+                .await
+                .unwrap()
+        );
+        assert!(miss.contains("nothing remembered matching"), "{miss}");
+    }
+}

--- a/mur-core/src/cli/notes.rs
+++ b/mur-core/src/cli/notes.rs
@@ -35,6 +35,17 @@ pub enum NotesAction {
         limit: usize,
     },
 
+    /// Remove a note. Global by default; `--agent` targets that agent's own
+    /// memory instead.
+    Remove {
+        /// Note name.
+        name: String,
+
+        /// Remove this agent's own memory rather than a global note.
+        #[arg(long)]
+        agent: Option<String>,
+    },
+
     /// List notes, optionally filtered by maturity.
     List {
         /// Filter by lifecycle maturity: draft|emerging|stable|canonical|deprecated|archived.
@@ -44,6 +55,12 @@ pub enum NotesAction {
         /// Maximum notes to print.
         #[arg(long, default_value_t = 50)]
         limit: usize,
+
+        /// Also show this agent's own memories, labelled by scope. Without it
+        /// the listing covers global notes only — an agent's own memories live
+        /// under its home and are invisible here.
+        #[arg(long)]
+        agent: Option<String>,
     },
 
     /// Print a single note's body and maturity (records a retrieval).

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -19,7 +19,7 @@ mod handover;
 mod login;
 mod manage;
 mod markdown;
-mod memory_cmds;
+pub mod memory_cmds;
 mod model_cmd;
 mod multiplex;
 mod panel;

--- a/mur-core/src/cmd/notes_cmd.rs
+++ b/mur-core/src/cmd/notes_cmd.rs
@@ -84,7 +84,10 @@ pub fn cmd_search(query: &str, limit: usize) -> Result<()> {
     let home = resolve_mur_home()?;
     let ranked = do_search(&home, query, limit)?;
     if ranked.is_empty() {
-        println!("No notes match '{query}'.");
+        println!(
+            "No global notes match '{query}'. (This searches global notes only; an agent's \
+             own memories live under its home — see `mur notes list --agent <name>`.)"
+        );
         return Ok(());
     }
     for (i, sp) in ranked.iter().enumerate() {
@@ -152,12 +155,27 @@ pub fn record_retrieval(mur_home: &Path, skill_name: &str, now: DateTime<Utc>) -
 }
 
 /// Top-level `mur notes list` handler.
-pub fn cmd_list(maturity: Option<&str>, limit: usize) -> Result<()> {
+pub fn cmd_list(maturity: Option<&str>, limit: usize, agent: Option<&str>) -> Result<()> {
     let home = resolve_mur_home()?;
+    // `--agent` reuses the `/memories` renderer rather than growing a second
+    // one: the TUI already labels agent-local · federated · shared correctly,
+    // and two listings of one fact are how they start disagreeing.
+    if let Some(a) = agent {
+        println!(
+            "{}",
+            crate::cmd::agent::cli::memory_cmds::memories(&home, a)
+        );
+        return Ok(());
+    }
     let filter = maturity.map(parse_maturity).transpose()?;
     let rows = do_list(&home, filter, limit)?;
     if rows.is_empty() {
-        println!("No notes found.");
+        // Naming the scope matters: an agent's own memories live under its
+        // home and are invisible here, so a bare "No notes found." reads as
+        // "you have no memories" when it means "none are global".
+        println!(
+            "No global notes found. (An agent's own memories are not listed here — try `mur notes list --agent <name>`.)"
+        );
         return Ok(());
     }
     for r in &rows {
@@ -220,6 +238,38 @@ pub fn parse_maturity(s: &str) -> Result<LifecycleState> {
              (expected draft|emerging|stable|canonical|deprecated|archived)"
         ),
     }
+}
+
+/// `mur notes remove <name> [--agent <a>]`.
+///
+/// A note IS a `category: note` skill, so removing a global one has always been
+/// possible — as `mur skill remove`. That is true, discoverable nowhere, and
+/// the command everyone reaches for first (`mur notes remove`) failed with
+/// `unrecognized subcommand`. Agent-local memories route to the same demotion
+/// `/forget` performs, so a memory removed from the CLI and one removed from a
+/// chat pane end in the same state rather than two.
+pub fn cmd_remove(name: &str, agent: Option<&str>) -> Result<()> {
+    let home = resolve_mur_home()?;
+    match agent {
+        Some(a) => {
+            let msg = crate::cmd::agent::cli::memory_cmds::forget(&home, a, Some(name))?;
+            println!("{msg}");
+        }
+        None => {
+            let dir = global_skill_dir(&home, name);
+            let manifest = read_from_dir(&dir).map_err(|_| anyhow!("note '{name}' not found"))?;
+            if manifest.category != Category::Note {
+                bail!(
+                    "'{name}' is not a note (category: {:?}) — use `mur skill remove` if you \
+                     meant to uninstall the skill",
+                    manifest.category
+                );
+            }
+            std::fs::remove_dir_all(&dir).with_context(|| format!("remove {}", dir.display()))?;
+            println!("removed note '{name}'");
+        }
+    }
+    Ok(())
 }
 
 /// A note rendered for `mur notes show`.

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -985,9 +985,14 @@ pub async fn run(cli: Cli) -> Result<()> {
             crate::cli::notes::NotesAction::Search { query, limit } => {
                 cmd::notes_cmd::cmd_search(&query, limit)?
             }
-            crate::cli::notes::NotesAction::List { maturity, limit } => {
-                cmd::notes_cmd::cmd_list(maturity.as_deref(), limit)?
+            crate::cli::notes::NotesAction::Remove { name, agent } => {
+                cmd::notes_cmd::cmd_remove(&name, agent.as_deref())?
             }
+            crate::cli::notes::NotesAction::List {
+                maturity,
+                limit,
+                agent,
+            } => cmd::notes_cmd::cmd_list(maturity.as_deref(), limit, agent.as_deref())?,
             crate::cli::notes::NotesAction::Show { name } => cmd::notes_cmd::cmd_show(&name)?,
         },
         // Deprecated: use `mur skill exchange`

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -465,10 +465,25 @@ async fn dispatch_tool(name: &str, arguments: &Value) -> Result<Value, String> {
                 })
                 .collect();
 
-            Ok(json!({
+            // Say what was searched. `do_search` reads the GLOBAL note store
+            // (`~/.mur/skills`) and never an agent's own memories, so a bare
+            // `count: 0` reads as "you remember nothing" when it means "nothing
+            // global matched". An agent asking what it remembers should use its
+            // built-in `recall`, which reads the set its own prompt was built
+            // from.
+            let mut out = json!({
                 "results": items,
                 "count": items.len(),
-            }))
+                "scope": "global notes only (~/.mur/skills)",
+            });
+            if items.is_empty() {
+                out["note"] = json!(
+                    "No GLOBAL note matched. This does not cover an agent's own memories — \
+                     an agent should call its built-in `recall` tool instead; from the CLI, \
+                     `mur notes list --agent <name>`."
+                );
+            }
+            Ok(out)
         }
 
         "mur_notes_show" => {


### PR DESCRIPTION
Closes #1060.

## The gap

An agent had **no path to its own memories**. MCP `mur_notes_search` calls
`notes_cmd::do_search`, whose first line is `mur_home.join("skills")` — the
global store, never `agents/<name>/skills/`. So an agent asked what it
remembers reached for the tool named for the question and got `0 results` while
the memory sat in its own home. That is not the agent guessing badly; the tool
structurally cannot do it.

## `recall` reads the snapshot, not the disk

The new built-in tool reads the live `RuntimeSkills` snapshot — **the same set
the prompt was built from**, so `recall` and the injected memory block cannot
disagree. A disk read would have reintroduced exactly the second source of truth
this area keeps producing.

It also covers what injection structurally cannot: memories past
`memory.max_in_prompt` / `max_chars` are in the snapshot but not the prompt.

Registered under the same capture gate as `remember` — an agent allowed to save
memories should be able to read them back, and one with capture off has none of
its own to read.

## `mur notes` could not delete

Removing a note meant `mur skill remove`, which works only because a note *is* a
`category: note` skill: true, discoverable nowhere, and the obvious command
failed with `unrecognized subcommand`. `mur notes remove [--agent <a>]` now
exists, and the agent-local route delegates to the same demotion `/forget`
performs — so a memory removed from the CLI and one removed from a chat pane
end in one state rather than two.

## Listings say what they cover

`mur notes list --agent <a>` renders through `/memories`' existing renderer
rather than growing a second listing of one fact. **Verified live:**

```
$ mur notes list
parallel-topology-guide   Draft   Full methodology behind parallel-decompose …

$ mur notes list --agent mur
memories visible to this agent (agent-local · federated · shared):
  reply-in-zh-tw            rule  agent    Draft  使用者要求一律以繁體中文回覆
  parallel-topology-guide   fact  shared   Draft  Full methodology behind …
```

`reply-in-zh-tw` was invisible from the CLI before this.

Empty results now name their scope. `No notes found.` read as "you have no
memories" when it meant "none are global"; the MCP result carries the same
correction, since a bare `count: 0` is what sent an agent down this path
originally.

## Not in this PR

**`mur notes search --agent`.** Scoring across scopes needs
`load_skill_candidates` extended to agent-local stats, which is its own change.
Shipping the honest subset beat half-doing the search — the empty-result message
points at `--agent` on `list` meanwhile.

**MCP scope plumbing.** Teaching the MCP server which agent called it would
mean an env-var contract between two binaries and six plumbing edits, and it
would still read the disk rather than the loaded snapshot — so it could disagree
with the prompt. `recall` gets it right by construction instead.

## Verification

Three `recall` tests, mutation-verified with two mutations that each fell
through to exactly one test and no other: dropping the note-kind filter fails
only `recall_ignores_skills_that_are_not_notes`; matching the name without the
body fails only `query_matches_the_body_not_only_the_name`.

CLI surfaces exercised against the real `~/.mur` (output above).
`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
full workspace nextest running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
