### PR TITLE
fix(lifecycle): key decay on replaceability, not on who typed it

### DIFF
--- a/mur-common/src/skill/lifecycle.rs
+++ b/mur-common/src/skill/lifecycle.rs
@@ -289,6 +289,27 @@ pub fn next_state(
 /// look. `Human`/`Hybrid` skills, curated skills, and a disabled gate all
 /// pass `proposed` through unchanged. States at or below `Emerging` are
 /// never raised.
+/// Whether decay may demote this item.
+///
+/// Decay arrived on 2026-02-25 as "Pattern Maturity + Automatic Decay" — the
+/// filter that made *automatic mining* survivable, because most of what a miner
+/// produces is noise and something had to prune it. The pattern pipeline was
+/// removed in #404 and notes inherited the machinery, but not the condition it
+/// depended on: a note holds what a human said or wrote, and an explicit
+/// statement does not become less true because nothing retrieved it this month.
+///
+/// So decay prunes exactly the set the promotion gate holds back — machine
+/// proposals no human has stood behind yet. `Human` and `Hybrid` are authored
+/// or reviewed by a person; a curated `Llm` item has been endorsed. None of
+/// them decay.
+///
+/// This governs demotion only. Evidence of actual failure (the broken-workflow
+/// fast path) still demotes anything, because that is a measurement, not a
+/// guess about staleness.
+pub fn decay_may_demote(provenance: Provenance, curated: bool) -> bool {
+    provenance == Provenance::Llm && !curated
+}
+
 pub fn cap_for_provenance(
     proposed: LifecycleState,
     provenance: Provenance,

--- a/mur-common/src/skill/lifecycle.rs
+++ b/mur-common/src/skill/lifecycle.rs
@@ -293,21 +293,29 @@ pub fn next_state(
 ///
 /// Decay arrived on 2026-02-25 as "Pattern Maturity + Automatic Decay" — the
 /// filter that made *automatic mining* survivable, because most of what a miner
-/// produces is noise and something had to prune it. The pattern pipeline was
-/// removed in #404 and notes inherited the machinery, but not the condition it
-/// depended on: a note holds what a human said or wrote, and an explicit
-/// statement does not become less true because nothing retrieved it this month.
+/// produces is noise. The pattern pipeline was removed in #404 and notes
+/// inherited the machinery, but not the condition it depended on.
 ///
-/// So decay prunes exactly the set the promotion gate holds back — machine
-/// proposals no human has stood behind yet. `Human` and `Hybrid` are authored
-/// or reviewed by a person; a curated `Llm` item has been endorsed. None of
-/// them decay.
+/// The axis is not human-versus-machine, which conflates MUR's own shipped
+/// builtins with what you wrote: deprecating a builtin you never use is
+/// correct, and `mur sync` puts it back. The axis is **replaceability**. Decay
+/// ends at `Archived`, `Archived` ends at `remove_dir_all`, and that is
+/// survivable only for content MUR can reinstall.
 ///
-/// This governs demotion only. Evidence of actual failure (the broken-workflow
-/// fast path) still demotes anything, because that is a measurement, not a
-/// guess about staleness.
-pub fn decay_may_demote(provenance: Provenance, curated: bool) -> bool {
-    provenance == Provenance::Llm && !curated
+/// So: machine proposals decay wherever they came from, MUR-published content
+/// decays because it is recoverable, and everything else — a `mur notes create`
+/// note, an agent memory, a skill you authored — does not.
+///
+/// Demotion only. Evidence of actual failure (the broken-workflow fast path)
+/// still demotes anything, because that is a measurement rather than a guess
+/// about staleness.
+pub fn decay_may_demote(publisher: &str, provenance: Provenance, curated: bool) -> bool {
+    // A machine proposal is noise until something proves otherwise, whoever
+    // published it.
+    if provenance == Provenance::Llm && !curated {
+        return true;
+    }
+    crate::skill::types::is_mur_owned_publisher(publisher)
 }
 
 pub fn cap_for_provenance(

--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -46,6 +46,21 @@ pub enum Category {
     Media,
 }
 
+/// Publishers whose on-disk copies MUR owns and may replace: the shipped
+/// builtins and the official catalog. Everything else — `human:local` from
+/// `mur notes create`, `agent:<name>` from the `remember` tool, a `human:<you>`
+/// skill you authored — is yours, and MUR cannot get it back if it removes it.
+///
+/// The list already existed in `sync_cmd` for "may I overwrite this?"; the
+/// lifecycle sweep needs the same question for "may I delete this?", and two
+/// copies of one list is how the answers start disagreeing.
+pub const MUR_OWNED_PUBLISHERS: &[&str] = &["human:mur-official", "human:mur"];
+
+/// Whether MUR published this and can therefore reinstall it.
+pub fn is_mur_owned_publisher(publisher: &str) -> bool {
+    MUR_OWNED_PUBLISHERS.contains(&publisher)
+}
+
 /// Where a skill came from. Drives the curation gate: `Llm`-authored skills
 /// cannot auto-promote past `Emerging` until a human curates them
 /// (amendment A1, `2026-05-28-mur-workflow-engine-design-v2.md`).

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1175,8 +1175,9 @@ const NEW_DEV_SKILL_NAMES: &[&str] = &[
     "mur-skill-authoring",
 ];
 
-/// Publishers whose on-disk copies we own and may update in place.
-const MUR_OFFICIAL_PUBLISHERS: &[&str] = &["human:mur-official", "human:mur"];
+/// Publishers whose on-disk copies we own and may update in place. Shared with
+/// the lifecycle sweep, which asks the same question about deletion.
+use mur_common::skill::types::MUR_OWNED_PUBLISHERS as MUR_OFFICIAL_PUBLISHERS;
 
 /// Never-shadow (spec 2026-07-23 §6): true when `name` is a dev-discipline
 /// builtin AND `dir/skill.yaml` exists but was not published by MUR.

--- a/mur-core/src/skill_lifecycle/sweep.rs
+++ b/mur-core/src/skill_lifecycle/sweep.rs
@@ -215,12 +215,25 @@ pub fn run_sweep(home: &Path, opts: SweepOptions) -> Result<SweepReport> {
             // above Emerging. Reuses the manifest loaded above; a missing
             // manifest defaults to Human (no cap), matching `#[serde(default)]`.
             let provenance = manifest.as_ref().map(|m| m.provenance).unwrap_or_default();
-            cap_for_provenance(
+            let curated = current.curated_at.is_some();
+            let capped = cap_for_provenance(
                 next_state(&current, opts.now, &opts.thresholds),
                 provenance,
-                current.curated_at.is_some(),
+                curated,
                 opts.require_human_curation_before_stable,
-            )
+            );
+            // Decay prunes what a machine proposed, never what a person stated.
+            // Without this a `mur skill sweep` walks a user-authored note down
+            // to Archived and, once the grace period passes, the destroy pass
+            // above deletes its directory outright. Promotion is untouched —
+            // only the downward move is held.
+            if rank(capped) < rank(current.lifecycle_state)
+                && !mur_common::skill::lifecycle::decay_may_demote(provenance, curated)
+            {
+                current.lifecycle_state
+            } else {
+                capped
+            }
         };
 
         let decayed_value = calculate_decay(
@@ -797,5 +810,129 @@ mod tests {
         ];
         // Only the final event forms a streak of 1.
         assert_eq!(consecutive_trailing_workflow_failures(&events), 1);
+    }
+
+    /// Stats that decay would walk DOWN: stale, never successful, low anchor.
+    fn decayed_grade_stats(
+        home: &std::path::Path,
+        name: &str,
+        now: chrono::DateTime<Utc>,
+        state: LifecycleState,
+    ) {
+        let mut s = SkillStats::new(name, "1", "digest", now - Duration::days(400));
+        s.lifecycle_state = state;
+        s.usage_count = 1;
+        s.success_count = 0;
+        s.last_used_at = Some(now - Duration::days(400));
+        s.last_success_at = Some(now - Duration::days(400));
+        s.anchor_confidence = 0.05;
+        // REQUIRED for the auto-archive branch in next_state(): without it the
+        // hard-archive condition is skipped entirely and decay bottoms out at
+        // Deprecated. The first version of this fixture omitted it and the
+        // destroy-pass test passed while proving nothing.
+        s.first_successful_use_at = Some(now - Duration::days(400));
+        s.lifecycle_changed_at = now - Duration::days(400);
+        let path = SkillStats::path(home, name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_string(&s).unwrap()).unwrap();
+    }
+
+    fn write_human_note(home: &std::path::Path, name: &str) {
+        std::fs::create_dir_all(home.join("skills").join(name)).unwrap();
+        std::fs::write(
+            home.join("skills").join(name).join("skill.yaml"),
+            format!(
+                "name: {name}\nversion: \"1\"\npublisher: me\ndescription: d\n\
+                 category: note\ncontent:\n  abstract: a\n  note: |\n    always reply in zh-TW\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn sweep_opts(now: chrono::DateTime<Utc>) -> SweepOptions {
+        SweepOptions {
+            filter: None,
+            dry_run: false,
+            now,
+            require_human_curation_before_stable: true,
+            thresholds: LifecycleThresholds::default(),
+            broken_workflow_streak: 3,
+            archive_destroy_grace_days: 30,
+        }
+    }
+
+    /// A note a person wrote must not be walked down by decay. Decay exists to
+    /// prune what a miner guessed; this is what the user said.
+    #[test]
+    fn decay_does_not_demote_a_human_authored_note() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_human_note(home, "reply-in-zh-tw");
+        decayed_grade_stats(home, "reply-in-zh-tw", now, LifecycleState::Stable);
+
+        run_sweep(home, sweep_opts(now)).unwrap();
+
+        let after = SkillStats::load(&SkillStats::path(home, "reply-in-zh-tw"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.lifecycle_state,
+            LifecycleState::Stable,
+            "a human-authored note must hold its state under decay"
+        );
+    }
+
+    /// The control: an uncurated machine proposal is exactly what decay is for,
+    /// and must still be demoted. Without this the fix would read as "nothing
+    /// decays any more".
+    #[test]
+    fn decay_still_demotes_an_uncurated_llm_skill() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_llm_skill(home, "mined-thing");
+        decayed_grade_stats(home, "mined-thing", now, LifecycleState::Stable);
+
+        run_sweep(home, sweep_opts(now)).unwrap();
+
+        let after = SkillStats::load(&SkillStats::path(home, "mined-thing"))
+            .unwrap()
+            .unwrap();
+        assert!(
+            rank(after.lifecycle_state) < rank(LifecycleState::Stable),
+            "an uncurated LLM skill must still decay; got {:?}",
+            after.lifecycle_state
+        );
+    }
+
+    /// The harm this closes, end to end: the destroy pass deletes the directory
+    /// of anything that reaches Archived. A human-authored note must never get
+    /// there by decay, so its files must still exist after a sweep.
+    #[test]
+    fn a_human_note_survives_the_destroy_pass() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_human_note(home, "kept-note");
+        decayed_grade_stats(home, "kept-note", now, LifecycleState::Draft);
+
+        // Enough rounds for the demotion chain (Draft → Deprecated → Archived)
+        // plus the destroy grace to elapse. Two sweeps was not enough and the
+        // test passed without the fix — it never reached the destroy pass.
+        for i in 0..12 {
+            run_sweep(home, sweep_opts(now + Duration::days(90 * i))).unwrap();
+        }
+
+        let state = SkillStats::load(&SkillStats::path(home, "kept-note"))
+            .unwrap()
+            .map(|s| s.lifecycle_state);
+        assert!(
+            home.join("skills")
+                .join("kept-note")
+                .join("skill.yaml")
+                .exists(),
+            "sweep deleted a note the user wrote (ended in {state:?})"
+        );
     }
 }

--- a/mur-core/src/skill_lifecycle/sweep.rs
+++ b/mur-core/src/skill_lifecycle/sweep.rs
@@ -222,13 +222,16 @@ pub fn run_sweep(home: &Path, opts: SweepOptions) -> Result<SweepReport> {
                 curated,
                 opts.require_human_curation_before_stable,
             );
-            // Decay prunes what a machine proposed, never what a person stated.
-            // Without this a `mur skill sweep` walks a user-authored note down
-            // to Archived and, once the grace period passes, the destroy pass
-            // above deletes its directory outright. Promotion is untouched —
-            // only the downward move is held.
+            // Decay ends at Archived, Archived ends at `remove_dir_all`, and
+            // that is only survivable for content MUR can reinstall. A missing
+            // manifest reads as MUR-owned: there is no file with content to
+            // lose, and orphaned stats should still be cleanable.
+            let publisher = manifest
+                .as_ref()
+                .map(|m| m.publisher.as_str())
+                .unwrap_or("human:mur");
             if rank(capped) < rank(current.lifecycle_state)
-                && !mur_common::skill::lifecycle::decay_may_demote(provenance, curated)
+                && !mur_common::skill::lifecycle::decay_may_demote(publisher, provenance, curated)
             {
                 current.lifecycle_state
             } else {
@@ -837,12 +840,23 @@ mod tests {
         std::fs::write(&path, serde_json::to_string(&s).unwrap()).unwrap();
     }
 
-    fn write_human_note(home: &std::path::Path, name: &str) {
+    /// A note as `mur notes create` writes it: `human:local`, which MUR cannot
+    /// put back.
+    fn write_user_note(home: &std::path::Path, name: &str) {
+        write_note_with_publisher(home, name, "human:local");
+    }
+
+    /// A note MUR shipped. Recoverable with `mur sync`, so decay may have it.
+    fn write_mur_note(home: &std::path::Path, name: &str) {
+        write_note_with_publisher(home, name, "human:mur");
+    }
+
+    fn write_note_with_publisher(home: &std::path::Path, name: &str, publisher: &str) {
         std::fs::create_dir_all(home.join("skills").join(name)).unwrap();
         std::fs::write(
             home.join("skills").join(name).join("skill.yaml"),
             format!(
-                "name: {name}\nversion: \"1\"\npublisher: me\ndescription: d\n\
+                "name: {name}\nversion: \"1\"\npublisher: {publisher}\ndescription: d\n\
                  category: note\ncontent:\n  abstract: a\n  note: |\n    always reply in zh-TW\n"
             ),
         )
@@ -861,14 +875,14 @@ mod tests {
         }
     }
 
-    /// A note a person wrote must not be walked down by decay. Decay exists to
-    /// prune what a miner guessed; this is what the user said.
+    /// A note the USER wrote must not be walked down by decay — MUR cannot put
+    /// it back.
     #[test]
-    fn decay_does_not_demote_a_human_authored_note() {
+    fn decay_does_not_demote_a_user_authored_note() {
         let tmp = tempfile::TempDir::new().unwrap();
         let home = tmp.path();
         let now = Utc::now();
-        write_human_note(home, "reply-in-zh-tw");
+        write_user_note(home, "reply-in-zh-tw");
         decayed_grade_stats(home, "reply-in-zh-tw", now, LifecycleState::Stable);
 
         run_sweep(home, sweep_opts(now)).unwrap();
@@ -879,7 +893,31 @@ mod tests {
         assert_eq!(
             after.lifecycle_state,
             LifecycleState::Stable,
-            "a human-authored note must hold its state under decay"
+            "a note the user wrote must hold its state under decay"
+        );
+    }
+
+    /// The control that separates "replaceable" from "human wrote it": a note
+    /// MUR shipped decays like anything else, because `mur sync` reinstalls it.
+    /// Without this the rule would read as "notes never decay", which is not
+    /// what was chosen — a builtin you never use SHOULD be deprioritised.
+    #[test]
+    fn decay_still_demotes_a_mur_published_note() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_mur_note(home, "shipped-note");
+        decayed_grade_stats(home, "shipped-note", now, LifecycleState::Stable);
+
+        run_sweep(home, sweep_opts(now)).unwrap();
+
+        let after = SkillStats::load(&SkillStats::path(home, "shipped-note"))
+            .unwrap()
+            .unwrap();
+        assert!(
+            rank(after.lifecycle_state) < rank(LifecycleState::Stable),
+            "a MUR-published note is recoverable and must still decay; got {:?}",
+            after.lifecycle_state
         );
     }
 
@@ -910,11 +948,11 @@ mod tests {
     /// of anything that reaches Archived. A human-authored note must never get
     /// there by decay, so its files must still exist after a sweep.
     #[test]
-    fn a_human_note_survives_the_destroy_pass() {
+    fn a_user_note_survives_the_destroy_pass() {
         let tmp = tempfile::TempDir::new().unwrap();
         let home = tmp.path();
         let now = Utc::now();
-        write_human_note(home, "kept-note");
+        write_user_note(home, "kept-note");
         decayed_grade_stats(home, "kept-note", now, LifecycleState::Draft);
 
         // Enough rounds for the demotion chain (Draft → Deprecated → Archived)


### PR DESCRIPTION
Implements #1062. **The rule changed after a dry run against a real store** —
the first version keyed on the wrong axis. Both versions are below, because the
correction is the interesting part.

## What I got wrong

Option 4 was "decay prunes what a machine proposed, not what a person wrote", and
I implemented it on `Provenance`. Then I ran `mur skill sweep --dry-run` against
a real `~/.mur`:

```
Examined: 62 skill(s)      Transitions (38)
provenance:  6 human · 56 human(default)     ← every single one resolves to Human
```

So the fix would have taken the sweep from **38 transitions to 0** — a no-op, not
a refinement. And the things it would have protected were mostly not the user's:

```
publisher:  42 human:mur · 19 human:mur-official · 1 human:david
```

`human:mur` is MUR's own shipped builtins. Deprecating one you never use is not
the bug — it is the feature, and `mur sync` puts it back. "Human versus machine"
conflates the vendor with the user.

## The axis that actually matters

**Replaceability.** Decay ends at `Archived`, `Archived` ends at
`remove_dir_all`, and that is survivable only for content MUR can reinstall.

| | decays | why |
|---|---|---|
| `human:mur`, `human:mur-official` | **yes** | MUR published it; `mur sync` restores it |
| `Provenance::Llm`, uncurated | **yes** | a machine proposed it; this is what decay is for |
| `human:local` (`mur notes create`) | no | you wrote it |
| `agent:<name>` (the `remember` tool) | no | your agent captured it for you |
| `human:<you>` (a skill you authored) | no | you wrote it |

`MUR_OWNED_PUBLISHERS` moves to `mur-common`. `sync_cmd` already kept that list
to answer *"may I overwrite this?"*; the sweep needs the same answer for *"may I
delete this?"*. Two copies is how the answers start disagreeing.

Demotion only — promotion is untouched, and the broken-workflow fast path still
demotes anything, because that is a measurement of failure rather than a guess
about staleness. The destroy pass is unchanged: an explicit `mur skill archive`
still leads to deletion after the grace period.

## Measured on the real store

```
before (v2.71.5):  Transitions (38)
after:             Transitions (37)   36 human:mur + 1 human:mur-official
                                      0 human:local, 0 agent:*
```

The one that dropped out is `fleet-issue-fix` — a skill the user authored. **The
sweep still does its job**; it just no longer reaches what MUR cannot give back.

## The precondition, and two tests that proved nothing

I described the deletion path as "decay → Archived → destroy" as if any stale
note walks it. Two versions of the test passed **with the fix reverted** before
I found why: `next_state` only proposes `Archived` when
`first_successful_use_at.is_some()` (`lifecycle.rs:225-239`). A note never
successfully used bottoms out at `Deprecated` — traced over twelve sweep rounds.

The real shape is narrower and more ordinary: a note **used once and then left
quiet** decays below the archive confidence, is auto-archived, and after the
grace period has its directory removed. Which is the normal life of a note. The
fixture now carries a comment naming that field as load-bearing.

## Verification

Two controls that must **not** move, so the rule cannot silently widen into
"nothing decays":

```
=== floor in place ===                    === floor reverted ===
decay_does_not_demote_a_user_authored_note  ok    FAILED
a_user_note_survives_the_destroy_pass       ok    FAILED
decay_still_demotes_a_mur_published_note    ok    ok      ← control
decay_still_demotes_an_uncurated_llm_skill  ok    ok      ← control
```

`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
full workspace nextest running.

## Not touched

Retrieval-side decay (`retrieve/scoring.rs`) still applies the same curves to
ranking. `NoteKind::default_half_life_factor`'s comment says the two systems
agree "unless deliberately tuned apart" — this tunes them apart deliberately.
Ranking a stale note lower is defensible; deleting it is not.

Sources are import-only, so none of this reaches a note-taking app: the Obsidian
adapter has `list_documents` / `fetch` / `chunk` and no write-back path. Nothing
MUR deletes can propagate to a vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
