### PR TITLE
feat(murmur): stop the tool line lying, and make gaps mean something

### DIFF
--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -288,6 +288,31 @@ fn hint_field(card: &StepCard) -> Option<&str> {
 /// that differs between two otherwise-identical commands) survives instead
 /// of being the first thing cut. Uses `floor_char_boundary`/
 /// `ceil_char_boundary` so multi-byte chars (CJK, emoji) can't be split.
+/// Keep the HEAD, cut at a word boundary.
+///
+/// For a shell command the identifying part is the front — the program and its
+/// first arguments — and the tail is routinely a branch that did not run.
+/// Middle-elision at 80 columns turned
+/// `grep -m1 '^version' Cargo.toml 2>/dev/null || head -20 Cargo.toml`
+/// into `grep -m1 '^version'… head -20 Cargo.toml`, which reads as though the
+/// fallback executed. At 60 it produced `grep -m1 '^…0 Cargo.toml`.
+///
+/// Cutting at the last space keeps the hint from ending mid-token, unless that
+/// would throw away most of the budget on a single long word.
+fn elide_tail_at_word(s: &str, budget: usize) -> String {
+    if s.len() <= budget {
+        return s.to_string();
+    }
+    let keep = budget.saturating_sub(ELLIPSIS_OVERHEAD);
+    let end = s.floor_char_boundary(keep);
+    let cut = match s[..end].rfind(' ') {
+        // Backing up past half the budget costs more than the ragged edge.
+        Some(i) if i * 2 >= end => i,
+        _ => end,
+    };
+    format!("{}…", s[..cut].trim_end())
+}
+
 fn elide_middle(s: &str, budget: usize) -> String {
     if s.len() <= budget {
         return s.to_string();
@@ -307,20 +332,24 @@ fn elide_middle(s: &str, budget: usize) -> String {
 }
 
 /// Compact arg hint for the header line (e.g. bash command, file path, query).
-/// For bash, strips a leading `cd <path> && ` segment first since it is
-/// session state repeated on every row and carries no distinguishing
-/// information. Elides the middle rather than the tail so truncation never
-/// eats the part that differs between two otherwise-similar calls.
+///
+/// Which end survives truncation depends on where the identity lives. Two calls
+/// to a file tool differ in the FILENAME, so paths elide the middle and keep
+/// both ends. Two `bash` calls differ in the PROGRAM and its first arguments,
+/// and a command's tail is routinely `|| fallback` or `2>/dev/null` — keeping
+/// it while dropping the front reports a branch that never ran.
+///
+/// Bash also loses a leading `cd <path> && `: session state repeated on every
+/// row, carrying nothing that distinguishes one call from the next.
 fn arg_hint(card: &StepCard, budget: usize) -> String {
     let Some(raw) = hint_field(card) else {
         return String::new();
     };
-    let s = if card.name.eq_ignore_ascii_case("bash") {
-        strip_cd_prefix(raw)
+    if card.name.eq_ignore_ascii_case("bash") {
+        elide_tail_at_word(strip_cd_prefix(raw), budget)
     } else {
-        raw
-    };
-    elide_middle(s, budget)
+        elide_middle(raw, budget)
+    }
 }
 
 #[cfg(test)]
@@ -375,6 +404,96 @@ mod tests {
         );
         assert!(text.contains("8ms"), "expected '8ms' in: {text}");
         assert!(text.contains('✔'), "expected '✔' in: {text}");
+    }
+
+    /// The real line from a real session, at the 80-column design baseline.
+    /// Middle-elision produced `grep -m1 '^version'… head -20 Cargo.toml`,
+    /// which reads as though the `||` fallback ran. It did not — grep
+    /// succeeded.
+    #[test]
+    fn a_shell_command_keeps_the_branch_that_ran() {
+        let cmd = "grep -m1 '^version' Cargo.toml 2>/dev/null || head -20 Cargo.toml";
+        let mut card = StepCard::new(
+            "s".into(),
+            "bash".into(),
+            serde_json::json!({ "command": cmd }),
+        );
+        card.state = crate::cmd::agent::cli::step::StepState::Done;
+
+        for width in [60u16, 80, 92] {
+            let hint = super::arg_hint(&card, super::hint_budget(width));
+            assert!(
+                hint.starts_with("grep -m1"),
+                "width {width}: the program must survive: {hint}"
+            );
+            assert!(
+                !hint.contains("head -20"),
+                "width {width}: reported a fallback branch that never ran: {hint}"
+            );
+        }
+    }
+
+    /// No half-tokens. Middle-elision produced `Cargo…ull` at 92 columns and
+    /// `'^…0` at 60 — fragments that mean nothing.
+    #[test]
+    fn a_truncated_command_never_ends_mid_token() {
+        let cmd = "grep -m1 '^version' Cargo.toml 2>/dev/null || head -20 Cargo.toml";
+        for budget in [24usize, 30, 40, 52] {
+            let hint = super::elide_tail_at_word(cmd, budget);
+            let body = hint.trim_end_matches('…');
+            assert!(
+                cmd.starts_with(body),
+                "budget {budget}: not a prefix of the command: {hint}"
+            );
+            assert!(
+                cmd[body.len()..].starts_with(' ') || body.len() == cmd.len(),
+                "budget {budget}: cut mid-token: {hint}"
+            );
+        }
+    }
+
+    /// Negative control on the ROUTING: a path must still elide the middle, so
+    /// two file calls differing only in the filename stay distinguishable.
+    /// Flipping paths to head-keep would render them identically.
+    #[test]
+    fn two_paths_differing_only_in_filename_stay_distinct() {
+        let hint_for = |path: &str| {
+            let mut card = StepCard::new(
+                "s".into(),
+                "read_file".into(),
+                serde_json::json!({ "path": path }),
+            );
+            card.state = crate::cmd::agent::cli::step::StepState::Done;
+            super::arg_hint(&card, 24)
+        };
+        let a = hint_for("mur-core/src/cmd/agent/cli/alpha.rs");
+        let b = hint_for("mur-core/src/cmd/agent/cli/omega.rs");
+        assert!(a.contains('…'), "expected elision at this budget: {a}");
+        assert_ne!(
+            a, b,
+            "two file calls must not render identically: {a} / {b}"
+        );
+    }
+
+    /// The cost of head-keep, stated rather than hidden: two commands that
+    /// differ only in their tail DO collapse to the same hint. That is accepted
+    /// — the header is a hint and expanding shows the full command, whereas
+    /// keeping the tail actively reports a branch that never ran.
+    #[test]
+    fn head_keep_trades_tail_detail_for_an_honest_front() {
+        let hint_for = |cmd: &str| {
+            let mut card = StepCard::new(
+                "s".into(),
+                "bash".into(),
+                serde_json::json!({ "command": cmd }),
+            );
+            card.state = crate::cmd::agent::cli::step::StepState::Done;
+            super::arg_hint(&card, 30)
+        };
+        let a = hint_for("grep -m1 '^version' Cargo.toml 2>/dev/null || head -20 a.toml");
+        let b = hint_for("grep -m1 '^version' Cargo.toml 2>/dev/null || head -20 b.toml");
+        assert_eq!(a, b, "documented trade-off");
+        assert!(a.starts_with("grep -m1"), "{a}");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -592,6 +592,30 @@ fn push_live(lines: &mut Vec<Line<'static>>, app: &App, m: &ChatMsg, skip: usize
 /// short by exactly the lines markdown folded away, with no way to pull them
 /// back out of scrollback. Measuring settled means the band is exactly full
 /// after the turn; while streaming it simply tail-follows, as it always has.
+/// Whether a gap row goes before this message.
+///
+/// A gap means "the speaker changed". A step card is a step *inside* the turn
+/// that precedes it, so a run of ten tool calls used to cost ten gap rows and
+/// read as ten unrelated events — twenty rows of scrollback for ten facts.
+/// Suppressing the gap there is what turns vertical rhythm into grouping
+/// instead of uniform repetition: every remaining gap now marks a real
+/// boundary.
+fn wants_gap_before(m: &super::app::ChatMsg) -> bool {
+    m.step.is_none()
+}
+
+/// The gap row itself — a rule when the skin asks for one, otherwise a blank.
+fn gap_row(theme: &'static super::theme::Theme) -> Line<'static> {
+    if theme.show_separator {
+        Line::styled(
+            "─".repeat(SEPARATOR_WIDTH),
+            Style::default().fg(theme.separator),
+        )
+    } else {
+        Line::default()
+    }
+}
+
 fn push_live_measured(lines: &mut Vec<Line<'static>>, app: &App, m: &ChatMsg, skip: usize) {
     push_live_inner(lines, app, m, skip, true)
 }
@@ -756,15 +780,8 @@ pub fn flush_finished<B: Backend>(
             let msg_skip = if i == start { skip } else { 0 };
             // Separator between messages — never before a continuation, which
             // resumes a message whose head is already in scrollback.
-            if i > 0 && msg_skip == 0 {
-                if theme.show_separator {
-                    lines.push(Line::styled(
-                        "─".repeat(SEPARATOR_WIDTH),
-                        Style::default().fg(theme.separator),
-                    ));
-                } else {
-                    lines.push(Line::default());
-                }
+            if i > 0 && msg_skip == 0 && wants_gap_before(&app.messages[i]) {
+                lines.push(gap_row(theme));
             }
             push_live(&mut lines, app, &app.messages[i], msg_skip);
         }
@@ -796,14 +813,10 @@ pub fn flush_finished<B: Backend>(
         let mut lines: Vec<Line<'static>> = Vec::new();
         if skip == 0 {
             if app.flushed_upto > 0 {
-                if theme.show_separator {
-                    lines.push(Line::styled(
-                        "─".repeat(SEPARATOR_WIDTH),
-                        Style::default().fg(theme.separator),
-                    ));
-                } else {
-                    lines.push(Line::default());
-                }
+                // This path only ever emits an agent turn's own body, which
+                // always opens a turn — no `wants_gap_before` test needed, but
+                // the row itself comes from the one builder.
+                lines.push(gap_row(theme));
             }
             lines.push(Line::from(Span::styled(
                 "● agent".to_string(),
@@ -2141,5 +2154,60 @@ mod status_chip_tests {
             !dump.contains("019ff831:"),
             "the chip must not append a second state word: {dump}"
         );
+    }
+}
+
+#[cfg(test)]
+mod gap_tests {
+    use super::super::app::{ChatMsg, Role};
+    use super::super::step::StepCard;
+    use super::super::theme::{DARK, MUR};
+    use super::{gap_row, wants_gap_before};
+
+    fn card_msg() -> ChatMsg {
+        ChatMsg::tool_for_test(StepCard::new(
+            "s".into(),
+            "bash".into(),
+            serde_json::json!({"command": "ls"}),
+        ))
+    }
+
+    /// The whole point: a run of tool calls is one block of work, not N
+    /// separate events. Ten calls used to cost ten gap rows.
+    #[test]
+    fn a_tool_call_does_not_open_a_gap() {
+        assert!(!wants_gap_before(&card_msg()));
+    }
+
+    /// Control — if this ever flips, gaps stop marking anything at all.
+    #[test]
+    fn a_spoken_turn_still_opens_a_gap() {
+        assert!(wants_gap_before(&ChatMsg::for_test(Role::User, "hi")));
+        assert!(wants_gap_before(&ChatMsg::for_test(Role::Agent, "hello")));
+        assert!(wants_gap_before(&ChatMsg::for_test(Role::System, "note")));
+    }
+
+    /// One builder for the row, so the two emit paths cannot drift into
+    /// different-looking gaps.
+    #[test]
+    fn the_gap_row_follows_the_skin() {
+        let blank: String = gap_row(&DARK)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            blank.trim().is_empty(),
+            "dark skin uses a blank row: {blank:?}"
+        );
+
+        let ruled: String = gap_row(&MUR)
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        if MUR.show_separator {
+            assert!(ruled.contains('─'), "a ruled skin draws a rule: {ruled:?}");
+        }
     }
 }


### PR DESCRIPTION
Two TUI fixes from a P1 diagnostic. Both were found by running a real transcript
through the real renderer at several widths — neither is visible in a screenshot.

## The tool line reported a command that never ran

Middle-elision keeps head and tail. That is right for a **path** — two file
calls differ in the filename — and wrong for a **shell command**, whose tail is
routinely `|| fallback` or `2>/dev/null`.

The actual line from the reporting session, `grep -m1 '^version' Cargo.toml
2>/dev/null || head -20 Cargo.toml`:

| width | rendered as | |
|---|---|---|
| 92 | `grep -m1 '^version' Cargo…ull \|\| head -20 Cargo.toml` | `Cargo…ull` is a fragment |
| **80** | `grep -m1 '^version'… head -20 Cargo.toml` | **reads as though the fallback ran** |
| 60 | `grep -m1 '^…0 Cargo.toml` | `'^…0` means nothing |

grep succeeded; `head` never executed. 80 columns is the design baseline, and
the line was misreporting there.

`arg_hint` now routes by tool — bash keeps its head and cuts at a word boundary,
everything else keeps both ends unchanged.

**The trade-off is a test, not a footnote.** Two commands differing only in their
tails now collapse to the same hint. Accepted: the header is a hint and expanding
shows the whole command, whereas keeping the tail actively misreports which
branch ran.

## Every gap was the same size, so no gap meant anything

A blank row sat between each pair of messages regardless of whether the speaker
changed. Ten tool calls cost ten gap rows and read as ten unrelated events —
twenty rows of scrollback for ten facts.

Gaps now mark a change of speaker. A step card is a step *inside* the turn that
precedes it, so it opens none:

```
you ›                          you ›
  Which version of mur?          Which version of mur?
                          →
✔ approved `bash`              ✔ approved `bash`
                               ✔ bash grep -m1 '^version' Cargo.toml…
✔ bash grep…
                               ● agent
● agent                          2.71.3 — …
  2.71.3 — …
                                                       ← gap = new turn
```

The two copies of the gap-drawing code collapse into one builder, because two
ways to draw one thing is how they start looking different.

## What the diagnostic also refuted

I had claimed murmur's hierarchy was carried almost entirely by colour. Stripping
every style from the real render shows otherwise — `you ›` / `● agent` labels,
two-space indents, `✔ ⚠ ✘` glyphs and the `SETTLEMENT` header all survive, and
the whole transcript carries only **10 coloured spans**. Colour is reinforcing,
which is what it should do. No colour work is in this PR as a result.

## Verification

Each rule has a control that must **not** move, so neither can quietly widen:

| | rule | control |
|---|---|---|
| elision | a command keeps the branch that ran | a path still keeps both ends |
| gaps | a tool call opens no gap | a spoken turn still opens one |

Both mutation-verified; reverting each rule fails only its own test and leaves
the control passing.

**One test of mine never passed.** It asserted a 24-column budget could hold a
full filename — it cannot — and a truncated `head -14` of the output hid that
from me. Replaced with the property that matters: two paths differing only in
filename must not render identically.

`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
full workspace nextest running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
