### PR TITLE
chore(release): bump workspace version to 2.71.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.5"
+version = "2.71.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.5"
+version = "2.71.6"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases five merged changes. **Merging this PR is the release** — `tag.yml`
tags `v2.71.6` on the merge commit and dispatches `release.yml`, which publishes
to crates.io. Irreversible, yank only. This PR is the release approval; there is
no later gate.

## What ships

**Agents can read their own memories** (#1061). MCP `mur_notes_search` reads the
global note store and structurally cannot see an agent's own memories — an agent
asked what it remembers got `0 results` while the memory sat in its home. The new
built-in `recall` reads the live snapshot the prompt was built from, so the two
cannot disagree. `mur notes remove` and `mur notes list --agent` fill the matching
CLI gaps.

**Decay no longer deletes what you wrote** (#1063). `mur skill sweep` could walk
a `mur notes create` note to Archived and, after the grace period,
`remove_dir_all` its directory. Decay now prunes by replaceability: MUR-published
content and uncurated machine proposals, never `human:local`, `agent:*`, or a
skill you authored. Measured on a real store: 38 transitions before, 37 after —
the sweep still works, it just cannot reach what MUR can't reinstall.

**The tool line stops misreporting** (#1064). At 80 columns,
`grep … Cargo.toml 2>/dev/null || head -20 Cargo.toml` rendered as
`grep -m1 '^version'… head -20 Cargo.toml` — reading as though the fallback ran.
Shell commands now keep their head and cut at a word boundary. Transcript gaps
now mark a change of speaker instead of appearing between every pair of messages.

**`mur update --restart-agents` stops lying** (#1058). It returned success
without touching an agent whenever the CLI was already current, saying nothing
about the skip.

**README** (#1059) documents `mur agent dial` and memory that takes effect
without a restart.

## Verification

Local `cargo nextest run --workspace`: 7865 passed, 0 failed. Every new rule in
these PRs carries a control that must not move, and each was mutation-verified.

`recall` and the decay exemption have not yet been exercised on a live agent —
both ship in binaries, so that check runs after this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)