### PR TITLE
fix(runtime): recall needs no approval, and the policy order is now testable

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1311,19 +1311,8 @@ impl TaskRunner {
 
         // 1b. Policy gate: check before executing.
         {
-            use mur_common::agent::{ToolPolicy, resolve_tool_policy_opt};
-            let policy = if crate::tools::suggest::suggest_replies_allowed(&call.tool_name) {
-                ToolPolicy::Allow
-            } else {
-                // issue #3: dispatch/spend tools (parallel_jobs, fleet_run,
-                // delegate_to) must ask BEFORE executing. The HITL gate below
-                // is now a pre-execution gate (execute happens only after an
-                // Allow decision), so `Ask` provides real spend protection and
-                // fleet_run no longer needs its old `None => Allow` special
-                // case. Unknown tools fall through to `ToolPolicy::default()`,
-                // which is `Ask` — fail-closed.
-                resolve_tool_policy_opt(&self.tools_policy, &call.tool_name).unwrap_or_default()
-            };
+            use mur_common::agent::ToolPolicy;
+            let policy = effective_tool_policy(&self.tools_policy, &call.tool_name);
             match policy {
                 ToolPolicy::Deny => {
                     return Ok(ToolResultEntry {
@@ -2197,6 +2186,37 @@ fn user_message(input: &Message) -> crate::llm::RichMessage {
             role: input.role.clone(),
             content: text,
         },
+    }
+}
+
+/// Effective policy for one tool call.
+///
+/// Extracted from the gate so the ordering is testable: an inline
+/// `if A || (B && C)` compiled fine with the `&& C` removed, which would have
+/// let an exemption silently override an operator's explicit `deny`.
+///
+/// Order is the whole content:
+/// 1. `suggest_replies` is a no-op the model uses to offer choices.
+/// 2. An explicit rule always wins — exemptions set defaults, never overrides.
+/// 3. `recall` defaults to Allow: a pure read of this agent's own snapshot,
+///    which cannot surface anything the injector would not have injected given
+///    more budget. Under `Ask` it parks for `hitl.timeout_secs` on every path
+///    with no human to answer.
+/// 4. Everything else falls to `ToolPolicy::default()` — `Ask`, fail-closed.
+///    Dispatch/spend tools (`parallel_jobs`, `fleet_run`, `delegate_to`) must
+///    ask BEFORE executing, which is what makes `Ask` real spend protection.
+fn effective_tool_policy(
+    rules: &[mur_common::agent::ToolRule],
+    tool_name: &str,
+) -> mur_common::agent::ToolPolicy {
+    use mur_common::agent::{ToolPolicy, resolve_tool_policy_opt};
+    if crate::tools::suggest::suggest_replies_allowed(tool_name) {
+        return ToolPolicy::Allow;
+    }
+    match resolve_tool_policy_opt(rules, tool_name) {
+        Some(explicit) => explicit,
+        None if crate::tools::recall::recall_needs_no_approval(tool_name) => ToolPolicy::Allow,
+        None => ToolPolicy::default(),
     }
 }
 
@@ -4046,6 +4066,70 @@ mod deny_message_tests {
         assert_eq!(
             deny_message(Some("no approval channel available")),
             "tool call denied: no approval channel available"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tool_policy_tests {
+    use super::effective_tool_policy;
+    use mur_common::agent::{ToolPolicy, ToolRule};
+
+    fn rule(pattern: &str, policy: ToolPolicy) -> ToolRule {
+        ToolRule {
+            pattern: pattern.into(),
+            policy,
+            risk: Default::default(),
+        }
+    }
+
+    /// The fix: with no rule, `recall` runs instead of parking for
+    /// `hitl.timeout_secs` on a path where nothing can approve.
+    #[test]
+    fn recall_defaults_to_allow() {
+        assert_eq!(effective_tool_policy(&[], "recall"), ToolPolicy::Allow);
+    }
+
+    /// The guard that matters. An exemption sets a DEFAULT; an operator's
+    /// explicit rule must still decide. Written at the call site because the
+    /// earlier inline form compiled fine with this half deleted.
+    #[test]
+    fn an_explicit_rule_beats_the_exemption() {
+        assert_eq!(
+            effective_tool_policy(&[rule("recall", ToolPolicy::Deny)], "recall"),
+            ToolPolicy::Deny
+        );
+        assert_eq!(
+            effective_tool_policy(&[rule("rec*", ToolPolicy::Deny)], "recall"),
+            ToolPolicy::Deny,
+            "a wildcard rule counts as explicit too"
+        );
+    }
+
+    /// Control: everything else stays fail-closed. If this flips, the
+    /// exemption has leaked into a general "allow unknown tools".
+    #[test]
+    fn unknown_tools_still_ask() {
+        for name in [
+            "bash",
+            "remember",
+            "fleet_run",
+            "parallel_jobs",
+            "recall_all",
+        ] {
+            assert_eq!(
+                effective_tool_policy(&[], name),
+                ToolPolicy::Ask,
+                "{name} must stay gated"
+            );
+        }
+    }
+
+    #[test]
+    fn suggest_replies_is_still_exempt() {
+        assert_eq!(
+            effective_tool_policy(&[], "suggest_replies"),
+            ToolPolicy::Allow
         );
     }
 }

--- a/mur-agent-runtime/src/tools/recall.rs
+++ b/mur-agent-runtime/src/tools/recall.rs
@@ -25,6 +25,22 @@ pub struct RecallTool {
     pub skills: Arc<RuntimeSkills>,
 }
 
+/// `recall` never needs an approval gate.
+///
+/// It is a pure read of this agent's own in-memory snapshot — no filesystem, no
+/// network, no spend, no side effect — and it cannot surface anything the
+/// injector would not have injected given more budget. Gating it gates the
+/// agent's own context, and the default policy is `Ask`, so on any path without
+/// a human to answer (`mur agent send`, a cron fire, a fleet step) the call
+/// parks for `hitl.timeout_secs` and then fails.
+///
+/// Same shape as `suggest_replies_allowed`: registration is already gated —
+/// here by `memory.capture` — so the tool policy has nothing left to protect.
+/// An explicit `deny` rule still wins; this only changes the default.
+pub fn recall_needs_no_approval(name: &str) -> bool {
+    name == RECALL
+}
+
 #[async_trait::async_trait]
 impl ToolExecutor for RecallTool {
     fn name(&self) -> &str {
@@ -135,6 +151,18 @@ mod tests {
         RecallTool {
             skills: Arc::new(RuntimeSkills::build(loaded)),
         }
+    }
+
+    /// The default is `Ask`, so without this exemption every path with no human
+    /// to answer — `mur agent send`, a cron fire, a fleet step — parks for
+    /// `hitl.timeout_secs` and then fails. `recall` has nothing for a gate to
+    /// protect: it reads the snapshot the prompt was already built from.
+    #[test]
+    fn recall_is_exempt_but_only_by_name() {
+        assert!(recall_needs_no_approval(RECALL));
+        assert!(!recall_needs_no_approval("remember"));
+        assert!(!recall_needs_no_approval("bash"));
+        assert!(!recall_needs_no_approval("recall_all"));
     }
 
     /// The gap this closes: an agent could not read its OWN memories. The MCP


### PR DESCRIPTION
Fixes the `recall` half of #1066.

## The problem

`recall` shipped in v2.71.6 **registered but unusable**. No rule matches it, so
it resolves to `ToolPolicy::default()` — `Ask` — and on any path with no human to
answer (`mur agent send`, a cron fire, a fleet step) the call parks for
`hitl.timeout_secs` and then fails. On a live agent that is 300 seconds of
nothing, ending in a task that carries no agent message and no hint that
approval was the cause.

`recall` is a pure read of the agent's own in-memory snapshot — no filesystem, no
network, no spend, no side effect — and it cannot surface anything the injector
would not have injected given more budget. **Gating it gates the agent's own
context.** Registration is already gated by `memory.capture`, which is the same
shape as the existing `suggest_replies_allowed` exemption.

## The part I nearly got wrong

The exemption must set a *default*, never an *override* — an operator who denies
`recall` still gets a denial. The first version wrote that inline:

```rust
if suggest_allowed(name) || (recall_exempt(name) && rules_lookup(name).is_none())
```

That compiles perfectly well with the `&&` half deleted, and **nothing failed
when I tried it**. A boolean condition buried in a 100-line async fn had no seam
a test could reach, so the guard existed only in my head and in a comment.

`effective_tool_policy` now states the order once, somewhere testable:

| | |
|---|---|
| `suggest_replies` | Allow |
| an explicit rule | **that rule** — exemptions never override |
| `recall`, no rule | Allow |
| anything else | Ask — fail-closed |

## Verification

Two mutations, each failing only its own guard:

```
exemption becomes an override  → an_explicit_rule_beats_the_exemption  FAILED
                                 unknown_tools_still_ask               ok
unknown tools become Allow     → unknown_tools_still_ask               FAILED
                                 an_explicit_rule_beats_the_exemption  ok
```

`unknown_tools_still_ask` covers `bash`, `remember`, `fleet_run`,
`parallel_jobs` and `recall_all` — so the exemption cannot leak into a general
"allow unknown tools", and a near-miss name does not inherit it.

Also caught while writing this: my first test claimed to guard the call site but
only exercised `resolve_tool_policy_opt` in isolation, which is why the mutation
above passed. Testing the extracted function is what makes the claim true.

## Left open in #1066

The wasted `hitl.timeout_secs` park when nothing can approve. The runtime cannot
tell a TUI that will show a prompt from a one-shot `message/send` that never
will — both supply a notifier — so fixing it means the client declaring whether
it can approve. That is a protocol change and its own piece of work. `remember`
and every other `Ask` tool stay exposed to it.

`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean;
full workspace nextest running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
