### PR TITLE
chore(release): bump workspace version to 2.71.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.6"
+version = "2.71.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.6"
+version = "2.71.7"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases two fixes. **Merging this PR is the release** — `tag.yml` tags
`v2.71.7` and dispatches `release.yml`, which publishes to crates.io.
Irreversible, yank only.

## What ships

**`recall` no longer needs approval** (#1069). It shipped in v2.71.6 registered
but unusable: no rule matched it, so it resolved to `Ask`, and on any path with
no human to answer — `mur agent send`, a cron fire, a fleet step — the call
parked for `hitl.timeout_secs` (300s on a real agent) and then failed with a task
carrying no agent message. It is a pure read of the agent's own snapshot and
cannot surface anything the injector would not have injected given more budget.
The exemption sets a default; an explicit `deny` still wins, which is now
enforced by a test rather than by a comment.

**One gap rule across all three renderers** (#1071). The viewport drew no gaps
at all while the scrollback emit drew them, so the same transcript was dense on
screen and spaced once it scrolled up. The row measurement that decides where to
cut between the two counted rows without the gaps, leaving the band taller than
the number the flush decision used. `message_block` now produces the rows once,
for all three.

## Verification

Local `cargo nextest run --workspace`: 7878 passed, 0 failed. Every rule carries
a control that must not move, and each was mutation-verified — including one
mutation that restores the shipped measurement bug exactly.

The viewport change is verified after this release, in a tmux pane pinned to 80
columns, by comparing spacing above and below the viewport border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)