### PR TITLE
fix(runtime): a caller that cannot approve gets the denial at once

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/message_send.rs
+++ b/mur-agent-runtime/src/protocol/methods/message_send.rs
@@ -72,6 +72,14 @@ impl MethodHandler for MessageSendHandler {
         let p = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
         let message: Message = serde_json::from_value(p["message"].clone())
             .map_err(|e| HandlerError::InvalidParams(format!("message: {e}")))?;
+        // Whether a human is reading this connection and can answer an approval
+        // prompt. Absent means yes — every client that predates this field is
+        // an interactive one, and defaulting the other way would make them all
+        // start refusing gated tools. `mur agent send` passes false.
+        let can_approve = p
+            .get("can_approve")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
         let context_task_id = p
             .get("context")
             .and_then(|c| c.get("task_id"))
@@ -118,7 +126,7 @@ impl MethodHandler for MessageSendHandler {
                 // connection (looked up by task id inside the runner).
                 if let Some(tid) = &turn_task_id {
                     self.runner
-                        .register_client_notifier(tid, notifier.clone())
+                        .register_client_notifier(tid, notifier.clone(), can_approve)
                         .await;
                 }
                 // Steering channel: only when this turn has a task id to address

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -145,6 +145,13 @@ impl ConversationStore {
     }
 }
 
+/// Where a turn's approval prompt goes, and whether anyone there can answer it.
+///
+/// The bool is the half that matters: a one-shot `mur agent send` receives
+/// deltas and step events perfectly well, so the sink alone cannot tell it from
+/// a murmur TUI with a human watching.
+type ApprovalSink = (tokio::sync::mpsc::Sender<serde_json::Value>, bool);
+
 pub struct TaskRunner {
     backend: RunnerBackend,
     registry: Arc<Mutex<HashMap<String, TaskState>>>,
@@ -199,9 +206,7 @@ pub struct TaskRunner {
     /// client — deltas and step events reach it fine — but nobody is reading
     /// for a `y`. Without this the gate could not tell the two apart and waited
     /// the full `hitl.timeout_secs` for an answer that was never coming.
-    client_notifiers: Arc<
-        tokio::sync::Mutex<HashMap<String, (tokio::sync::mpsc::Sender<serde_json::Value>, bool)>>,
-    >,
+    client_notifiers: Arc<tokio::sync::Mutex<HashMap<String, ApprovalSink>>>,
     /// Per-turn steering channels keyed by task id. A running agentic loop
     /// holds the receiver; `turn/steer` pushes a user interjection here and the
     /// loop picks it up at the next iteration boundary.

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -193,8 +193,15 @@ pub struct TaskRunner {
     /// Per-turn client notifiers keyed by task id, registered by `message/send`
     /// so a tool-approval prompt is routed to the connection that issued the
     /// turn instead of broadcast to every client. Falls back to `notifier`.
-    client_notifiers:
-        Arc<tokio::sync::Mutex<HashMap<String, tokio::sync::mpsc::Sender<serde_json::Value>>>>,
+    ///
+    /// The flag is whether that connection can actually answer an approval
+    /// prompt. A one-shot `mur agent send` supplies a sink like any other
+    /// client — deltas and step events reach it fine — but nobody is reading
+    /// for a `y`. Without this the gate could not tell the two apart and waited
+    /// the full `hitl.timeout_secs` for an answer that was never coming.
+    client_notifiers: Arc<
+        tokio::sync::Mutex<HashMap<String, (tokio::sync::mpsc::Sender<serde_json::Value>, bool)>>,
+    >,
     /// Per-turn steering channels keyed by task id. A running agentic loop
     /// holds the receiver; `turn/steer` pushes a user interjection here and the
     /// loop picks it up at the next iteration boundary.
@@ -473,15 +480,19 @@ impl TaskRunner {
 
     /// Register the connection sink that should receive this turn's HITL
     /// approval prompts, keyed by the turn's task id.
+    /// `can_approve` says whether a human is reading this connection and able
+    /// to answer an approval prompt. `false` makes the gate deny at once
+    /// instead of waiting out `hitl.timeout_secs` for nobody.
     pub async fn register_client_notifier(
         &self,
         task_id: &str,
         tx: tokio::sync::mpsc::Sender<serde_json::Value>,
+        can_approve: bool,
     ) {
         self.client_notifiers
             .lock()
             .await
-            .insert(task_id.to_string(), tx);
+            .insert(task_id.to_string(), (tx, can_approve));
     }
 
     /// Drop the per-turn HITL sink once the turn completes.
@@ -1304,7 +1315,12 @@ impl TaskRunner {
         // Resolve step notifier once (route by task id, fall back to baked notifier).
         // Used for step/started + step/completed in both Allow and Ask arms.
         let step_notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>> = {
-            let routed = self.client_notifiers.lock().await.get(task_id).cloned();
+            let routed = self
+                .client_notifiers
+                .lock()
+                .await
+                .get(task_id)
+                .map(|(tx, _)| tx.clone());
             routed.or_else(|| self.notifier.clone())
         };
         let step_id = uuid::Uuid::now_v7().to_string();
@@ -1391,9 +1407,20 @@ impl TaskRunner {
                     // broadcast. fail-closed: with no approval sink wired
                     // (pending_approvals or notifier missing) the decision is
                     // DENY, so dispatch/spend tools cannot run unattended.
-                    let routed = self.client_notifiers.lock().await.get(task_id).cloned();
+                    let entry = self.client_notifiers.lock().await.get(task_id).cloned();
+                    // A connection that declared it cannot approve is not an
+                    // approval sink, however well it receives everything else.
+                    // Waiting on it burns `hitl.timeout_secs` and then returns
+                    // the same denial — and the silence in between reads as
+                    // "the agent had nothing to say", which is how this cost me
+                    // a misdiagnosis rather than five minutes.
+                    let shortcut =
+                        decide_without_asking(entry.as_ref().map(|(_, ok)| *ok), &call.tool_name);
+                    let routed = entry.map(|(tx, _)| tx);
                     let effective_notifier = routed.as_ref().or(self.notifier.as_ref());
-                    let decision = if let (Some(pa), Some(notifier)) =
+                    let decision = if let Some(d) = shortcut {
+                        d
+                    } else if let (Some(pa), Some(notifier)) =
                         (&self.pending_approvals, effective_notifier)
                     {
                         let hitl_id = uuid::Uuid::now_v7().to_string();
@@ -2135,6 +2162,37 @@ fn last_assistant_text(history: &[crate::llm::RichMessage]) -> Option<String> {
 /// — adds nothing the prefix has not already said, and appending it anyway
 /// printed `tool call denied: denied` (#940). Only a reason that carries new
 /// information is appended.
+/// The answer the gate already knows, before it sends a prompt to anyone.
+///
+/// `Some(false)` means the caller told us it cannot answer an approval prompt —
+/// a one-shot `mur agent send`, a cron fire, a script. Waiting on it burns the
+/// whole `hitl.timeout_secs` and then returns this same denial, and the silence
+/// in between reads as "the agent had nothing to say". That cost a
+/// misdiagnosis, not just five minutes: the turn came back with no agent
+/// message and nothing naming approval as the cause.
+///
+/// `Some(true)` and `None` both fall through to asking — an interactive client,
+/// or no routed entry at all, where the existing no-sink handling applies.
+///
+/// Extracted because the same shape as an inline condition was untestable: a
+/// test of the map that carries the flag says nothing about whether the gate
+/// reads it.
+fn decide_without_asking(
+    can_approve: Option<bool>,
+    tool_name: &str,
+) -> Option<crate::hitl::HitlDecision> {
+    if can_approve != Some(false) {
+        return None;
+    }
+    Some(crate::hitl::HitlDecision {
+        allow: false,
+        reason: Some(format!(
+            "`{tool_name}` needs approval and this caller cannot give one — run it from \
+             `murmur`, or allow the tool with `mur agent perm tool-allow <agent> {tool_name}`"
+        )),
+    })
+}
+
 fn deny_message(reason: Option<&str>) -> String {
     match reason.map(str::trim) {
         Some(r) if !r.is_empty() && r != "denied" => format!("tool call denied: {r}"),
@@ -4131,5 +4189,88 @@ mod tool_policy_tests {
             effective_tool_policy(&[], "suggest_replies"),
             ToolPolicy::Allow
         );
+    }
+}
+
+#[cfg(test)]
+mod approver_tests {
+    use super::TaskRunner;
+    use std::sync::Arc;
+
+    fn runner() -> Arc<TaskRunner> {
+        Arc::new(TaskRunner::new_stub_echo())
+    }
+
+    /// The fix: a caller that cannot approve gets the denial immediately,
+    /// instead of after `hitl.timeout_secs` of silence.
+    #[test]
+    fn a_caller_that_cannot_approve_is_denied_at_once() {
+        let d = super::decide_without_asking(Some(false), "remember").expect("must short-circuit");
+        assert!(!d.allow);
+        let why = d.reason.unwrap_or_default();
+        assert!(why.contains("remember"), "must name the tool: {why}");
+        assert!(
+            why.contains("murmur"),
+            "must name where it can be approved: {why}"
+        );
+        assert!(
+            why.contains("tool-allow"),
+            "must name the other way out: {why}"
+        );
+    }
+
+    /// Controls. An interactive caller must still be asked, and no routed entry
+    /// must still reach the existing no-sink handling — this shortcut is only
+    /// for a caller that told us it cannot answer.
+    #[test]
+    fn everyone_else_is_still_asked() {
+        assert!(super::decide_without_asking(Some(true), "remember").is_none());
+        assert!(super::decide_without_asking(None, "remember").is_none());
+    }
+
+    /// A caller that declared it cannot approve must be distinguishable from
+    /// one that can, at the map the gate reads. Before this the two were the
+    /// same entry and the gate waited on both.
+    #[tokio::test]
+    async fn the_gate_can_tell_the_two_callers_apart() {
+        let r = runner();
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        r.register_client_notifier("t-interactive", tx.clone(), true)
+            .await;
+        r.register_client_notifier("t-oneshot", tx, false).await;
+
+        let map = r.client_notifiers.lock().await;
+        assert_eq!(map.get("t-interactive").map(|(_, ok)| *ok), Some(true));
+        assert_eq!(map.get("t-oneshot").map(|(_, ok)| *ok), Some(false));
+    }
+
+    /// Step events still reach a caller that cannot approve — it is not a
+    /// second-class client, it just has nobody to answer a prompt. If this
+    /// breaks, `mur agent send` goes silent about tool progress too.
+    #[tokio::test]
+    async fn a_non_approving_caller_still_receives_notifications() {
+        let r = runner();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        r.register_client_notifier("t1", tx, false).await;
+
+        let sink = {
+            let map = r.client_notifiers.lock().await;
+            map.get("t1").map(|(tx, _)| tx.clone())
+        };
+        sink.expect("sink must still be routed")
+            .send(serde_json::json!({"method": "step/started"}))
+            .await
+            .expect("send must reach the client");
+        assert!(rx.recv().await.is_some());
+    }
+
+    /// Unregistering clears both halves.
+    #[tokio::test]
+    async fn unregister_removes_the_entry() {
+        let r = runner();
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        r.register_client_notifier("t1", tx, false).await;
+        r.unregister_client_notifier("t1").await;
+        assert!(r.client_notifiers.lock().await.get("t1").is_none());
     }
 }

--- a/mur-core/src/cmd/agent/comm.rs
+++ b/mur-core/src/cmd/agent/comm.rs
@@ -11,7 +11,11 @@ pub fn cmd_send(name: &str, message_json: &str, output_artifact_path: Option<&st
     let msg: serde_json::Value =
         serde_json::from_str(message_json).context("parse --message JSON")?;
     let home = resolve_mur_home()?;
-    let mut params = serde_json::json!({"message": msg});
+    // One-shot send: the caller is a script or a shell, not a person watching
+    // for a prompt. Saying so lets the runtime refuse a gated tool at once
+    // instead of holding the turn open for `hitl.timeout_secs` waiting on an
+    // approval nobody is there to give.
+    let mut params = serde_json::json!({"message": msg, "can_approve": false});
     if let Some(path) = output_artifact_path {
         params["output_artifact_path"] = serde_json::json!(path);
     }


### PR DESCRIPTION
Closes #1066 — the half left open after #1069.

## The problem, measured

The gate waited out `hitl.timeout_secs` for an approval that could never arrive.
`mur agent send` supplies a notifier like any other client — deltas and step
events reach it fine — so the runtime could not tell it from a murmur TUI with a
human watching, and asked both.

Triggered on a live agent by asking it to use `remember` (which is `Ask` and
unpermitted):

```
state:  failed
error:  {"code": "hitl_denied", "message": "tool call denied: timed out"}
roles:  ['user']
```

Wall clock: longer than the configured `hitl.timeout_secs: 300`.

## Correcting the issue

I wrote in #1066 that the failure carried "no statement that approval was the
cause". **That was wrong** — `error.code` is `hitl_denied`. I had printed only
the last message and never looked at the error field.

What is actually wrong is narrower and still real: the caller waits five minutes
for an answer that was knowable at once, and the `message` says `timed out`
without naming the tool or a way forward.

## The fix

Callers declare whether anyone can answer. `message/send` takes `can_approve`;
absent means `true`, so every client that predates the field keeps its behaviour
and defaulting the other way would have made them all start refusing gated
tools. `mur agent send` passes `false`.

```
before:  tool call denied: timed out                        (after 300s+)
after:   `remember` needs approval and this caller cannot    (immediately)
         give one — run it from `murmur`, or allow the tool
         with `mur agent perm tool-allow <agent> remember`
```

A non-approving caller is not a second-class client: step events and deltas
still route to it. It just has nobody to answer a prompt.

## Why the decision is extracted

`decide_without_asking` is a function rather than an inline condition because
that shape has now failed me twice in two days:

- in #1069, `if A || (B && C)` compiled fine with `&& C` deleted and nothing
  caught it;
- here, my first tests verified the map that carries the flag and said nothing
  about whether the gate reads it — mutating the guard would have passed.

Both mutations now fail a test. Controls hold: an interactive caller is still
asked, `None` (no routed entry) still reaches the existing no-sink handling, and
a non-approving caller still receives notifications.

`cargo nextest run --workspace`: 7883 passed, 0 failed.
`cargo clippy --workspace --all-targets` exits 0; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
