### PR TITLE
test(runtime): a UUID can contain the sentinel

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -2683,7 +2683,7 @@ mod tests {
     async fn tool_use_stop_without_calls_fails_instead_of_fabricating() {
         use crate::llm::stub::SequenceLlm;
         let responses: Vec<crate::llm::LlmResponse> = vec![crate::llm::LlmResponse {
-            text: "The exact output of git rev-list --count HEAD is: 2469".into(),
+            text: "The exact output of git rev-list --count HEAD is: FABRICATED-2469".into(),
             input_tokens: 5,
             output_tokens: 5,
             model: "test".into(),
@@ -2699,7 +2699,23 @@ mod tests {
         let outcome = runner.run_sync(loop_spec("fabricate")).await;
         match outcome {
             TaskOutcome::Failed(task) => {
-                let rendered = format!("{task:?}");
+                // Search the MESSAGES, not the whole Debug rendering: that
+                // includes the task id, and a v7 UUID ending in the sentinel
+                // digits failed this on CI at roughly 1-in-65k per run. The
+                // sentinel is now prefixed for the same reason — four bare
+                // digits are something a UUID can produce by chance, and a
+                // test that fails on a coin flip teaches people to re-run
+                // rather than to read.
+                let delivered: String = task
+                    .messages
+                    .iter()
+                    .flat_map(|m| m.parts.iter())
+                    .filter_map(|p| match p {
+                        mur_common::a2a::MessagePart::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 let err = task.error.expect("Failed task must carry an error");
                 assert_eq!(err.code, "llm_error");
                 assert!(
@@ -2707,8 +2723,8 @@ mod tests {
                     "a call dropped in the provider client reproduces on retry"
                 );
                 assert!(
-                    !rendered.contains("2469"),
-                    "the model's fabricated tool output must never reach the user, got: {rendered}"
+                    !delivered.contains("FABRICATED-2469"),
+                    "the model's fabricated tool output must never reach the user, got: {delivered}"
                 );
             }
             other => panic!("expected Failed, got {other:?}"),


### PR DESCRIPTION
CI failed on `tool_use_stop_without_calls_fails_instead_of_fabricating` while
the branch under review touched only the Hub crate. It was not the change.

## The collision

The test asserts the Debug rendering of the whole task does not contain `2469` —
the digits the stubbed model fabricates as a command's output. That rendering
includes the task id, and a v7 UUID ends in four hex digits:

```
task-01a04fd0-64e1-75b3-931b-aed3adca2469
                                    ~~~~
```

Roughly one run in 65k, on every branch, forever.

## Two changes, because either alone leaves it fragile

The sentinel is now `FABRICATED-2469`, which a UUID cannot produce.

The assertion searches the task's **messages** — where a fabricated tool result
would actually be delivered — rather than a Debug string that also carries ids,
timestamps and token counts the test has no opinion about. Searching the wrong
haystack is what made a collision possible at all.

## Verification

Mutation: forcing the sentinel into the searched text fails the test, so it
still catches what it was written to catch. Local run passes; the whole
`mur-agent-runtime` lib suite is green.

A test that fails on a coin flip teaches people to re-run rather than to read,
which is worse than not having it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)