### PR TITLE
chore(release): bump workspace version to 2.71.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.7"
+version = "2.71.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.7"
+version = "2.71.8"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases five fixes, four of them reported from a live session. **Merging this
PR is the release** — `tag.yml` tags `v2.71.8` and dispatches `release.yml`,
which publishes to crates.io. Irreversible, yank only.

## What ships

**MUR Hub read the wrong `mur`** (#1074). It probed two install dirs and took
the first that existed, Homebrew first, so with a stale `/opt/homebrew/bin/mur`
beside a current `~/.local/bin/mur` earlier on PATH it reported
"Command-line tools are v2.71.3" while the terminal ran 2.71.7. It now asks the
user's shell — `-ilc`, because PATH is often exported from `.zshrc`, which a
login shell never reads.

**A caller that cannot approve waited five minutes to be told no** (#1073).
`mur agent send` supplies a notifier like any other client, so the gate could
not tell it from a TUI with a human watching and waited out
`hitl.timeout_secs`. Callers now declare `can_approve`; absent means true, so no
existing client changes behaviour.

**Two of murmur's four full-width rules said nothing** (#1078). `chat · mur`
restated the status-bar badge; the transcript's bottom border marked the same
seam as the composer's own titled top border directly beneath it.

**`bash` can say what it is for** (#1079). An optional `description` splits the
card — intent on top, command indented under a `⎿` and dimmed. Absent means
unchanged, which is asserted by a test.

**A test failed on a coin flip** (#1077). It asserted the task's Debug rendering
did not contain `2469`; the rendering includes a v7 UUID, which ends in four hex
digits. Roughly one run in 65k, on every branch.

## Verification

`cargo nextest run --workspace`: 7889 passed, 0 failed.
`cargo clippy --workspace --all-targets -- -D warnings`: exit 0.

Every new rule carries a control that must not move, and each was
mutation-verified. Three things need a live turn after this release: whether the
model writes useful `description` values, whether the Hub banner clears once the
Hub itself updates, and the `⎿` rendering in a real 80-column pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)