### PR TITLE
fix(agent): `logs` read a file the service supervisor never writes

### DIFF
--- a/mur-core/src/cmd/agent/stats.rs
+++ b/mur-core/src/cmd/agent/stats.rs
@@ -103,13 +103,19 @@ pub fn cmd_stats(name: &str) -> Result<()> {
 /// supervisor redirects to /tmp (macOS) or the journal (Linux, no file). So
 /// `logs` cannot assume which supervisor is in charge — it takes whichever
 /// candidate was written last.
+#[cfg(target_os = "macos")]
 fn log_candidates(agent_home: &Path, name: &str) -> Vec<std::path::PathBuf> {
-    let mut v = vec![agent_home.join("stderr.log")];
-    #[cfg(target_os = "macos")]
-    v.push(super::service::service_stderr_log(name));
-    #[cfg(not(target_os = "macos"))]
-    let _ = name;
-    v
+    vec![
+        agent_home.join("stderr.log"),
+        super::service::service_stderr_log(name),
+    ]
+}
+
+/// The systemd unit sets no `StandardError=`, so the runtime's stderr goes to
+/// the journal and there is no second file to consider.
+#[cfg(not(target_os = "macos"))]
+fn log_candidates(agent_home: &Path, _name: &str) -> Vec<std::path::PathBuf> {
+    vec![agent_home.join("stderr.log")]
 }
 
 fn newest_log(agent_home: &Path, name: &str) -> Option<std::path::PathBuf> {

--- a/mur-core/src/cmd/agent/stats.rs
+++ b/mur-core/src/cmd/agent/stats.rs
@@ -98,17 +98,46 @@ pub fn cmd_stats(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Where a runtime's stderr can land. Two launch paths write two *different*
+/// files: `mur agent start` writes into the agent home, while the service
+/// supervisor redirects to /tmp (macOS) or the journal (Linux, no file). So
+/// `logs` cannot assume which supervisor is in charge — it takes whichever
+/// candidate was written last.
+fn log_candidates(agent_home: &Path, name: &str) -> Vec<std::path::PathBuf> {
+    let mut v = vec![agent_home.join("stderr.log")];
+    #[cfg(target_os = "macos")]
+    v.push(super::service::service_stderr_log(name));
+    #[cfg(not(target_os = "macos"))]
+    let _ = name;
+    v
+}
+
+fn newest_log(agent_home: &Path, name: &str) -> Option<std::path::PathBuf> {
+    log_candidates(agent_home, name)
+        .into_iter()
+        .filter_map(|p| Some((fs::metadata(&p).ok()?.modified().ok()?, p)))
+        .max_by_key(|(mtime, _)| *mtime)
+        .map(|(_, p)| p)
+}
+
 pub fn cmd_logs(name: &str, tail: usize) -> Result<()> {
     let mur_home = resolve_mur_home()?;
     let dir = mur_home.join("agents").join(name);
     if !dir.exists() {
         bail!("agent '{name}' not found");
     }
-    let log_path = dir.join("stderr.log");
-    if !log_path.exists() {
-        eprintln!("(no stderr.log for '{name}' yet)");
+    let Some(log_path) = newest_log(&dir, name) else {
+        eprintln!("(no log file for '{name}' yet)");
+        if cfg!(target_os = "linux") {
+            eprintln!(
+                "  a service-managed agent logs to the journal, not a file:\n    journalctl --user -u mur-agent-{name}.service"
+            );
+        }
         return Ok(());
-    }
+    };
+    // Name the source: two launch paths write two files, and the one this
+    // picked may be days stale if the agent moved to the other path.
+    eprintln!("── {} ──", log_path.display());
     let body =
         fs::read_to_string(&log_path).with_context(|| format!("read {}", log_path.display()))?;
     let lines: Vec<&str> = body.lines().collect();
@@ -121,6 +150,65 @@ pub fn cmd_logs(name: &str, tail: usize) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, SystemTime};
+
+    fn touch(p: &std::path::Path, ago: u64) {
+        std::fs::write(p, "x").unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(p).unwrap();
+        f.set_modified(SystemTime::now() - Duration::from_secs(ago))
+            .unwrap();
+    }
+
+    #[test]
+    fn newest_log_is_none_when_no_launch_path_has_written() {
+        let home = tempfile::tempdir().unwrap();
+        assert_eq!(
+            super::newest_log(home.path(), "nobody-has-run-me"),
+            None,
+            "no candidate exists, so there is nothing honest to show"
+        );
+    }
+
+    /// The bug: `mur agent start` writes `<agent>/stderr.log`, the launchd unit
+    /// writes /tmp. Reading only the first showed days-stale lines as if live.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn newest_log_prefers_the_service_path_when_it_is_fresher() {
+        let home = tempfile::tempdir().unwrap();
+        // Unique name so the hardcoded /tmp path cannot collide with a real agent.
+        let name = format!("mur-test-{}", std::process::id());
+        let svc = super::super::service::service_stderr_log(&name);
+        touch(&home.path().join("stderr.log"), 86_400); // yesterday
+        touch(&svc, 1); // a second ago
+        let picked = super::newest_log(home.path(), &name);
+        let _ = std::fs::remove_file(&svc);
+        assert_eq!(picked, Some(svc), "the fresher of the two must win");
+    }
+
+    /// ...and the preference is by mtime, not by a fixed ranking of the paths.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn newest_log_prefers_the_agent_home_when_it_is_fresher() {
+        let home = tempfile::tempdir().unwrap();
+        let name = format!("mur-test-rev-{}", std::process::id());
+        let svc = super::super::service::service_stderr_log(&name);
+        let own = home.path().join("stderr.log");
+        touch(&svc, 86_400);
+        touch(&own, 1);
+        let picked = super::newest_log(home.path(), &name);
+        let _ = std::fs::remove_file(&svc);
+        assert_eq!(picked, Some(own), "mtime decides, not candidate order");
+    }
+
+    /// Non-macOS has no second file at all (systemd logs to the journal), so
+    /// the candidate list must not grow a path nothing ever writes.
+    #[test]
+    fn candidate_count_matches_what_this_platform_actually_writes() {
+        let home = tempfile::tempdir().unwrap();
+        let n = super::log_candidates(home.path(), "a").len();
+        assert_eq!(n, if cfg!(target_os = "macos") { 2 } else { 1 });
+    }
+
     use super::*;
 
     #[test]

--- a/mur-core/src/cmd/agent/stats.rs
+++ b/mur-core/src/cmd/agent/stats.rs
@@ -156,9 +156,10 @@ pub fn cmd_logs(name: &str, tail: usize) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime};
-
+    /// Only the two-candidate tests below need this, and they are macOS-only.
+    #[cfg(target_os = "macos")]
     fn touch(p: &std::path::Path, ago: u64) {
+        use std::time::{Duration, SystemTime};
         std::fs::write(p, "x").unwrap();
         let f = std::fs::OpenOptions::new().write(true).open(p).unwrap();
         f.set_modified(SystemTime::now() - Duration::from_secs(ago))


### PR DESCRIPTION
`mur agent logs <name>` was reading days-stale output as if it were live.

## Root cause

Two launch paths write two *different* files:

| launcher | stderr lands in |
|---|---|
| `mur agent start` | `~/.mur/agents/<name>/stderr.log` |
| launchd unit (macOS) | `/tmp/mur-agent-<name>.err.log` |
| systemd unit (Linux) | the journal — **no file** |

`cmd_logs` hardcoded the first. On this machine:

```
~/.mur/agents/mur/stderr.log    08-25 09:09   8.9MB   ← what `logs` showed
/tmp/mur-agent-mur.err.log      08-30 10:25  31.5MB   ← what was actually being written
```

Five-day-old lines, presented as current. The command also never named the file
it read, which is what kept it from being obvious.

## Fix

Pick the candidate with the newest mtime, and print its path. The Linux
candidate list stays length 1 (nothing writes a second file there), and the
"nothing yet" branch points at `journalctl` instead of implying a file exists.

## Verification

Mutation-tested — reverting `newest_log` to the pre-fix body:

```
Summary: 8 tests run: 6 passed, 2 failed
FAIL  newest_log_prefers_the_service_path_when_it_is_fresher   (lib + bin)
  left:  …/T/.tmpWI2toQ/stderr.log
  right: /tmp/mur-agent-mur-test-90080.err.log
```

The one test that should move moved; the three controls did not. Restored
byte-identical afterwards.

End to end on the live agent:

```
$ mur agent logs mur --tail 2
── /tmp/mur-agent-mur.err.log ──
2026-08-30T02:40:57.577526Z  INFO … agent=mur
```

`cargo clippy -p mur-core --all-targets -- -D warnings` exits 0.

Fixes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)