### PR TITLE
feat(open-items): age reported items out of the default list

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -982,12 +982,13 @@ impl App {
             crate::open_items::collect(&self.home),
             &self.muted_origins(),
         );
+        let (visible, stale) = crate::open_items::split_stale(visible, chrono::Utc::now());
         let fp = crate::open_items::fingerprint(&visible);
         if self.open_items_fp == Some(fp) {
             return;
         }
         self.open_items_fp = Some(fp);
-        if let Some(line) = crate::open_items::summary_line(&visible) {
+        if let Some(line) = crate::open_items::summary_line(&visible, stale.len()) {
             self.push_system(line);
         }
     }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -2058,9 +2058,10 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Open => {
             let items = crate::open_items::collect(&app.home);
             let (visible, muted) = crate::open_items::partition(items, &app.muted_origins());
+            let (visible, stale) = crate::open_items::split_stale(visible, chrono::Utc::now());
             app.open_items_fp = Some(crate::open_items::fingerprint(&visible));
             app.push_system(
-                crate::open_items::render(&visible, &muted)
+                crate::open_items::render(&visible, &muted, stale.len())
                     .trim()
                     .to_string(),
             );

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1105,7 +1105,18 @@ pub async fn run(cli: Cli) -> Result<()> {
                             }))?
                         );
                     } else {
-                        print!("{}", crate::open_items::render(&visible, &matched));
+                        let (fresh, stale) =
+                            crate::open_items::split_stale(visible, chrono::Utc::now());
+                        // `--all` suspends this policy too: stale items come
+                        // back into the list rather than being counted in a
+                        // footer. Oldest last, which the split already gives.
+                        let (shown, hidden) = if all {
+                            ([fresh, stale].concat(), 0)
+                        } else {
+                            let n = stale.len();
+                            (fresh, n)
+                        };
+                        print!("{}", crate::open_items::render(&shown, &matched, hidden));
                     }
                 }
             }

--- a/mur-core/src/open_items/mod.rs
+++ b/mur-core/src/open_items/mod.rs
@@ -70,9 +70,22 @@ pub fn partition(items: Vec<OpenItem>, muted: &[String]) -> (Vec<OpenItem>, Vec<
 /// `None` when there is nothing open, because the alternative is telling the
 /// user "0 open items" after every single turn, which is how a surface earns
 /// its way into the part of the screen people stop reading.
-pub fn summary_line(items: &[OpenItem]) -> Option<String> {
+/// Split off the items that have aged out of the default view.
+///
+/// Returns `(fresh, stale)` preserving `collect`'s ordering within each half.
+pub fn split_stale(
+    items: Vec<OpenItem>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> (Vec<OpenItem>, Vec<OpenItem>) {
+    items.into_iter().partition(|i| !i.is_stale_at(now))
+}
+
+pub fn summary_line(items: &[OpenItem], stale: usize) -> Option<String> {
     if items.is_empty() {
-        return None;
+        // Stale items are demoted, not gone. Dropping the line entirely here
+        // would make them invisible, which is worse than the accumulation
+        // this ageing exists to fix.
+        return (stale > 0).then(|| format!("{stale} stale — mur open --all"));
     }
     let observed = items
         .iter()
@@ -87,10 +100,15 @@ pub fn summary_line(items: &[OpenItem]) -> Option<String> {
         parts.push(format!("{reported} reported"));
     }
     Some(format!(
-        "{} open item{} ({}) — /open",
+        "{} open item{} ({}){} — /open",
         items.len(),
         if items.len() == 1 { "" } else { "s" },
-        parts.join(", ")
+        parts.join(", "),
+        if stale > 0 {
+            format!(" · {stale} stale")
+        } else {
+            String::new()
+        }
     ))
 }
 
@@ -113,7 +131,7 @@ pub fn fingerprint(items: &[OpenItem]) -> u64 {
 
 /// Render for a terminal. Groups by source with the marker legend, because an
 /// unlabelled mixed list is the thing this module exists to avoid.
-pub fn render(items: &[OpenItem], muted: &[String]) -> String {
+pub fn render(items: &[OpenItem], muted: &[String], stale: usize) -> String {
     let mut out = if items.is_empty() {
         "No open items.\n".to_string()
     } else {
@@ -151,11 +169,61 @@ pub fn render(items: &[OpenItem], muted: &[String]) -> String {
             muted.join(", ")
         ));
     }
+    // Same trade as the mute footer above: one line versus N, never
+    // show-versus-hide. A reader must not have to wonder what aged out.
+    if stale > 0 {
+        out.push_str(&format!(
+            "\n{stale} stale item{} not shown — mur open --all\n",
+            if stale == 1 { "" } else { "s" }
+        ));
+    }
     out
 }
 
 #[cfg(test)]
 mod tests {
+    fn old(source: ItemSource, days: i64) -> OpenItem {
+        item(source, "aged", Utc::now() - chrono::Duration::days(days))
+    }
+
+    #[test]
+    fn split_keeps_observed_fresh_and_moves_only_aged_reports() {
+        let n = mur_open_items::REPORTED_STALE_AFTER_DAYS + 1;
+        let (fresh, stale) = split_stale(
+            vec![
+                old(ItemSource::Observed, n),
+                old(ItemSource::Reported, n),
+                item(ItemSource::Reported, "new", Utc::now()),
+            ],
+            Utc::now(),
+        );
+        assert_eq!(fresh.len(), 2, "observed and the recent report stay");
+        assert_eq!(stale.len(), 1);
+    }
+
+    #[test]
+    fn summary_appends_the_stale_count_and_omits_it_at_zero() {
+        let one = vec![item(ItemSource::Reported, "a", Utc::now())];
+        assert!(summary_line(&one, 3).unwrap().contains("3 stale"));
+        assert!(!summary_line(&one, 0).unwrap().contains("stale"));
+    }
+
+    /// Demoted, not deleted. If everything aged out, the line must still say
+    /// so — silence here would be the accumulation bug traded for a worse one.
+    #[test]
+    fn summary_still_speaks_when_every_item_is_stale() {
+        let s = summary_line(&[], 4).expect("4 hidden items cannot be silent");
+        assert!(s.contains("4 stale"), "{s}");
+        assert!(s.contains("--all"), "must name the way to see them: {s}");
+    }
+
+    #[test]
+    fn render_footer_names_what_aged_out_and_how_to_see_it() {
+        let out = render(&[item(ItemSource::Observed, "a", Utc::now())], &[], 2);
+        assert!(out.contains("2 stale items not shown"), "{out}");
+        assert!(out.contains("mur open --all"), "{out}");
+    }
+
     use super::*;
     use chrono::{DateTime, Utc};
 
@@ -193,6 +261,7 @@ mod tests {
                 item(ItemSource::Reported, "b", Utc::now()),
             ],
             &[],
+            0,
         );
         assert!(out.contains("observed"), "{out}");
         assert!(out.contains("reported"), "{out}");
@@ -201,7 +270,7 @@ mod tests {
 
     #[test]
     fn empty_says_so_rather_than_printing_a_bare_header() {
-        assert_eq!(render(&[], &[]), "No open items.\n");
+        assert_eq!(render(&[], &[], 0), "No open items.\n");
     }
 
     /// A permanent mute is only safe if the list always says something is
@@ -211,6 +280,7 @@ mod tests {
         let out = render(
             &[item(ItemSource::Observed, "visible", Utc::now())],
             &["inbox".to_string(), "fleet:old".to_string()],
+            0,
         );
         assert!(out.contains("2 sources muted"), "{out}");
         assert!(out.contains("inbox"), "{out}");
@@ -220,7 +290,7 @@ mod tests {
 
     #[test]
     fn no_footer_when_nothing_is_muted() {
-        let out = render(&[item(ItemSource::Observed, "a", Utc::now())], &[]);
+        let out = render(&[item(ItemSource::Observed, "a", Utc::now())], &[], 0);
         assert!(!out.contains("muted"), "{out}");
     }
 
@@ -228,7 +298,7 @@ mod tests {
     /// difference has to be visible.
     #[test]
     fn everything_muted_still_shows_the_footer() {
-        let out = render(&[], &["inbox".to_string()]);
+        let out = render(&[], &["inbox".to_string()], 0);
         assert!(out.contains("1 source muted"), "{out}");
         assert!(out.contains("No open items"), "{out}");
     }
@@ -237,16 +307,19 @@ mod tests {
     /// turn is how a surface trains people to stop reading it.
     #[test]
     fn summary_is_silent_when_nothing_is_open() {
-        assert_eq!(summary_line(&[]), None);
+        assert_eq!(summary_line(&[], 0), None);
     }
 
     #[test]
     fn summary_counts_each_source_separately() {
-        let s = summary_line(&[
-            item(ItemSource::Observed, "a", Utc::now()),
-            item(ItemSource::Observed, "b", Utc::now()),
-            item(ItemSource::Reported, "c", Utc::now()),
-        ])
+        let s = summary_line(
+            &[
+                item(ItemSource::Observed, "a", Utc::now()),
+                item(ItemSource::Observed, "b", Utc::now()),
+                item(ItemSource::Reported, "c", Utc::now()),
+            ],
+            0,
+        )
         .unwrap();
         assert!(s.contains("3 open items"), "{s}");
         assert!(s.contains("2 observed"), "{s}");

--- a/mur-open-items/src/lib.rs
+++ b/mur-open-items/src/lib.rs
@@ -97,6 +97,30 @@ pub struct OpenItem {
     pub at: chrono::DateTime<chrono::Utc>,
 }
 
+/// How long a reported item may sit unresolved before it stops crowding the
+/// default list.
+///
+/// 14 days is the `Draft` half-life the skill lifecycle already uses for "a
+/// claim that has not proved itself yet" — the same judgement, so it gets the
+/// same interval rather than a second number to keep in sync.
+pub const REPORTED_STALE_AFTER_DAYS: i64 = 14;
+
+impl OpenItem {
+    /// Whether this item has aged out of the default list.
+    ///
+    /// Stale means *demoted*, never deleted: the claim may still be real, and
+    /// removing what a person recorded because a timer said so is the failure
+    /// this codebase already fixed once on the decay side.
+    ///
+    /// Only `Reported` items age. An `Observed` one is re-derived from state
+    /// MUR holds every time it is listed, so it clears itself when it stops
+    /// being true — ageing it out would hide a fact that still holds.
+    pub fn is_stale_at(&self, now: chrono::DateTime<chrono::Utc>) -> bool {
+        self.source == ItemSource::Reported
+            && now.signed_duration_since(self.at).num_days() >= REPORTED_STALE_AFTER_DAYS
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum Record {
@@ -249,6 +273,34 @@ fn item_id(agent: &str, title: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    fn aged(source: ItemSource, days: i64) -> OpenItem {
+        OpenItem {
+            title: "t".into(),
+            next: None,
+            source,
+            origin: "agent:mur".into(),
+            at: chrono::Utc::now() - chrono::Duration::days(days),
+        }
+    }
+
+    #[test]
+    fn a_reported_item_goes_stale_once_past_the_threshold() {
+        let now = chrono::Utc::now();
+        assert!(aged(ItemSource::Reported, REPORTED_STALE_AFTER_DAYS + 1).is_stale_at(now));
+        assert!(!aged(ItemSource::Reported, REPORTED_STALE_AFTER_DAYS - 1).is_stale_at(now));
+    }
+
+    /// The policy that keeps this from hiding true things: an observed item is
+    /// re-derived from state on every listing, so age says nothing about it.
+    #[test]
+    fn an_observed_item_never_goes_stale_however_old() {
+        assert!(
+            !aged(ItemSource::Observed, REPORTED_STALE_AFTER_DAYS * 100)
+                .is_stale_at(chrono::Utc::now()),
+            "ageing out a derived fact would hide something still true"
+        );
+    }
+
     use super::*;
 
     fn home() -> tempfile::TempDir {


### PR DESCRIPTION
Reported open items only accumulated — nothing aged them, nothing re-checked
them. A live panel carried `release/2.68.7` items while the project was on
2.71.7, alongside a breakfast reminder for 08-09 still open on 08-30.

## What changes

A reported item goes **stale** after 14 days: it drops out of the default list,
the count line says how many, and `mur open --all` brings it back.

```
$ mur open
○ reported — an agent said so, unverified
  opened just now [agent:mur]

1 stale item not shown — mur open --all

$ mur open --all
○ reported — an agent said so, unverified
  opened just now [agent:mur]
  twenty days old [agent:mur]
```

## Stale demotes, it does not delete

Removing what a person recorded because a timer said so is the failure this
codebase spent a release fixing on the decay side (#1063). Two invariants keep
it fixed here, and both are tested:

- **`Observed` items never age.** They are re-derived from state MUR holds on
  every listing, so they clear themselves when they stop being true. Ageing one
  out would hide a fact that still holds.
- **With everything stale, the summary still speaks** — `4 stale — mur open
  --all` rather than falling silent. Invisible is worse than crowded.

## Choices worth naming

- **14 days** is the `Draft` half-life the skill lifecycle already uses for "a
  claim that has not proved itself yet" — the same judgement, so it reuses the
  interval rather than adding a second number to keep in sync.
- **No new flag.** `--all` already meant "suspend the display policy for this
  render" for mutes. Staleness is a second display policy and rides it.
- **The footer follows the mute footer's rule verbatim** — collapsed, never
  hidden, and it names the way back.
- **JSON output is unchanged.** It already emits every item; a consumer has `at`
  and the public `REPORTED_STALE_AFTER_DAYS` and can apply its own policy.

## Not in this PR

Evidence-based clearing — checking that a named tag, path or date actually
resolved — is the other half of #1076. It needs a parser per item kind, while
ageing already covers every case observed in the issue. Left open there.

## Verification

Mutation-tested by dropping the `Observed` guard from `is_stale_at`:

```
FAIL  an_observed_item_never_goes_stale_however_old            (mur-open-items)
FAIL  split_keeps_observed_fresh_and_moves_only_aged_reports   (lib + bin)
        assertion failed: observed and the recent report stay
          left: 1   right: 2
```

The threshold, summary and footer tests stayed green. Restored byte-identical.

Live, against the real store: 0 stale today — the three oldest items are 13 days
old and cross the threshold tomorrow — so the negative control produced output
identical to before. The positive control above ran against a seeded home.

`cargo nextest run -p mur-open-items -p mur-core` → 274 passed.
`cargo clippy -p mur-core -p mur-open-items --all-targets -- -D warnings` → 0.

Refs #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)