### PR TITLE
chore(release): bump workspace version to 2.71.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.8"
+version = "2.71.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.8"
+version = "2.71.9"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.9 — three open issues fixed.

| PR | Issue | What |
|---|---|---|
| #1081 | #1068 | `mur agent logs` read a file the service supervisor never writes — it showed 5-day-old output as if live, and never named the file it read |
| #1082 | #1076 | Reported open items now age out of the default list after 14 days instead of accumulating forever. Demoted, never deleted; `mur open --all` brings them back |
| #1083 | #1075 | An agent recording something time-bound is told the open-items list has no clock, and pointed at `mur agent schedule` |

## User-visible change to watch

**#1082 changes what `mur open` shows by default.** A reported item older than 14
days drops out of the list; the count line and a footer say how many and how to
see them. `Observed` items never age — they are re-derived from state and clear
themselves.

## Also in this cycle, not code

- **#1021** — ran the experiment it was blocked on: a CI-signed tarball keeps its
  Developer ID and Team ID through `brew install` (`codesign -v` → 0), so brew
  users never reach the keychain failure. Posted; the security decision is still
  open.
- **#1062** — #1063 removed the destructive half (decay can no longer demote or
  delete an external note); the retrieval-ranking half remains. Posted; the fork
  is still open.

Merging this tags `v2.71.9` and dispatches `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)