### PR TITLE
feat(sandbox): record what the seal actually installed in running.lock

### DIFF
--- a/mur-agent-runtime/src/lock_file.rs
+++ b/mur-agent-runtime/src/lock_file.rs
@@ -158,6 +158,7 @@ mod tests {
             capabilities: vec![],
             build_sha: String::new(),
             proto_version: 0,
+            sandbox: None,
         }
     }
 

--- a/mur-agent-runtime/src/sandbox/linux.rs
+++ b/mur-agent-runtime/src/sandbox/linux.rs
@@ -90,6 +90,7 @@ pub fn apply_linux(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
         platform: "linux-landlock-v4".to_string(),
         effective_abi: None, // landlock 0.4 does not expose effective ABI in RestrictionStatus
         enforcing,
+        dropped: Vec::new(),
     })
 }
 

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -44,6 +44,7 @@ pub fn apply_macos(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
             platform: "macos-sbpl-failed".to_string(),
             effective_abi: None,
             enforcing: false,
+            dropped: Vec::new(),
         });
     }
 
@@ -51,6 +52,7 @@ pub fn apply_macos(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
         platform: "macos-sbpl".to_string(),
         effective_abi: None,
         enforcing: true,
+        dropped: Vec::new(),
     })
 }
 

--- a/mur-agent-runtime/src/sandbox/mod.rs
+++ b/mur-agent-runtime/src/sandbox/mod.rs
@@ -31,6 +31,13 @@ pub struct SandboxStatus {
     pub platform: String,
     pub effective_abi: Option<u32>,
     pub enforcing: bool,
+    /// Filesystem grants the policy discarded while being built, so they never
+    /// reached the kernel however they read in `profile.yaml`.
+    ///
+    /// Platform backends leave this empty — they receive an already-built
+    /// policy and never see what was discarded producing it. [`apply`] fills it
+    /// from the policy immediately after they return.
+    pub dropped: Vec<mur_common::agent::DroppedGrant>,
 }
 
 /// Apply the kernel sandbox derived from `entitlements` to the current process.
@@ -57,7 +64,9 @@ pub fn apply(
     // …and to write the shared runtime media state it owns (co-watching:
     // watch.json + VLC snapshot dir), which lives outside agent_home.
     policy.allow_extra_write_paths(extra_write_paths);
-    let status = apply_policy(&policy)?;
+    let dropped = policy.dropped.clone();
+    let mut status = apply_policy(&policy)?;
+    status.dropped = dropped;
     // Store for attestation. OnceLock: if called twice, second call is ignored.
     let _ = SANDBOX_STATUS.set(status.clone());
     Ok(status)
@@ -84,6 +93,7 @@ fn apply_policy(_policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
         platform: "unsupported".to_string(),
         effective_abi: None,
         enforcing: false,
+        dropped: Vec::new(),
     })
 }
 

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -1454,20 +1454,31 @@ mod tests {
         ent.filesystem.write = vec![gone.display().to_string()];
         let p = SandboxPolicy::from_entitlements(&ent, home.path());
 
-        let verbs: Vec<&str> = p.dropped.iter().map(|d| d.verb.as_str()).collect();
+        // Only the grant under test: the fixture's own paths are
+        // environment-dependent, so an assertion over the whole list would be
+        // about the CI runner rather than about this code.
+        let mine: Vec<_> = p
+            .dropped
+            .iter()
+            .filter(|d| d.path == gone.display().to_string())
+            .collect();
+        let verbs: Vec<&str> = mine.iter().map(|d| d.verb.as_str()).collect();
         assert!(verbs.contains(&"read"), "{:?}", p.dropped);
         assert!(verbs.contains(&"write"), "{:?}", p.dropped);
         assert!(
-            p.dropped.iter().all(
-                |d| d.path == gone.display().to_string() && d.reason.contains("does not exist")
-            ),
+            mine.iter().all(|d| d.reason.contains("does not exist")),
             "{:?}",
             p.dropped
         );
     }
 
-    /// The control: a healthy profile records nothing, so a non-empty list on a
-    /// real agent always means something actually went missing.
+    /// The control: a grant whose path is present is never recorded as dropped.
+    ///
+    /// Asserts about *this* grant rather than an empty list, because the
+    /// fixture's own entitlements are environment-dependent — `~/Documents`
+    /// exists on the macOS runner and not on a bare Ubuntu one, so a global
+    /// emptiness assertion passes locally and fails in CI for a reason that has
+    /// nothing to do with what this test is about.
     #[test]
     fn a_live_grant_records_no_drop() {
         let home = tempfile::tempdir().unwrap();
@@ -1476,7 +1487,13 @@ mod tests {
         let mut ent = minimal_entitlements();
         ent.filesystem.write = vec![live.display().to_string()];
         let p = SandboxPolicy::from_entitlements(&ent, home.path());
-        assert!(p.dropped.is_empty(), "{:?}", p.dropped);
+        assert!(
+            !p.dropped
+                .iter()
+                .any(|d| d.path == live.display().to_string()),
+            "a grant whose path exists must never be recorded as dropped: {:?}",
+            p.dropped
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -44,6 +44,9 @@ pub fn expand_entitlement_path(s: &str) -> PathBuf {
 /// feed directly to Landlock / SBPL / Job Object APIs.
 #[derive(Debug, Clone)]
 pub struct SandboxPolicy {
+    /// Filesystem grants that were discarded while building this policy, so
+    /// the kernel never received them however they read in `profile.yaml`.
+    pub dropped: Vec<mur_common::agent::DroppedGrant>,
     /// Paths the process may read (not write).
     pub fs_read: Vec<PathBuf>,
     /// Paths the process may read AND write.
@@ -131,6 +134,7 @@ impl Default for SandboxPolicy {
             net_allow_hosts: None,
             memory_limit_mb: None,
             launch_chain: crate::sandbox::launch_chain::LaunchChain::default(),
+            dropped: Vec::new(),
             dropped_grants: Vec::new(),
             dropped_read_grants: Vec::new(),
         }
@@ -141,6 +145,9 @@ impl SandboxPolicy {
     pub fn from_entitlements(ent: &Entitlements, agent_home: &Path) -> Self {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
         let expand = expand_entitlement_path;
+        // Every grant discarded below is recorded, not just warned about: a
+        // WARN in a 30MB log is not an answer to "what can this agent write".
+        let mut dropped: Vec<mur_common::agent::DroppedGrant> = Vec::new();
 
         // USER-DECLARED read/write entitlement paths are existence-checked at
         // profile-build time and dropped (fail-closed, warned) if missing.
@@ -169,6 +176,11 @@ impl SandboxPolicy {
                          agent will NOT have read access to it (dropping dead grant \
                          to avoid destabilizing the sandbox profile — Issue 16)"
                     );
+                    dropped.push(mur_common::agent::DroppedGrant {
+                        path: p.display().to_string(),
+                        verb: "read".into(),
+                        reason: "path does not exist on disk".into(),
+                    });
                     false
                 }
             })
@@ -197,6 +209,11 @@ impl SandboxPolicy {
                  sibling signing key; the whole grant is dropped (a protected \
                  path inside a grant cannot be carved out)"
             );
+            dropped.push(mur_common::agent::DroppedGrant {
+                path: p.display().to_string(),
+                verb: "read".into(),
+                reason: "reaches the credential store or a sibling signing key".into(),
+            });
         }
         let mut fs_read = kept_reads;
 
@@ -215,6 +232,11 @@ impl SandboxPolicy {
                          agent will NOT have write access to it (dropping dead grant \
                          to avoid destabilizing the sandbox profile — Issue 16)"
                     );
+                    dropped.push(mur_common::agent::DroppedGrant {
+                        path: p.display().to_string(),
+                        verb: "write".into(),
+                        reason: "path does not exist on disk".into(),
+                    });
                     false
                 }
             })
@@ -619,7 +641,21 @@ impl SandboxPolicy {
         // SBPL deny/re-allow carve-out needs no drop.
         let (_, dropped_grants) =
             crate::sandbox::linux::partition_write_grants(&fs_write, &launch_chain);
+        // Only where the drop actually happens. Landlock cannot carve a grant,
+        // so Linux drops it whole; macOS keeps the grant and re-closes the
+        // overlap with `deny file-read*` clauses emitted after the allows
+        // (last-match-wins), so the grant IS installed there. Recording these
+        // on macOS would report a loss of access that did not occur.
+        #[cfg(target_os = "linux")]
+        for pth in &dropped_grants {
+            dropped.push(mur_common::agent::DroppedGrant {
+                path: pth.display().to_string(),
+                verb: "write".into(),
+                reason: "overlaps MUR's launch chain and cannot be carved (Landlock)".into(),
+            });
+        }
         SandboxPolicy {
+            dropped,
             fs_read,
             fs_write,
             fs_deny,
@@ -1403,6 +1439,44 @@ mod tests {
         let resolved =
             resolve_binary_path("definitely-does-not-exist", &[tmp.path().to_path_buf()]);
         assert_eq!(resolved, None);
+    }
+
+    /// The pairing that makes the drop *knowable*. Dropping a dead grant is
+    /// already covered by the test below; this pins that the drop is also
+    /// recorded, because a WARN in a log is not an answer to "what can this
+    /// agent write".
+    #[test]
+    fn a_dropped_dead_grant_is_recorded_with_its_verb_and_reason() {
+        let home = tempfile::tempdir().unwrap();
+        let gone = home.path().join("not-here");
+        let mut ent = minimal_entitlements();
+        ent.filesystem.read = vec![gone.display().to_string()];
+        ent.filesystem.write = vec![gone.display().to_string()];
+        let p = SandboxPolicy::from_entitlements(&ent, home.path());
+
+        let verbs: Vec<&str> = p.dropped.iter().map(|d| d.verb.as_str()).collect();
+        assert!(verbs.contains(&"read"), "{:?}", p.dropped);
+        assert!(verbs.contains(&"write"), "{:?}", p.dropped);
+        assert!(
+            p.dropped.iter().all(
+                |d| d.path == gone.display().to_string() && d.reason.contains("does not exist")
+            ),
+            "{:?}",
+            p.dropped
+        );
+    }
+
+    /// The control: a healthy profile records nothing, so a non-empty list on a
+    /// real agent always means something actually went missing.
+    #[test]
+    fn a_live_grant_records_no_drop() {
+        let home = tempfile::tempdir().unwrap();
+        let live = home.path().join("tree");
+        std::fs::create_dir(&live).unwrap();
+        let mut ent = minimal_entitlements();
+        ent.filesystem.write = vec![live.display().to_string()];
+        let p = SandboxPolicy::from_entitlements(&ent, home.path());
+        assert!(p.dropped.is_empty(), "{:?}", p.dropped);
     }
 
     #[test]

--- a/mur-agent-runtime/src/sandbox/windows.rs
+++ b/mur-agent-runtime/src/sandbox/windows.rs
@@ -73,5 +73,6 @@ pub fn apply_windows(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
         platform: "windows-job-object".to_string(),
         effective_abi: None,
         enforcing: true,
+        dropped: Vec::new(),
     })
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -386,7 +386,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     }
 
     let loopback_ports: Vec<u16> = egress_proxy.iter().map(|h| h.addr.port()).collect();
-    match crate::sandbox::apply(
+    let granted_digest =
+        mur_common::agent::filesystem_grants_digest(&profile.inner.entitlements.filesystem);
+    let sandbox_record = match crate::sandbox::apply(
         &profile.inner.entitlements,
         &agent_home,
         &extra_ports,
@@ -407,8 +409,15 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 platform = %status.platform,
                 effective_abi = ?status.effective_abi,
                 enforcing = status.enforcing,
+                dropped = status.dropped.len(),
                 "B1 sandbox applied"
             );
+            Some(mur_common::agent::SandboxRecord {
+                enforcing: status.enforcing,
+                mode: status.platform,
+                granted_digest,
+                dropped: status.dropped,
+            })
         }
         Err(e) => {
             if fail_closed {
@@ -419,8 +428,17 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 ));
             }
             tracing::warn!(error = %e, "B1 sandbox::apply failed; running advisory-only (B0 remains active)");
+            // No policy was installed, so there is nothing to have dropped.
+            // `enforcing: false` is the finding here, and it subsumes the rest:
+            // the agent has MORE access than its profile grants, not less.
+            Some(mur_common::agent::SandboxRecord {
+                enforcing: false,
+                mode: "advisory-only".into(),
+                granted_digest,
+                dropped: Vec::new(),
+            })
         }
-    }
+    };
 
     // 4–4a. Telemetry writer, hook chain, skills — extracted to prepare_runtime.
     let socket_enabled = profile.inner.transport.socket.enabled
@@ -684,6 +702,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         capabilities: profile.inner.capabilities.clone(),
         build_sha: mur_common::build::SHORT_SHA.to_string(),
         proto_version: mur_common::build::A2A_PROTO_VERSION,
+        sandbox: sandbox_record,
     };
     write_lock(&lock_path, &lock)?;
     info!("agent {} ({}) ready", profile.inner.name, profile.inner.id);

--- a/mur-agent-runtime/tests/lock_file.rs
+++ b/mur-agent-runtime/tests/lock_file.rs
@@ -22,6 +22,7 @@ fn sample_lock() -> LockFile {
         capabilities: vec!["a2a.message.send".into()],
         build_sha: String::new(),
         proto_version: 0,
+        sandbox: None,
     }
 }
 

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1152,6 +1152,66 @@ fn default_env() -> Option<String> {
     Some("dev".into())
 }
 
+/// One filesystem grant the sandbox refused to install, and why.
+///
+/// The grant stays in `profile.yaml` — this records that it did not reach the
+/// kernel, which is otherwise knowable only from a WARN line in a log nobody
+/// queries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DroppedGrant {
+    pub path: String,
+    /// `"read"` or `"write"`.
+    pub verb: String,
+    pub reason: String,
+}
+
+/// Digest of the filesystem half of a profile's entitlements.
+///
+/// Narrower than `card_digest` on purpose: that one moves whenever any profile
+/// field does, so using it to flag "grants changed since this agent started"
+/// would raise a false alarm on an unrelated edit — and a status line that
+/// cries wolf is one people stop reading.
+pub fn filesystem_grants_digest(fs: &FilesystemEntitlement) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    for (label, list) in [("r", &fs.read), ("w", &fs.write), ("d", &fs.deny)] {
+        let mut sorted = list.clone();
+        sorted.sort();
+        for p in sorted {
+            h.update(label.as_bytes());
+            h.update(b"\0");
+            h.update(p.as_bytes());
+            h.update(b"\0");
+        }
+    }
+    format!("sha256:{:x}", h.finalize())
+}
+
+/// What the sandbox actually installed, recorded at the moment it sealed.
+///
+/// A seatbelt profile cannot be widened after `sandbox_init`, so this is fixed
+/// for the process's lifetime — the same lifetime as the lock file it rides in.
+/// Without it, `profile.yaml` is the only readable account of an agent's
+/// permissions, and it describes what was asked for rather than what took
+/// effect.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SandboxRecord {
+    /// False means the kernel sandbox is NOT installed and only advisory hooks
+    /// remain — the agent then has MORE access than its profile grants, which
+    /// is the opposite of every other failure here and the one worth shouting.
+    pub enforcing: bool,
+    /// `"macos-sbpl"`, `"linux-landlock"`, `"advisory-only"`, …
+    pub mode: String,
+    /// Digest of `entitlements.filesystem` as sealed. Comparing it against the
+    /// profile on disk answers "were grants changed since this agent started"
+    /// without anyone tracking that — and unlike `card_digest` it does not move
+    /// when an unrelated field does, so it cannot raise a false alarm.
+    pub granted_digest: String,
+    /// Grants that did not reach the kernel. Empty is the normal case.
+    #[serde(default)]
+    pub dropped: Vec<DroppedGrant>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LockFile {
     pub schema: u32,
@@ -1172,6 +1232,10 @@ pub struct LockFile {
     /// 0 = an old lock; the dial gates versioned methods on it.
     #[serde(default)]
     pub proto_version: u32,
+    /// What the sandbox installed at seal time. `None` = a lock written before
+    /// this field existed, or a platform that installs no sandbox.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxRecord>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1719,6 +1783,78 @@ impl AgentProfile {
 
 #[cfg(test)]
 mod tests {
+    /// Order must not matter: the same grants written in a different order are
+    /// the same grants, and a digest that disagreed would report "restart to
+    /// apply" after a cosmetic profile edit.
+    #[test]
+    fn grants_digest_ignores_order_but_not_content() {
+        let a = FilesystemEntitlement {
+            read: vec!["/a".into(), "/b".into()],
+            write: vec!["/w".into()],
+            deny: vec![],
+        };
+        let reordered = FilesystemEntitlement {
+            read: vec!["/b".into(), "/a".into()],
+            ..a.clone()
+        };
+        let changed = FilesystemEntitlement {
+            write: vec!["/w".into(), "/x".into()],
+            ..a.clone()
+        };
+        assert_eq!(
+            filesystem_grants_digest(&a),
+            filesystem_grants_digest(&reordered)
+        );
+        assert_ne!(
+            filesystem_grants_digest(&a),
+            filesystem_grants_digest(&changed)
+        );
+    }
+
+    /// A read grant and a write grant for the same path are different grants.
+    #[test]
+    fn grants_digest_separates_the_verbs() {
+        let r = FilesystemEntitlement {
+            read: vec!["/p".into()],
+            write: vec![],
+            deny: vec![],
+        };
+        let w = FilesystemEntitlement {
+            read: vec![],
+            write: vec!["/p".into()],
+            deny: vec![],
+        };
+        assert_ne!(filesystem_grants_digest(&r), filesystem_grants_digest(&w));
+    }
+
+    /// A lock written before this field existed must still load — every agent
+    /// running at upgrade time wrote one.
+    #[test]
+    fn a_lock_without_the_sandbox_block_still_deserialises() {
+        let old = r#"{"schema":1,"uuid":"u","name":"n","pid":1,"ppid":0,
+            "started_at":"t","binary_version":"v",
+            "transports":{"stdio":true},"card_digest":"d","capabilities":[]}"#;
+        let lf: LockFile = serde_json::from_str(old).expect("old lock must load");
+        assert!(lf.sandbox.is_none());
+    }
+
+    #[test]
+    fn the_sandbox_block_round_trips() {
+        let rec = SandboxRecord {
+            enforcing: false,
+            mode: "advisory-only".into(),
+            granted_digest: "sha256:x".into(),
+            dropped: vec![DroppedGrant {
+                path: "/gone".into(),
+                verb: "write".into(),
+                reason: "path does not exist on disk".into(),
+            }],
+        };
+        let back: SandboxRecord =
+            serde_json::from_str(&serde_json::to_string(&rec).unwrap()).unwrap();
+        assert_eq!(back, rec);
+    }
+
     use super::*;
 
     #[test]

--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -176,6 +176,7 @@ mod tests {
             capabilities: vec!["a2a.message.send".into()],
             build_sha: String::new(),
             proto_version: 0,
+            sandbox: None,
         }
     }
 

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -431,6 +431,7 @@ mod tests {
             capabilities: vec![],
             build_sha: build_sha.to_string(),
             proto_version: 1,
+            sandbox: None,
         }
     }
 

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -673,6 +673,7 @@ mod tests {
             capabilities: vec![],
             build_sha: build_sha.to_string(),
             proto_version: 1,
+            sandbox: None,
         };
         fs::write(path, serde_json::to_vec(&lock).unwrap()).unwrap();
     }

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -122,6 +122,7 @@ mod tests {
             capabilities: vec![],
             build_sha: build_sha.to_string(),
             proto_version: 1,
+            sandbox: None,
         }
     }
 

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -103,6 +103,7 @@ pub(crate) mod tests {
             capabilities: vec!["a2a.message.send".to_string()],
             build_sha: String::new(),
             proto_version: 0,
+            sandbox: None,
         }
     }
 

--- a/mur-core/tests/agent_lifecycle.rs
+++ b/mur-core/tests/agent_lifecycle.rs
@@ -47,6 +47,7 @@ fn write_lock_with_pid(mur_home: &std::path::Path, name: &str, pid: u32) {
         capabilities: vec![],
         build_sha: String::new(),
         proto_version: 0,
+        sandbox: None,
     };
     std::fs::write(path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
 }

--- a/mur-core/tests/agent_list_status.rs
+++ b/mur-core/tests/agent_list_status.rs
@@ -42,6 +42,7 @@ fn write_running_lock(mur_home: &std::path::Path, name: &str, pid: u32) {
         capabilities: vec!["a2a.message.send".into()],
         build_sha: String::new(),
         proto_version: 0,
+        sandbox: None,
     };
     let bytes = serde_json::to_vec_pretty(&lock).unwrap();
     std::fs::write(agent_home.join("running.lock"), bytes).unwrap();

--- a/mur-core/tests/agent_send.rs
+++ b/mur-core/tests/agent_send.rs
@@ -44,6 +44,7 @@ fn write_running_lock(mur_home: &Path, name: &str, sock: &str) {
         capabilities: vec!["a2a.message.send".into()],
         build_sha: String::new(),
         proto_version: 0,
+        sandbox: None,
     };
     std::fs::write(lock_path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
 }

--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -461,6 +461,7 @@ mod tests {
             capabilities: vec![],
             build_sha: String::new(),
             proto_version: 0,
+            sandbox: None,
         };
         std::fs::write(dir.join("running.lock"), serde_json::to_vec(&lock).unwrap()).unwrap();
         std::fs::write(dir.join("running.sentinel"), b"").unwrap();


### PR DESCRIPTION
C1 of the [permission truthfulness spec](docs/superpowers/specs/2026-08-30-agent-permission-truthfulness-design.md).
Independent of #1087/#1088 — different files.

`profile.yaml` says what was asked for; the kernel enforces something else. The
difference existed only as WARN lines in a 30 MB log and a policy struct that
died with the function that built it.

## What lands

```json
"sandbox": {
  "enforcing": true,
  "mode": "macos-sbpl",
  "granted_digest": "sha256:…",
  "dropped": [{"path": "…/cc-proxy", "verb": "write",
               "reason": "path does not exist on disk"}]
}
```

Written at the same point and with the same lifetime as `running.lock` itself —
sealed once at startup, never updated, gone with the process. That match is why
it rides in the lock rather than a sibling file.

**`enforcing` is the field that had no home at all.** `supervisor.rs` runs the
agent advisory-only when `sandbox::apply` fails and `fail_closed` is off. The
agent then has *more* access than its profile grants — the opposite of every
other failure here — and nothing reported it.

## Smaller than the spec, in two places

Both because the lock already answers them:

- **no general profile digest** — `card_digest` is already a sha256 of the whole
  expanded profile
- **no `admitted` list** — it is `granted − dropped` for the user-declared set;
  the rest of the resolved set is runtime-chosen (fleet carve-ins, system paths),
  not anything a user granted

`granted_digest` covers only `entitlements.filesystem`, and is narrower than
`card_digest` on purpose: that one moves whenever *any* profile field does, so
using it to flag "grants changed since startup" would cry wolf on an unrelated
edit — and a status line that cries wolf is one people stop reading.

## A correction to my own investigation

I first enumerated the drop sites by grepping for `tracing::warn!` and found
three. That missed `partition_write_grants`, which drops a grant and does **not**
warn. There are four, and the fourth is recorded only under
`#[cfg(target_os = "linux")]` — macOS keeps that grant and re-closes the overlap
with `deny` clauses emitted after the allows, so recording it there would report
a loss of access that did not occur.

## Verification

Mutation — removing the write-side record:

```
PASS  from_entitlements_drops_dead_read_write_but_keeps_dead_deny   ← pre-existing
FAIL  a_dropped_dead_grant_is_recorded_with_its_verb_and_reason     ← new
PASS  a_live_grant_records_no_drop                                  ← control
```

That pair is the whole point, and it is what the spec predicted: **testing the
drop alone passes today and proves nothing about this change.**

Also pinned: a lock written before this field still deserialises (every agent
running at upgrade time wrote one), the block round-trips, and the digest ignores
ordering but not content or verb.

`cargo nextest run -p mur-agent-runtime -p mur-common` → 1891 passed.
`cargo clippy --workspace --all-targets -- -D warnings` → 0.

The `LockFile` literal appears in 12 places across four crates; `cargo check
--workspace --all-targets` passing is the proof none was missed. The two
workspace-excluded GUI crates construct none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)