### PR TITLE
feat(perm): `list-paths` — the filesystem half of the permission picture

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -759,6 +759,8 @@ pub enum AgentPermAction {
     DenyHost { name: String, glob: String },
     /// Print the outbound host allow / deny lists
     ListHosts { name: String },
+    /// Print the filesystem grants and what the sandbox actually installed
+    ListPaths { name: String },
     /// Allow filesystem read on a path
     AllowRead { name: String, path: String },
     /// Allow filesystem write on a path

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -98,8 +98,8 @@ pub use peers::cmd_peers;
 pub use perm::{
     cmd_perm_allow_host, cmd_perm_allow_read, cmd_perm_allow_spawn, cmd_perm_allow_spawn_dir,
     cmd_perm_allow_write, cmd_perm_clear_tool, cmd_perm_deny_host, cmd_perm_deny_path,
-    cmd_perm_deny_spawn, cmd_perm_deny_spawn_dir, cmd_perm_list_hosts, cmd_perm_list_tools,
-    cmd_perm_set_limit, cmd_perm_set_mode, cmd_perm_set_tool, cmd_perm_show,
+    cmd_perm_deny_spawn, cmd_perm_deny_spawn_dir, cmd_perm_list_hosts, cmd_perm_list_paths,
+    cmd_perm_list_tools, cmd_perm_set_limit, cmd_perm_set_mode, cmd_perm_set_tool, cmd_perm_show,
 };
 #[allow(unused_imports)]
 pub(crate) use prompt::prompt_path_for;

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -288,6 +288,105 @@ pub fn cmd_perm_list_hosts(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// `mur agent perm list-paths` — what this agent may touch, and what actually
+/// took effect.
+///
+/// `profile.yaml` is a request; the kernel enforces the profile as it stood
+/// when the agent sealed. This is the only surface that shows both.
+pub fn cmd_perm_list_paths(name: &str) -> Result<()> {
+    let (path, profile) = load_profile_for_edit(name)?;
+    let lock = path
+        .parent()
+        .map(|d| d.join("running.lock"))
+        .and_then(|p| std::fs::read(p).ok())
+        .and_then(|b| serde_json::from_slice::<LockFile>(&b).ok());
+    print!("{}", paths_picture(name, &profile, lock.as_ref()));
+    Ok(())
+}
+
+/// Testable core of [`cmd_perm_list_paths`].
+fn paths_picture(
+    name: &str,
+    profile: &mur_common::AgentProfile,
+    lock: Option<&LockFile>,
+) -> String {
+    use std::fmt::Write as _;
+    let mut o = String::new();
+    let fs = &profile.entitlements.filesystem;
+    let sandbox = lock.and_then(|l| l.sandbox.as_ref());
+
+    // The header can subsume everything below it, so it goes first.
+    match (lock, sandbox) {
+        (None, _) => {
+            let _ = writeln!(
+                o,
+                "agent '{name}' is not running — these are the grants it would ask for; \
+                 nothing is enforced until it starts."
+            );
+        }
+        (Some(_), None) => {
+            let _ = writeln!(
+                o,
+                "agent '{name}' was started by a runtime that did not record its seal, \
+                 so what actually took effect is unknown. Restart it to find out."
+            );
+        }
+        (Some(_), Some(sb)) if !sb.enforcing => {
+            let _ = writeln!(
+                o,
+                "agent '{name}' is running WITHOUT a kernel sandbox ({}). Only advisory \
+                 hooks apply, so it can reach MORE than the grants below — restart it to \
+                 try sealing again.",
+                sb.mode
+            );
+        }
+        (Some(_), Some(sb)) => {
+            let _ = writeln!(o, "agent '{name}' — sandbox enforcing ({})", sb.mode);
+        }
+    }
+
+    // A grant added after the seal is inert until restart. Which specific rows
+    // moved is not recoverable — only that the set differs — so this is stated
+    // once, for the whole listing, rather than guessed at per row.
+    let drifted = sandbox
+        .is_some_and(|sb| sb.granted_digest != mur_common::agent::filesystem_grants_digest(fs));
+
+    for (label, list) in [("read", &fs.read), ("write", &fs.write), ("deny", &fs.deny)] {
+        if list.is_empty() {
+            continue;
+        }
+        let _ = writeln!(o, "\n{}", label.to_uppercase());
+        for raw in list {
+            let expanded = mur_agent_runtime::sandbox::policy::expand_entitlement_path(raw);
+            let dropped = sandbox.and_then(|sb| {
+                sb.dropped
+                    .iter()
+                    .find(|d| d.verb == label && d.path == expanded.display().to_string())
+            });
+            match dropped {
+                Some(d) => {
+                    let _ = writeln!(o, "  ✗ {raw}\n      dropped — {}", d.reason);
+                }
+                None if sandbox.is_none() => {
+                    let _ = writeln!(o, "  · {raw}");
+                }
+                None => {
+                    let _ = writeln!(o, "  ✓ {raw}");
+                }
+            }
+        }
+    }
+
+    if drifted {
+        let _ = writeln!(
+            o,
+            "\nGrants have changed since this agent sealed, so the ✓ rows describe the \
+             profile as it is now, not as it was enforced:\n    mur agent restart {name}"
+        );
+    }
+    o
+}
+
 /// Refuse a filesystem grant the sandbox would silently discard.
 ///
 /// `SandboxPolicy::from_entitlements` drops entitlement paths that do not exist
@@ -544,7 +643,118 @@ pub fn cmd_perm_list_tools(name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{outbound_picture, validate_host_pattern};
+    use super::{outbound_picture, paths_picture, validate_host_pattern};
+    use mur_common::LockFile;
+    use mur_common::agent::{DroppedGrant, SandboxRecord};
+
+    fn fs_profile(read: &[&str], write: &[&str]) -> mur_common::AgentProfile {
+        let mut p = mur_common::AgentProfile::default_for_tests();
+        p.entitlements.filesystem.read = read.iter().map(|s| s.to_string()).collect();
+        p.entitlements.filesystem.write = write.iter().map(|s| s.to_string()).collect();
+        p
+    }
+
+    fn lock_with(sandbox: Option<SandboxRecord>) -> LockFile {
+        LockFile {
+            schema: 1,
+            uuid: "u".into(),
+            name: "mur".into(),
+            pid: 1,
+            ppid: 0,
+            started_at: "t".into(),
+            binary_version: "v".into(),
+            transports: mur_common::agent::LockTransports {
+                stdio: true,
+                unix_socket: None,
+                tcp: None,
+                webhook: None,
+            },
+            card_digest: "d".into(),
+            capabilities: vec![],
+            build_sha: String::new(),
+            proto_version: 0,
+            sandbox,
+        }
+    }
+
+    fn sealed(profile: &mur_common::AgentProfile, dropped: Vec<DroppedGrant>) -> SandboxRecord {
+        SandboxRecord {
+            enforcing: true,
+            mode: "macos-sbpl".into(),
+            granted_digest: mur_common::agent::filesystem_grants_digest(
+                &profile.entitlements.filesystem,
+            ),
+            dropped,
+        }
+    }
+
+    /// Without a running agent nothing is enforced, and the listing must not
+    /// imply otherwise by ticking every row.
+    #[test]
+    fn a_stopped_agent_is_listed_without_claiming_anything_took_effect() {
+        let p = fs_profile(&[], &["/tmp/x"]);
+        let out = paths_picture("mur", &p, None);
+        assert!(out.contains("is not running"), "{out}");
+        assert!(out.contains("· /tmp/x"), "{out}");
+        assert!(
+            !out.contains('✓'),
+            "a stopped agent has nothing effective: {out}"
+        );
+    }
+
+    #[test]
+    fn a_dropped_grant_is_marked_with_its_reason() {
+        let p = fs_profile(&[], &["/tmp/gone", "/tmp/live"]);
+        let rec = sealed(
+            &p,
+            vec![DroppedGrant {
+                path: "/tmp/gone".into(),
+                verb: "write".into(),
+                reason: "path does not exist on disk".into(),
+            }],
+        );
+        let out = paths_picture("mur", &p, Some(&lock_with(Some(rec))));
+        assert!(out.contains("✗ /tmp/gone"), "{out}");
+        assert!(out.contains("does not exist on disk"), "{out}");
+        assert!(out.contains("✓ /tmp/live"), "{out}");
+        assert!(!out.contains("restart"), "nothing drifted: {out}");
+    }
+
+    /// The loudest case: no kernel sandbox at all means MORE access than the
+    /// grants below, so it cannot be a footnote.
+    #[test]
+    fn an_unenforced_sandbox_is_stated_before_anything_else() {
+        let p = fs_profile(&[], &["/tmp/x"]);
+        let mut rec = sealed(&p, vec![]);
+        rec.enforcing = false;
+        rec.mode = "advisory-only".into();
+        let out = paths_picture("mur", &p, Some(&lock_with(Some(rec))));
+        let first = out.lines().next().unwrap_or_default();
+        assert!(first.contains("WITHOUT a kernel sandbox"), "{out}");
+        assert!(first.contains("MORE"), "{out}");
+    }
+
+    /// Editing grants after the seal does not change what is enforced, and the
+    /// listing has to say so or its ticks are lies.
+    #[test]
+    fn grants_edited_after_the_seal_are_flagged_for_restart() {
+        let sealed_profile = fs_profile(&[], &["/tmp/x"]);
+        let rec = sealed(&sealed_profile, vec![]);
+        let now = fs_profile(&[], &["/tmp/x", "/tmp/added-later"]);
+        let out = paths_picture("mur", &now, Some(&lock_with(Some(rec))));
+        assert!(out.contains("changed since this agent sealed"), "{out}");
+        assert!(out.contains("mur agent restart mur"), "{out}");
+    }
+
+    /// An agent started by an older runtime has no record; saying nothing would
+    /// let its rows read as verified.
+    #[test]
+    fn a_lock_without_a_seal_record_says_the_effect_is_unknown() {
+        let p = fs_profile(&[], &["/tmp/x"]);
+        let out = paths_picture("mur", &p, Some(&lock_with(None)));
+        assert!(out.contains("did not record its seal"), "{out}");
+        assert!(!out.contains('✓'), "{out}");
+    }
 
     fn profile_with(
         servers: Vec<(&str, Option<mur_common::agent::McpNetMode>)>,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1905,6 +1905,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 cmd::agent::cmd_perm_deny_host(&name, &glob)?
             }
             AgentPermAction::ListHosts { name } => cmd::agent::cmd_perm_list_hosts(&name)?,
+            AgentPermAction::ListPaths { name } => cmd::agent::cmd_perm_list_paths(&name)?,
             AgentPermAction::AllowRead { name, path } => {
                 cmd::agent::cmd_perm_allow_read(&name, &path)?
             }


### PR DESCRIPTION
**Stacked on #1089** — base is `feat/record-sandbox-seal-in-lock`, which supplies
the seal record this reads.

C2 of the permission truthfulness spec.

## The gap

`perm` could set filesystem grants but never show them:

| question | command |
|---|---|
| what can this agent reach | `perm list-hosts` |
| what may it run | `perm tool-list` |
| **what can it touch** | **nothing** |

And `profile.yaml` alone is the wrong answer: it is a *request*, while the kernel
enforces the profile as it stood when the agent sealed.

```
agent 'mur' — sandbox enforcing (macos-sbpl)

WRITE
  ✓ /Volumes/…/mur
  ✗ /Volumes/…/cc-proxy
      dropped — path does not exist on disk
```

## What it refuses to claim

Three of the four states exist to *not* overstate:

- **no lock** — the agent is not running, nothing is enforced. Rows are `·`,
  never `✓`.
- **a lock with no seal record** — started by a runtime that did not write one,
  so what took effect is unknown. Again no `✓`.
- **`enforcing: false`** — said in the first line, because an agent with no
  kernel sandbox has *more* access than the list below and that subsumes every
  row beneath it.

Live against the running agent, which is on 2.71.9 and predates #1089:

```
$ mur agent perm list-paths mur
agent 'mur' was started by a runtime that did not record its seal, so what
actually took effect is unknown. Restart it to find out.

READ
  · /Volumes/Firecuda4tb/Projects/mur
  · /Volumes/Firecuda4tb/Projects/cc-proxy
  …
```

Exactly right: it declines to tick anything. After #1089 ships and agents
restart, that `cc-proxy` row becomes `✗ … dropped — path does not exist on disk`.

## A limit worth naming

Grants edited after the seal are flagged **once for the whole listing**, not per
row. #1089 records `granted_digest` but not the sealed path set, so which
specific rows moved is genuinely not recoverable — and guessing per row would be
the same kind of confident wrong answer this whole spec exists to remove. A
restart makes it precise again.

## Verification

Mutation — forcing drift detection off:

```
FAIL  grants_edited_after_the_seal_are_flagged_for_restart
PASS  a_dropped_grant_is_marked_with_its_reason     ← asserts the restart line is ABSENT
```

`cargo nextest run -p mur-core` → 5651 passed.
`cargo clippy -p mur-core --all-targets -- -D warnings` → 0.

## On C4

**C4 needs no work — it already exists.** `mur agent doctor <name>` reports both
findings the spec described, live:

```
✗ entitlements (2 of 22 filesystem grant(s) will be DROPPED at start — the path
  does not exist: read …/cc-proxy, write …/cc-proxy.)
```

The spec's C4 was redundant and I have not built a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)