### PR TITLE
docs(spec): the Hub does have a Permissions tab — it just has no permissions in it

### DIFF
--- a/docs/superpowers/specs/2026-08-30-agent-permission-truthfulness-design.md
+++ b/docs/superpowers/specs/2026-08-30-agent-permission-truthfulness-design.md
@@ -255,6 +255,17 @@ the network half of the same question. B is deliberately second: it is a
 display layer, and building it on a source that cannot distinguish granted from
 effective would render the `cc-proxy` grant as "granted" in a nicer font.
 
+B starts from a worse position than "nothing", which this document originally
+recorded. `mur-hub-gui/ui/src/components/inspector/tabs/PermissionsTab.tsx`
+exists — 41 lines showing the agent's capability strings, its MCP server count
+and its skill count. No filesystem grant, no network reach, nothing the sandbox
+enforces. So a user looking for "what may this agent write" finds a tab named
+**Permissions**, reads it, and reasonably concludes MUR does not track that.
+
+An empty space invites the question; a tab that answers it wrongly closes it.
+B therefore has to correct a claim, not just fill a gap — and the correction is
+the more urgent half, because it is the part that actively misleads.
+
 **Issue #1085** — bridge liveness is classified from a `running.lock` mtime that
 nothing refreshes. Found while auditing the lock for C1, unrelated to it, and
 fixed separately. It does constrain C1 in one way: whatever #1085 chooses must


### PR DESCRIPTION
Correction to the spec merged in #1086. Docs only.

It recorded subproject B as filling an empty space — "a Hub permissions page".
That is wrong:

`mur-hub-gui/ui/src/components/inspector/tabs/PermissionsTab.tsx` — 41 lines:

| shows | does not show |
|---|---|
| capability strings | filesystem grants |
| MCP server **count** | network reach |
| skill **count** | anything the kernel enforces |

So the tab is named for the topic and contains none of it.

**That is worse than nothing, for the same reason the rest of the spec exists.**
An empty space invites the question. A tab labelled *Permissions* that answers it
wrongly closes it — a user looking for "what may this agent write" opens it,
reads three counts, and reasonably concludes MUR does not track that.

B therefore has to correct a claim, not just fill a gap, and the correction is
the more urgent half.

Found while inventorying the Hub and Dashboard surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)