### PR TITLE
docs(spec): D5 — the Hub must reach the Dashboard before it links to it

### DIFF
--- a/docs/superpowers/specs/2026-08-30-hub-dashboard-surface-split-design.md
+++ b/docs/superpowers/specs/2026-08-30-hub-dashboard-surface-split-design.md
@@ -173,6 +173,42 @@ A link into a dead port is worse than no link. This is a precondition, not a
 detail: the server is not running by default, and had to be started by hand to
 take the measurements in this document.
 
+### D5 — reaching the Dashboard from the Hub
+
+D3c leaves a link to `localhost:3847` conditional on the target being reachable.
+That condition is general — it applies to every Hub → Dashboard link, not just
+the schedule one — so it is specified here rather than inside D3.
+
+**The check must identify MUR, not the port.** `GET /api/v1/health` returns
+`{"source":"local","status":"ok","version":"2.71.9"}`. A TCP connect is not
+enough, and neither is a 200: this server answers 200 with the SPA for any
+unmatched path, and an unrelated process can hold 3847. The check is: health
+responds, parses as JSON, and reports `status: "ok"`.
+
+Three states, three behaviours:
+
+| state | what the Hub does |
+|---|---|
+| health answers `ok` | open the browser |
+| port closed | start the server, wait for health, then open — with a visible "starting…", not a frozen click |
+| port held, not MUR | **do not open.** Say what is on the port |
+
+The third row is the one that is easy to omit and expensive to get wrong:
+without it the Hub opens a browser onto a stranger's server, which is worse than
+the blank page this exists to prevent.
+
+**Whoever starts it, stops it.** If the Hub started the server, the Hub shuts it
+down when it quits; a listening socket the user never asked for should not
+outlive the app that opened it. If it was already running, leave it alone —
+someone else owns it.
+
+**On demand, not at launch.** Opening a port when the Hub starts is a surprise,
+and the kind of thing this project keeps deliberately opt-in. The trigger is the
+user asking for the Dashboard.
+
+The Hub already supervises child processes (`mur-gui-core/src/sidecar.rs`), so
+this needs a new client of existing machinery rather than new machinery.
+
 ### D4 — one describer, one next-fire calculator
 
 `mur-web/src/lib/schedule-parser.ts` is 288 lines carrying natural-language →


### PR DESCRIPTION
Follow-up to #1093. Docs only.

The spec made the `localhost:3847` link conditional on reachability, buried in
D3c. The condition is general — it applies to **every** Hub → Dashboard link —
so it becomes its own section.

## What it pins

**The check identifies MUR, not the port.**

```
$ curl -s localhost:3847/api/v1/health
{"source":"local","status":"ok","version":"2.71.9"}
```

A TCP connect is not enough, and neither is a 200 — this server answers 200 with
the SPA for any unmatched path (the same trap that made the endpoint inventory
in #1093 wrong on its first pass), and an unrelated process can hold 3847.

| state | Hub |
|---|---|
| health answers `ok` | open the browser |
| port closed | start it, wait for health, then open — with a visible "starting…" |
| **port held, not MUR** | **do not open.** Say what is on the port |

The third row is easy to omit and expensive to get wrong: without it the Hub
opens a browser onto a stranger's server, which is worse than the blank page this
exists to prevent.

**Ownership and timing.** Whoever starts it stops it — a listening socket the
user never asked for should not outlive the app that opened it. And on demand,
never at launch: opening a port when the Hub starts is a surprise, and this
project keeps that kind of thing opt-in.

The Hub already supervises child processes (`mur-gui-core/src/sidecar.rs`), so
this is a new client of existing machinery, not new machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)