### PR TITLE
fix(schedule): a blank "Next" column is never an acceptable answer

### DIFF
--- a/mur-core/src/schedule_status.rs
+++ b/mur-core/src/schedule_status.rs
@@ -28,6 +28,8 @@ pub enum ScheduleItem {
         message: String,
         next_fires: Vec<String>,
         status: String,
+        description: String,
+        next_note: Option<String>,
     },
     AgentIdle {
         owner: String,
@@ -35,12 +37,16 @@ pub enum ScheduleItem {
         cooldown_secs: u64,
         message: String,
         status: String,
+        description: String,
+        next_note: Option<String>,
     },
     Workflow {
         owner: String,
         expr: Option<String>,
         next_fires: Vec<String>,
         status: String,
+        description: String,
+        next_note: Option<String>,
     },
     Fleet {
         owner: String,
@@ -49,6 +55,8 @@ pub enum ScheduleItem {
         status: String,
         budget_usd: f64,
         autorun_env: bool,
+        description: String,
+        next_note: Option<String>,
     },
 }
 
@@ -74,6 +82,90 @@ pub fn schedule_status(mur_home: &Path, agent_filter: Option<&str>) -> ScheduleS
         schedules,
         warnings,
     }
+}
+
+/// Human phrasing for a cron expression.
+///
+/// Computed here, not in each client: cron → English is a real derivation, and
+/// a second implementation of it eventually disagrees with this one. The
+/// Dashboard already carries such a second implementation
+/// (`mur-web/src/lib/schedule-parser.ts`), which is what this is working
+/// toward retiring.
+///
+/// Only the shapes that actually occur are phrased; anything else falls back to
+/// the raw expression. A wrong sentence is worse than a cron string a reader can
+/// look up, so the fallback is deliberate rather than a gap to be filled in
+/// later with guesses.
+pub fn describe_cron(expr: &str) -> String {
+    let f: Vec<&str> = expr.split_whitespace().collect();
+    if f.len() != 5 {
+        return expr.to_string();
+    }
+    let (min, hour, dom, mon, dow) = (f[0], f[1], f[2], f[3], f[4]);
+    let every_day = dom == "*" && mon == "*";
+    let at = |h: &str, m: &str| -> Option<String> {
+        let (h, m) = (h.parse::<u32>().ok()?, m.parse::<u32>().ok()?);
+        (h < 24 && m < 60).then(|| format!("{h:02}:{m:02}"))
+    };
+    match (min, hour, dow) {
+        (m, "*", "*") if every_day => {
+            if let Some(n) = m.strip_prefix("*/").and_then(|n| n.parse::<u32>().ok()) {
+                return format!("every {n} minutes");
+            }
+            if m == "*" {
+                return "every minute".into();
+            }
+            if m.parse::<u32>().is_ok() {
+                return "hourly".into();
+            }
+            expr.to_string()
+        }
+        (m, h, "*") if every_day => match at(h, m) {
+            Some(t) => format!("daily at {t}"),
+            None => expr.to_string(),
+        },
+        (m, h, "1-5") if every_day => match at(h, m) {
+            Some(t) => format!("weekdays at {t}"),
+            None => expr.to_string(),
+        },
+        _ => expr.to_string(),
+    }
+}
+
+/// Human phrasing for a fleet loop trigger (`cron:…`, `interval:…`, `manual`).
+fn describe_trigger(trigger: &str) -> String {
+    if let Some(expr) = trigger.strip_prefix("cron:") {
+        return describe_cron(expr);
+    }
+    if let Some(every) = trigger.strip_prefix("interval:") {
+        return format!("every {every}");
+    }
+    if trigger == "manual" {
+        return "manual — runs only when started".into();
+    }
+    trigger.to_string()
+}
+
+/// Why an item has no next fire.
+///
+/// The invariant this exists for: **an empty `next_fires` always carries a
+/// note.** A blank "Next" column is indistinguishable from "will not run
+/// again", and one of the things it currently hides is a fleet that runs every
+/// thirty minutes.
+fn trigger_note(trigger: &str) -> Option<String> {
+    if trigger == "manual" {
+        return Some("no timetable — this runs only when something starts it".into());
+    }
+    if trigger.starts_with("interval:") {
+        // `.last_run` is named by `schedule_status`'s own comment and by
+        // `cmd/fleet/export.rs` as the state this would need — and nothing in
+        // the tree writes it, so the gap is permanent until something does.
+        return Some(
+            "not tracked — an interval fires relative to its last run, which is not recorded"
+                .into(),
+        );
+    }
+    Some(format!("could not read a schedule from `{trigger}`"))
 }
 
 fn fires(expr: &str) -> Vec<String> {
@@ -115,11 +207,16 @@ fn collect_agents(
         };
 
         for s in &profile.lifecycle.schedule {
+            let next_fires = fires(&s.cron);
             out.push(ScheduleItem::AgentCron {
                 owner: name.clone(),
                 expr: s.cron.clone(),
                 message: s.message.clone(),
-                next_fires: fires(&s.cron),
+                description: describe_cron(&s.cron),
+                next_note: next_fires
+                    .is_empty()
+                    .then(|| format!("could not read a schedule from `{}`", s.cron)),
+                next_fires,
                 status: "enabled".into(),
             });
         }
@@ -129,6 +226,10 @@ fn collect_agents(
                 after_secs: t.after_secs,
                 cooldown_secs: t.cooldown_secs,
                 message: t.message.clone(),
+                description: format!("after {}s idle", t.after_secs),
+                // Not a failure to compute: an idle trigger has no clock to
+                // read. Saying so beats a blank that reads as "never".
+                next_note: Some("no fixed time — fires once the agent has been idle".into()),
                 status: "enabled".into(),
             });
         }
@@ -138,11 +239,22 @@ fn collect_agents(
 fn collect_workflows(out: &mut Vec<ScheduleItem>) {
     for s in list_system_schedules_detailed() {
         let next_fires = s.cron.as_deref().map(fires).unwrap_or_default();
+        let description = s
+            .cron
+            .as_deref()
+            .map(describe_cron)
+            .unwrap_or_else(|| "manual — runs only when started".into());
+        let next_note = next_fires.is_empty().then(|| match s.cron.as_deref() {
+            Some(expr) => format!("could not read a schedule from `{expr}`"),
+            None => "no timetable — this runs only when something starts it".into(),
+        });
         out.push(ScheduleItem::Workflow {
             owner: s.workflow,
             expr: s.cron,
             next_fires,
             status: "enabled".into(),
+            description,
+            next_note,
         });
     }
 }
@@ -182,6 +294,11 @@ fn collect_fleets(home: &Path, out: &mut Vec<ScheduleItem>, warnings: &mut Vec<S
             .strip_prefix("cron:")
             .map(fires)
             .unwrap_or_default();
+        let description = describe_trigger(&loop_cfg.trigger);
+        let next_note = next_fires
+            .is_empty()
+            .then(|| trigger_note(&loop_cfg.trigger))
+            .flatten();
         out.push(ScheduleItem::Fleet {
             owner: fleet.name,
             trigger: loop_cfg.trigger,
@@ -189,12 +306,131 @@ fn collect_fleets(home: &Path, out: &mut Vec<ScheduleItem>, warnings: &mut Vec<S
             status: if stopped { "stopped" } else { "enabled" }.into(),
             budget_usd: loop_cfg.budget_usd,
             autorun_env: std::env::var("MUR_FLEET_AUTORUN").is_ok_and(|v| v == "1"),
+            description,
+            next_note,
         });
     }
 }
 
 #[cfg(test)]
 mod tests {
+    /// `(has a next fire, note explaining why not)` for any item.
+    fn next_state(it: &ScheduleItem) -> (bool, Option<&str>) {
+        match it {
+            ScheduleItem::AgentCron {
+                next_fires,
+                next_note,
+                ..
+            }
+            | ScheduleItem::Workflow {
+                next_fires,
+                next_note,
+                ..
+            }
+            | ScheduleItem::Fleet {
+                next_fires,
+                next_note,
+                ..
+            } => (!next_fires.is_empty(), next_note.as_deref()),
+            ScheduleItem::AgentIdle { next_note, .. } => (false, next_note.as_deref()),
+        }
+    }
+
+    /// The invariant the whole change exists for: a blank "Next" is never an
+    /// acceptable resting state. Either there is a fire time, or there is a
+    /// sentence saying why there is not — never neither.
+    #[test]
+    fn every_item_either_has_a_next_fire_or_says_why_not() {
+        let home = tempfile::tempdir().unwrap();
+        let fleets = home.path().join("fleets");
+        for (name, trigger) in [
+            ("timed", "cron:*/15 * * * *"),
+            ("paced", "interval:30m"),
+            ("handstart", "manual"),
+            ("garbled", "whenever-i-feel-like-it"),
+        ] {
+            let d = fleets.join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(
+                d.join("fleet.yaml"),
+                format!(
+                    "name: {name}\nchannel_id: fleet-{name}\nloop:\n  trigger: \"{trigger}\"\n"
+                ),
+            )
+            .unwrap();
+        }
+        let st = schedule_status(home.path(), None);
+        assert_eq!(st.schedules.len(), 4, "{:?}", st.schedules);
+        for it in &st.schedules {
+            let (has_fire, note) = next_state(it);
+            assert!(
+                has_fire != note.is_some(),
+                "exactly one of a fire time and a note, got ({has_fire}, {note:?}) for {it:?}"
+            );
+        }
+    }
+
+    /// The row from the report: a fleet running every half hour rendered as
+    /// "—", which reads as "will not run again".
+    #[test]
+    fn an_interval_fleet_says_why_it_has_no_next_time() {
+        let home = tempfile::tempdir().unwrap();
+        let d = home.path().join("fleets/smoke");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(
+            d.join("fleet.yaml"),
+            "name: smoke\nchannel_id: fleet-smoke\nloop:\n  trigger: \"interval:30m\"\n",
+        )
+        .unwrap();
+        let st = schedule_status(home.path(), None);
+        let ScheduleItem::Fleet {
+            description,
+            next_note,
+            ..
+        } = &st.schedules[0]
+        else {
+            panic!("{:?}", st.schedules)
+        };
+        assert_eq!(description, "every 30m");
+        assert!(
+            next_note.as_deref().unwrap().contains("last run"),
+            "{next_note:?}"
+        );
+    }
+
+    #[test]
+    fn cron_is_phrased_for_the_shapes_that_occur() {
+        for (expr, want) in [
+            ("*/15 * * * *", "every 15 minutes"),
+            ("* * * * *", "every minute"),
+            ("0 * * * *", "hourly"),
+            ("30 9 * * *", "daily at 09:30"),
+            ("0 3 * * *", "daily at 03:00"),
+            ("30 9 * * 1-5", "weekdays at 09:30"),
+        ] {
+            assert_eq!(describe_cron(expr), want, "for {expr}");
+        }
+    }
+
+    /// A cron string a reader can look up beats a sentence that is wrong, so
+    /// anything unrecognised must come back verbatim rather than guessed at.
+    #[test]
+    fn an_unrecognised_cron_shape_is_returned_verbatim() {
+        for expr in ["0 9 1 * *", "15 2 * 6 3", "not a cron", "0 9 * *"] {
+            assert_eq!(describe_cron(expr), expr, "must not invent a phrasing");
+        }
+    }
+
+    #[test]
+    fn trigger_phrasing_covers_all_three_forms() {
+        assert_eq!(describe_trigger("cron:0 * * * *"), "hourly");
+        assert_eq!(describe_trigger("interval:2h"), "every 2h");
+        assert_eq!(
+            describe_trigger("manual"),
+            "manual — runs only when started"
+        );
+    }
+
     use super::*;
     use std::fs;
 

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -29,6 +29,8 @@ type ScheduleItem =
       message: string;
       next_fires: string[];
       status: string;
+      description: string;
+      next_note: string | null;
     }
   | {
       kind: "agent_idle";
@@ -37,6 +39,8 @@ type ScheduleItem =
       cooldown_secs: number;
       message: string;
       status: string;
+      description: string;
+      next_note: string | null;
     }
   | {
       kind: "workflow";
@@ -44,6 +48,8 @@ type ScheduleItem =
       expr?: string | null;
       next_fires: string[];
       status: string;
+      description: string;
+      next_note: string | null;
     }
   | {
       kind: "fleet";
@@ -53,6 +59,8 @@ type ScheduleItem =
       status: string;
       budget_usd: number;
       autorun_env: boolean;
+      description: string;
+      next_note: string | null;
     };
 
 type ScheduleStatus = { schedules: ScheduleItem[]; warnings: string[] };
@@ -98,25 +106,43 @@ type Activities = { channels: ChannelSummary[]; hitl: HitlRequestView[] };
 
 const POLL_MS = 30000;
 
-function scheduleWhen(s: ScheduleItem): string {
+/// The raw expression, kept as a tooltip: the phrasing is for reading, the
+/// expression is for editing, and a reader who wants to change it needs both.
+function scheduleExpr(s: ScheduleItem): string {
   switch (s.kind) {
     case "agent_cron":
       return s.expr;
     case "agent_idle":
-      return `every ${s.after_secs}s idle`;
+      return `after ${s.after_secs}s idle`;
     case "workflow":
-      return s.expr ?? "";
+      return s.expr ?? "manual";
     case "fleet":
       return s.trigger;
   }
 }
 
-function scheduleNext(s: ScheduleItem): { text: string; title: string } {
+/// Which agent this row belongs to.
+///
+/// A pure mapping over `kind`, so it lives here rather than in the aggregator:
+/// it is a label, not a derivation, and four constants cannot drift. Fleet and
+/// workflow schedules are machine-wide — the panel is scoped to one agent, and
+/// showing them unlabelled is what makes a five-row table look like five of
+/// this agent's schedules.
+function scheduleScope(s: ScheduleItem): "agent" | "global" {
+  return s.kind === "agent_cron" || s.kind === "agent_idle" ? "agent" : "global";
+}
+
+function scheduleNext(s: ScheduleItem): { text: string; title: string; muted: boolean } {
   const fires = "next_fires" in s ? s.next_fires : [];
-  if (!fires.length) return { text: "—", title: "" };
+  if (!fires.length) {
+    // Never a bare dash. A blank here reads as "will not run again", and one of
+    // the things it used to hide was a fleet running every thirty minutes. The
+    // backend guarantees a note whenever there is no fire time.
+    return { text: s.next_note ?? "not scheduled", title: s.next_note ?? "", muted: true };
+  }
   const first = new Date(fires[0]);
   const text = Number.isNaN(first.getTime()) ? fires[0] : first.toLocaleString();
-  return { text, title: fires.join("\n") };
+  return { text, title: fires.join("\n"), muted: false };
 }
 
 export function PanelWindow() {
@@ -444,7 +470,7 @@ export function PanelWindow() {
             <table className="panel-table">
               <thead>
                 <tr>
-                  <th>Kind</th>
+                  <th>Scope</th>
                   <th>Owner</th>
                   <th>When</th>
                   <th>Next</th>
@@ -456,10 +482,26 @@ export function PanelWindow() {
                   const next = scheduleNext(s);
                   return (
                     <tr key={i}>
-                      <td>{s.kind}</td>
+                      <td
+                        className={
+                          scheduleScope(s) === "global" ? "panel-muted" : undefined
+                        }
+                        title={
+                          scheduleScope(s) === "global"
+                            ? "machine-wide — not specific to this agent"
+                            : "this agent"
+                        }
+                      >
+                        {scheduleScope(s) === "global" ? "all agents" : "this agent"}
+                      </td>
                       <td>{s.owner}</td>
-                      <td>{scheduleWhen(s)}</td>
-                      <td title={next.title}>{next.text}</td>
+                      <td title={scheduleExpr(s)}>{s.description}</td>
+                      <td
+                        className={next.muted ? "panel-muted" : undefined}
+                        title={next.title}
+                      >
+                        {next.text}
+                      </td>
                       <td>
                         <span
                           className={


### PR DESCRIPTION
D3b of the [surface-split spec](docs/superpowers/specs/2026-08-30-hub-dashboard-surface-split-design.md).

## What was on screen

An agent panel, five rows, **none of them belonging to that agent**:

| Kind | Owner | When | Next |
|---|---|---|---|
| fleet | smoke | `interval:30m` | **—** |
| fleet | deep-research | `manual` | — |
| fleet | builder | `cron:*/15 * * * *` | 2026/8/30 19:30 |

That first row runs every thirty minutes. The dash reads as "will not run
again".

## The dash had three meanings and one rendering

| case | what it meant |
|---|---|
| `manual` | no timetable exists |
| idle trigger | no clock exists |
| `interval:30m` | **cannot be computed** |

The third is the interesting one. It is not that cron parsing fails — it is a
documented fail-soft: an interval's next fire is relative to `.last_run`. Two
places name that file as the state this needs, and **nothing in the tree writes
it**, so the fail-soft is permanent. (Third time this week a comment has
described a mechanism that does not exist — see #1085.)

## The fix

Two fields on every `ScheduleItem`:

- **`description`** — the trigger in words. `*/15 * * * *` → "every 15 minutes".
  The raw expression moves to the tooltip: the phrasing is for reading, the
  expression is for editing, and someone changing it needs both.
- **`next_note`** — why there is no next fire, whenever there is none.

**The invariant, and the test that holds it: exactly one of a fire time and a
note.** "Neither" is not a state this can rest in any more.

```rust
assert!(has_fire != note.is_some(), "…");
```

`describe_cron` phrases only the shapes that occur and returns anything else
verbatim — a cron string a reader can look up beats a sentence that is wrong, so
the fallback is deliberate, pinned by its own test.

## On the panel

The **Kind** column held one distinct value across all five rows. It becomes
**Scope** — "this agent" or "all agents" — which is what makes five machine-wide
fleet schedules stop looking like five of this agent's.

Scope is a four-constant mapping over `kind`, so it stays in the client. A
label, not a derivation; `description` and `next_note` are derivations and stay
in Rust, per D4.

## Verification

Mutation — dropping the interval note:

```
FAIL  every_item_either_has_a_next_fire_or_says_why_not
FAIL  an_interval_fleet_says_why_it_has_no_next_time
PASS  cron_is_phrased_for_the_shapes_that_occur      ← control
PASS  trigger_phrasing_covers_all_three_forms        ← control
```

`cargo clippy -p mur-core --all-targets -- -D warnings` → 0.
`npx tsc --noEmit` → clean. Hub UI: 185 tests passed.

Defects 2 (the "Show all agents" toggle) and 4 (ordering) are not here — the
Scope column makes the toggle's effect visible, which is the precondition for
fixing what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)