### PR TITLE
chore(release): bump workspace version to 2.71.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.9"
+version = "2.71.10"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.9"
+version = "2.71.10"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.10 — permission truthfulness, and schedules that explain themselves.

## Permissions (spec #1086)

An agent that hit `cannot create '.git/index.lock': Operation not permitted`
handed the work back, because nothing could say which path was missing, which
command would grant it, or whether a grant already existed but had not taken
effect.

| PR | |
|---|---|
| #1087 | a write denial in a child's stderr is classified and explained — and says **nothing** when it cannot account for the errno |
| #1088 | the exec-denial half moves in beside it (pure code motion) |
| #1089 | `running.lock` records what the sandbox actually sealed: `enforcing`, the grants it discarded, and why |
| #1090 | `mur agent perm list-paths` — granted against effective |

`enforcing` is the field that had no home at all: the runtime can run an agent
advisory-only when the seal fails, which gives it **more** access than its
profile grants, and no surface reported it.

Live on this machine and now visible: `cc-proxy` is in the profile's read and
write lists and the sandbox dropped both, because the directory no longer
exists.

## Schedules

| PR | |
|---|---|
| #1095 | a blank "Next" column is never an acceptable answer |
| #1096 | an agent's schedules appear on the agent, split from machine-wide ones |

The dash had three meanings and one rendering — no timetable, no clock, and
*cannot be computed*. The third hid a fleet running every thirty minutes. There
is now an invariant with a test behind it: exactly one of a fire time and a note
saying why there is none.

## Specs

#1086 (permission truthfulness), #1093 (which surface owns what), #1094 (the Hub
must reach the Dashboard before linking to it), #1092 (correcting this document's
own claim that the Hub had no permissions tab — it has one, with no permissions
in it).

## User-visible changes to watch

- **`mur agent logs`** now reads whichever log the running supervisor actually
  writes, and names the file. Previously it could show days-old output as
  current (shipped 2.71.9, listed here because it changes what the command
  prints).
- **The Panel's Schedule tab** replaces its `Kind` column with `Scope`, and
  renders trigger phrasing instead of raw cron.
- **A bash failure that hit a sandbox denial** now carries an extra advisory
  paragraph naming the grant command.

Merging this tags `v2.71.10` and dispatches `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)