### PR TITLE
chore(release): bump workspace version to 2.71.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.10"
+version = "2.71.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.10"
+version = "2.71.11"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.11 — one fix, for something 2.71.10 shipped broken.

**#1098** — the write-denial advisory added in #1087 could never fire inside a
real agent. It resolved the agent's write grants through `agent_facts()`, which
starts by reading `<agent>/profile.yaml` — a file the sandbox denies to the
agent itself (`SELF_PROTECTED_AGENT_FILES`, issue #712). `.ok()?` returned
`None` and the explanation silently vanished.

Found by running the fix against the live agent after 2.71.10 deployed, which is
the only place it could have been found: a test process can read the profile
that a sandboxed agent cannot, so no test — including an end-to-end one — would
have caught it.

The grants are now passed in from the profile already in memory, and the
regression test asserts the structural property that broke: given a `mur_home`
with no profile in it, the advisory must still appear.

## The rest of 2.71.10 verified on the live agent

| | |
|---|---|
| #1089 seal record in `running.lock` | ✅ `enforcing: true`; `cc-proxy` recorded dropped, read and write |
| #1090 `perm list-paths` | ✅ `✗ /Volumes/…/cc-proxy — dropped — path does not exist on disk` |
| #1095 schedule phrasing | ✅ `every 30m` with its note, against the real fleets |

Merging this tags `v2.71.11` and dispatches `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)