### PR TITLE
fix(bridge): classify liveness from the file a heartbeat actually touches

### DIFF
--- a/mur-agent-runtime/src/bridge/beacon.rs
+++ b/mur-agent-runtime/src/bridge/beacon.rs
@@ -4,10 +4,14 @@
 //! `telemetry/bridge_alive` JSON-RPC notification every 30 s. Peers that
 //! cooperate with the bridge (typically a user agent reading the
 //! commander or another agent's notification stream) classify the
-//! bridge's liveness via [`bridge_status_for_peer`] which inspects the
-//! `running.lock` mtime — a still-running supervisor refreshes the lock
-//! on every beacon emit (file mtime advances when telemetry is written
-//! through `TelemetryWriter`'s JSONL append path).
+//! bridge's liveness via [`bridge_status_for_peer`].
+//!
+//! That used to read `running.lock`'s mtime, on the belief that writing
+//! telemetry advanced it. Writing telemetry advances the *telemetry file's*
+//! mtime; `running.lock` is written once at startup and never again, so the
+//! age being measured was simply the bridge's uptime and every bridge read as
+//! `Degraded` ninety seconds after starting. The intent was right and the file
+//! was wrong — see issue #1085.
 //!
 //! See plan task M-c1.4 in
 //! `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md`.
@@ -20,7 +24,7 @@ use crate::telemetry_writer::Event;
 
 pub use mur_common::telemetry::METHOD_BRIDGE_ALIVE;
 
-/// Maximum age of a bridge's `running.lock` mtime before peers should
+/// Maximum age of a bridge's last written telemetry before peers should
 /// treat the bridge as `Degraded`. The bridge supervisor emits a
 /// `telemetry/bridge_alive` notification every 30 s, so a 90 s window
 /// tolerates two missed beats.
@@ -106,16 +110,21 @@ pub enum BridgePeerStatus {
 /// Classify a bridge peer by inspecting `running.lock` mtime in
 /// `agent_dir` (typically `~/.mur/agents/<name>/`).
 pub fn bridge_status_for_peer(agent_dir: &Path) -> BridgePeerStatus {
-    let meta = match std::fs::metadata(agent_dir.join("running.lock")) {
-        Ok(m) => m,
-        Err(_) => return BridgePeerStatus::Offline,
-    };
-    let mtime = match meta.modified() {
+    // Existence comes from the lock, which is accurate: it is written at
+    // startup and removed on shutdown. Recency comes from telemetry, which is
+    // the file a beat actually touches.
+    let lock = match std::fs::metadata(agent_dir.join("running.lock")).and_then(|m| m.modified()) {
         Ok(t) => t,
         Err(_) => return BridgePeerStatus::Offline,
     };
+    // The lock's mtime is the start time, and it stays useful as a floor: the
+    // first beat only lands after one full interval, so a bridge that started
+    // twenty seconds ago has no telemetry yet and is not degraded.
+    let last_sign_of_life = newest_telemetry_write(agent_dir)
+        .max(Some(lock))
+        .unwrap_or(lock);
     let age = SystemTime::now()
-        .duration_since(mtime)
+        .duration_since(last_sign_of_life)
         .unwrap_or_default()
         .as_secs();
     if age > DEGRADED_AFTER_SECS {
@@ -125,8 +134,84 @@ pub fn bridge_status_for_peer(agent_dir: &Path) -> BridgePeerStatus {
     }
 }
 
+/// When this agent last appended telemetry.
+///
+/// One file per day (`telemetry/YYYY-MM-DD.jsonl`), appended per event, so the
+/// newest mtime across them is the last time the process wrote anything —
+/// which for a bridge agent is dominated by its own heartbeat.
+fn newest_telemetry_write(agent_dir: &Path) -> Option<SystemTime> {
+    std::fs::read_dir(agent_dir.join("telemetry"))
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "jsonl"))
+        .filter_map(|e| e.metadata().ok()?.modified().ok())
+        .max()
+}
+
 #[cfg(test)]
 mod tests {
+    fn stamp(p: &std::path::Path, ago: u64) {
+        if let Some(d) = p.parent() {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(p, "x").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(p)
+            .unwrap()
+            .set_modified(SystemTime::now() - Duration::from_secs(ago))
+            .unwrap();
+    }
+
+    /// The bug in #1085: a bridge beating normally read `Degraded` because the
+    /// age being measured was its uptime. Old lock, fresh telemetry — that is
+    /// a healthy bridge, and the only thing distinguishing it is which file is
+    /// consulted.
+    #[test]
+    fn a_bridge_up_for_hours_and_still_beating_is_running() {
+        let d = tempfile::tempdir().unwrap();
+        stamp(&d.path().join("running.lock"), 7 * 3600);
+        stamp(&d.path().join("telemetry/2026-08-31.jsonl"), 10);
+        assert_eq!(bridge_status_for_peer(d.path()), BridgePeerStatus::Running);
+    }
+
+    #[test]
+    fn a_bridge_that_stopped_beating_is_degraded() {
+        let d = tempfile::tempdir().unwrap();
+        stamp(&d.path().join("running.lock"), 7 * 3600);
+        stamp(
+            &d.path().join("telemetry/2026-08-31.jsonl"),
+            DEGRADED_AFTER_SECS + 60,
+        );
+        assert_eq!(bridge_status_for_peer(d.path()), BridgePeerStatus::Degraded);
+    }
+
+    /// The first beat only lands after one full interval, so a bridge that
+    /// started seconds ago has no telemetry and must not read as degraded.
+    #[test]
+    fn a_bridge_that_just_started_is_running_before_its_first_beat() {
+        let d = tempfile::tempdir().unwrap();
+        stamp(&d.path().join("running.lock"), 5);
+        std::fs::create_dir_all(d.path().join("telemetry")).unwrap();
+        assert_eq!(bridge_status_for_peer(d.path()), BridgePeerStatus::Running);
+    }
+
+    /// …but a long-running process that has never written anything is not
+    /// healthy, and the lock's mtime must not keep it looking alive forever.
+    #[test]
+    fn silence_for_longer_than_the_window_is_degraded_even_with_a_lock() {
+        let d = tempfile::tempdir().unwrap();
+        stamp(&d.path().join("running.lock"), DEGRADED_AFTER_SECS + 60);
+        assert_eq!(bridge_status_for_peer(d.path()), BridgePeerStatus::Degraded);
+    }
+
+    #[test]
+    fn no_lock_is_offline_whatever_telemetry_says() {
+        let d = tempfile::tempdir().unwrap();
+        stamp(&d.path().join("telemetry/2026-08-31.jsonl"), 1);
+        assert_eq!(bridge_status_for_peer(d.path()), BridgePeerStatus::Offline);
+    }
+
     use super::*;
     #[test]
     fn payload_has_method_and_bridge_id() {


### PR DESCRIPTION
Fixes #1085.

## The bug

`bridge_status_for_peer` read `running.lock`'s mtime against a 90-second window
sized for a 30-second heartbeat. **Nothing refreshes that mtime** — the lock is
written once at startup and never again — so the age being measured was the
bridge's uptime, and every bridge reads `Degraded` ninety seconds after starting.

Measured on a live agent: lock written 3 seconds after start, untouched through
seven hours of uptime.

## The module explained the mechanism it believed in

> a still-running supervisor refreshes the lock on every beacon emit (file mtime
> advances when telemetry is written through `TelemetryWriter`'s JSONL append
> path)

Writing telemetry advances the **telemetry file's** mtime. The intent was right
and the file was wrong.

## Fix

| | source | why |
|---|---|---|
| existence | `running.lock` | accurate — written at startup, removed at shutdown |
| recency | newest `telemetry/*.jsonl` mtime | the file a beat actually touches |

The lock's mtime stays useful as a **floor**: the first beat lands one full
interval after start, so a bridge twenty seconds old has no telemetry yet and
must not read as degraded. `max(lock, newest telemetry)` covers both.

## Why there were no tests before

The old behaviour was not merely wrong — it was **untestable**. It depended on a
mechanism that did not exist, so there was nothing to assert about it. The five
tests here are possible only because the classification now reads something that
moves.

Mutation — reverting to the lock-only form:

```
FAIL  a_bridge_up_for_hours_and_still_beating_is_running    ← the issue's case
PASS  a_bridge_that_stopped_beating_is_degraded             ← control
PASS  a_bridge_that_just_started_is_running_before_its_first_beat
PASS  silence_for_longer_than_the_window_is_degraded_even_with_a_lock
PASS  no_lock_is_offline_whatever_telemetry_says
```

The first mutation attempt silently did not apply — `cargo fmt` had rewrapped
the anchor line, and five green tests were the *unmutated* code. Caught by the
script's own assertion; the run above is the real one.

`cargo nextest run -p mur-agent-runtime` → 950 passed.
`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → 0.

This machine has no agent with `entitlements.llm.mode = off`, so the end-to-end
misreport could not be reproduced here — the fix is verified against the three
established facts (the mtime never moves, telemetry does, the window was sized
for the beat) rather than against a live bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)