### PR TITLE
feat(llm): a 401 names the endpoint, the model and the credential it used

### DIFF
--- a/mur-agent-runtime/src/llm/client_builder.rs
+++ b/mur-agent-runtime/src/llm/client_builder.rs
@@ -71,16 +71,23 @@ fn endpoint_context(entry: &ModelEntry) -> String {
         .base_url
         .as_deref()
         .unwrap_or("the provider's default endpoint");
+    // `label`, not `to_string`: a `cmd:` reference Displays its whole command
+    // line, and this string travels further than `mur agent doctor`'s stdout —
+    // it lands in the turn error, the TUI and whatever persists that.
     let secret = match &entry.secret {
-        Some(s) => s.to_string(),
+        Some(s) => s.label(),
         None => "the agent's own credentials (no secret ref)".to_string(),
     };
-    format!(
+    // A net under the structural fix above: a base URL can carry userinfo and a
+    // provider can echo a key back in a body we later concatenate. Catches only
+    // known key shapes, which is why it is the second line of defence.
+    let line = format!(
         "[auth] this request went to {endpoint} as {}/{}, carrying {secret}. \
          The endpoint rejected that credential — the model entry, the endpoint and the \
          credential are all named here so the wrong one can be found without guessing.",
         entry.provider, entry.model
-    )
+    );
+    mur_common::redact::redact_secrets(&line).into_owned()
 }
 
 /// Names the endpoint on an authentication failure.
@@ -309,6 +316,28 @@ mod endpoint_named_tests {
         // A resolved key would look nothing like a path; assert the shape we
         // print rather than trying to detect a secret after the fact.
         assert!(!c.contains("sk-"), "{c}");
+    }
+
+    /// This string travels further than `mur agent doctor`'s stdout — into the
+    /// turn error, the TUI, and whatever persists that — so a `cmd:` reference
+    /// must not bring its command line along.
+    #[test]
+    fn a_command_credential_does_not_carry_its_arguments_here() {
+        let mut e = entry();
+        e.secret = Some(SecretRef::Cmd("vault read --token=orgtok123".into()));
+        let c = endpoint_context(&e);
+        assert!(!c.contains("orgtok123"), "{c}");
+        assert!(c.contains("cmd:vault"), "{c}");
+    }
+
+    /// The pattern net under the structural fix: a key shape reaching this
+    /// string by any other route is still removed.
+    #[test]
+    fn a_key_shaped_string_anywhere_in_the_context_is_redacted() {
+        let mut e = entry();
+        e.base_url = Some("https://proxy/sk-ant-0123456789abcdefghijklmnop".into());
+        let c = endpoint_context(&e);
+        assert!(!c.contains("sk-ant-0123456789"), "{c}");
     }
 
     #[test]

--- a/mur-agent-runtime/src/llm/client_builder.rs
+++ b/mur-agent-runtime/src/llm/client_builder.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use tracing::warn;
 
-use crate::llm::LlmClient;
+use crate::llm::{LlmClient, LlmError};
 use crate::llm::{anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient};
 use crate::profile::Profile;
 use crate::sandbox::reqwest_guard::HostGuard;
@@ -50,6 +50,96 @@ impl std::error::Error for GuardedHttpBuildError {}
 /// the differentiated stub/log behaviour for those two on `Err` (see
 /// `build_provider_runner` in `supervisor_runner.rs`).
 pub(crate) fn build_client_from_entry(
+    entry: &ModelEntry,
+    profile: &Profile,
+    mur_home: &Path,
+) -> anyhow::Result<Arc<dyn LlmClient>> {
+    let client = build_bare_client(entry, profile, mur_home)?;
+    Ok(Arc::new(EndpointNamed {
+        inner: client,
+        context: endpoint_context(entry),
+    }))
+}
+
+/// Describe where a request goes and which credential it carries.
+///
+/// `SecretRef`'s Display is the *reference* — `file:…`, `keychain:svc/acct`,
+/// `env:VAR` — never the value, which is why it is safe to print here and why
+/// `mur agent doctor` already prints the same form.
+fn endpoint_context(entry: &ModelEntry) -> String {
+    let endpoint = entry
+        .base_url
+        .as_deref()
+        .unwrap_or("the provider's default endpoint");
+    let secret = match &entry.secret {
+        Some(s) => s.to_string(),
+        None => "the agent's own credentials (no secret ref)".to_string(),
+    };
+    format!(
+        "[auth] this request went to {endpoint} as {}/{}, carrying {secret}. \
+         The endpoint rejected that credential — the model entry, the endpoint and the \
+         credential are all named here so the wrong one can be found without guessing.",
+        entry.provider, entry.model
+    )
+}
+
+/// Names the endpoint on an authentication failure.
+///
+/// A 401 body says "API key is invalid" and nothing about *which* key or
+/// *which* endpoint, which leaves an operator with three suspects and no way
+/// to narrow them. The facts are in the `ModelEntry` this was built from, and
+/// they cannot be recovered when the error arrives: `~/.mur/models.yaml` is
+/// not in an agent's read grants, so looking them up later fails exactly the
+/// way the write-denial advisory did (#1087). They are captured once, here.
+///
+/// Only `Auth` is touched. Every other class either already names its cause or
+/// is a candidate for the fallback chain, and decorating those would put this
+/// paragraph in front of failures it does not explain.
+struct EndpointNamed {
+    inner: Arc<dyn LlmClient>,
+    context: String,
+}
+
+impl EndpointNamed {
+    fn name_endpoint(&self, e: LlmError) -> LlmError {
+        match e {
+            LlmError::Auth(status, body) => {
+                LlmError::Auth(status, format!("{body}\n\n{}", self.context))
+            }
+            other => other,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmClient for EndpointNamed {
+    async fn generate(
+        &self,
+        req: crate::llm::LlmRequest,
+    ) -> Result<crate::llm::LlmResponse, LlmError> {
+        self.inner
+            .generate(req)
+            .await
+            .map_err(|e| self.name_endpoint(e))
+    }
+
+    fn model_name(&self) -> &str {
+        self.inner.model_name()
+    }
+
+    async fn generate_stream(
+        &self,
+        req: crate::llm::LlmRequest,
+        sink: tokio::sync::mpsc::Sender<crate::llm::StreamDelta>,
+    ) -> Result<crate::llm::LlmResponse, LlmError> {
+        self.inner
+            .generate_stream(req, sink)
+            .await
+            .map_err(|e| self.name_endpoint(e))
+    }
+}
+
+fn build_bare_client(
     entry: &ModelEntry,
     profile: &Profile,
     mur_home: &Path,
@@ -175,5 +265,106 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
             .build()
             .expect("failed to build scratch runtime")
             .block_on(fut),
+    }
+}
+
+#[cfg(test)]
+mod endpoint_named_tests {
+    use super::*;
+    use mur_common::model::ModelEntry;
+    use mur_common::secret::SecretRef;
+
+    fn entry() -> ModelEntry {
+        ModelEntry {
+            provider: "anthropic".into(),
+            model: "claude-opus-5".into(),
+            base_url: Some("http://127.0.0.1:8088".into()),
+            secret: Some(SecretRef::File(
+                "/Users/d/.mur/secrets/anthropic.key".into(),
+            )),
+            ..Default::default()
+        }
+    }
+
+    /// The dead end this exists to remove: "API key is invalid" names neither
+    /// the key nor the endpoint, so the credential, the base URL and the model
+    /// entry are all suspects and the error rules out none of them.
+    #[test]
+    fn the_context_names_endpoint_model_and_credential() {
+        let c = endpoint_context(&entry());
+        assert!(c.contains("127.0.0.1:8088"), "{c}");
+        assert!(c.contains("claude-opus-5"), "{c}");
+        assert!(
+            c.contains("file:/Users/d/.mur/secrets/anthropic.key"),
+            "{c}"
+        );
+    }
+
+    /// `SecretRef`'s Display is the reference, not the value — but a test is
+    /// the only thing that keeps it that way if the type ever changes.
+    #[test]
+    fn the_context_carries_a_reference_never_a_value() {
+        let c = endpoint_context(&entry());
+        assert!(c.contains("file:"), "must name the ref form: {c}");
+        // A resolved key would look nothing like a path; assert the shape we
+        // print rather than trying to detect a secret after the fact.
+        assert!(!c.contains("sk-"), "{c}");
+    }
+
+    #[test]
+    fn an_entry_without_a_secret_says_so_rather_than_printing_nothing() {
+        let mut e = entry();
+        e.secret = None;
+        let c = endpoint_context(&e);
+        assert!(c.contains("no secret ref"), "{c}");
+    }
+
+    fn named() -> EndpointNamed {
+        EndpointNamed {
+            inner: Arc::new(NullClient),
+            context: "[auth] CONTEXT".into(),
+        }
+    }
+
+    struct NullClient;
+    #[async_trait::async_trait]
+    impl LlmClient for NullClient {
+        async fn generate(
+            &self,
+            _req: crate::llm::LlmRequest,
+        ) -> Result<crate::llm::LlmResponse, LlmError> {
+            unreachable!("not called by these tests")
+        }
+        fn model_name(&self) -> &str {
+            "null"
+        }
+    }
+
+    #[test]
+    fn an_auth_failure_gains_the_endpoint() {
+        let out = named().name_endpoint(LlmError::Auth(401, "API key is invalid".into()));
+        let LlmError::Auth(status, body) = out else {
+            panic!("class must not change")
+        };
+        assert_eq!(status, 401);
+        assert!(body.contains("API key is invalid"), "{body}");
+        assert!(body.contains("[auth] CONTEXT"), "{body}");
+    }
+
+    /// Everything else is left alone. A rate limit or a retired model already
+    /// names its own cause, and a candidate that the fallback chain will route
+    /// around must not carry a paragraph about credentials.
+    #[test]
+    fn every_other_class_is_left_untouched() {
+        let n = named();
+        assert!(matches!(
+            n.name_endpoint(LlmError::RateLimit),
+            LlmError::RateLimit
+        ));
+        let out = n.name_endpoint(LlmError::Rejected(413, "too large".into()));
+        let LlmError::Rejected(_, body) = out else {
+            panic!("class must not change")
+        };
+        assert_eq!(body, "too large", "must not be decorated");
     }
 }

--- a/mur-common/src/secret.rs
+++ b/mur-common/src/secret.rs
@@ -94,6 +94,35 @@ fn preseal_lookup(r: &SecretRef) -> Option<SecretString> {
     c.iter().find(|(k, _)| k == r).map(|(_, v)| v.clone())
 }
 
+/// A form of this reference that is safe to put in front of a user, a log, or
+/// a model.
+///
+/// [`Display`](std::fmt::Display) prints the reference verbatim, which is right
+/// where the reader is the operator looking at their own config. It is wrong
+/// for `Cmd`: the whole command line is printed, and a command line is exactly
+/// where an inline credential lives (`cmd:vault read --token=…`).
+///
+/// Redaction by pattern does not cover this — `redact_secrets` matches known
+/// key shapes (`sk-`, `AKIA`, `ghp_`, JWT, PEM) and an arbitrary `--token=`
+/// argument is none of them. So the arguments are dropped structurally rather
+/// than filtered: the program name is what identifies the credential, and the
+/// arguments are only where the danger is.
+impl SecretRef {
+    pub fn label(&self) -> String {
+        match self {
+            SecretRef::Cmd(c) => {
+                let program = c.split_whitespace().next().unwrap_or("");
+                if c.split_whitespace().nth(1).is_some() {
+                    format!("cmd:{program} (arguments hidden)")
+                } else {
+                    format!("cmd:{program}")
+                }
+            }
+            other => other.to_string(),
+        }
+    }
+}
+
 impl std::fmt::Display for SecretRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -462,6 +491,41 @@ async fn decrypt_age(bytes: &[u8]) -> Result<String, SecretError> {
 
 #[cfg(test)]
 mod tests {
+    /// A command line is exactly where an inline credential lives, and pattern
+    /// redaction does not cover it: `redact_secrets` matches known key shapes
+    /// and `--token=anything` is none of them. The arguments go structurally.
+    #[test]
+    fn a_command_reference_hides_its_arguments() {
+        let r = SecretRef::Cmd("vault read -field=key secret/x --token=orgtok123".into());
+        let label = r.label();
+        assert!(label.starts_with("cmd:vault"), "{label}");
+        assert!(!label.contains("orgtok123"), "{label}");
+        assert!(label.contains("arguments hidden"), "{label}");
+    }
+
+    /// …but a bare command has nothing to hide, and saying "arguments hidden"
+    /// when there are none is its own small lie.
+    #[test]
+    fn a_bare_command_reference_is_shown_whole() {
+        assert_eq!(SecretRef::Cmd("get-key".into()).label(), "cmd:get-key");
+    }
+
+    /// The other forms name a location, not a payload, so they are unchanged —
+    /// `mur agent doctor` has printed them for a long time.
+    #[test]
+    fn the_other_forms_are_unchanged() {
+        for r in [
+            SecretRef::Env("ANTHROPIC_API_KEY".into()),
+            SecretRef::File("/home/d/.mur/secrets/k".into()),
+            SecretRef::Keychain {
+                service: "mur".into(),
+                account: "anthropic".into(),
+            },
+        ] {
+            assert_eq!(r.label(), r.to_string(), "{r}");
+        }
+    }
+
     use super::*;
     use serde_yaml_ng as yaml;
 


### PR DESCRIPTION
Refs #1100 — the first and larger half of it.

## The dead end

```
error: auth refused (401): {"type":"error","error":{"type":"authentication_error",
"message":"API key is invalid."}}
```

Which key? Which endpoint? The credential, the base URL and the registry entry
are all suspects and the message rules out none of them. Diagnosing this one
took reading the agent log, probing the gateway, and a `/login` that reported
**healthy** — because it checks the owner CLI's OAuth state, not the path the
turn takes.

## After

```
[auth] this request went to http://127.0.0.1:8088 as anthropic/claude-opus-5,
carrying file:/Users/d/.mur/secrets/anthropic.key. The endpoint rejected that
credential — the model entry, the endpoint and the credential are all named here
so the wrong one can be found without guessing.
```

## Captured at construction, not looked up later

Not a preference: **`~/.mur/models.yaml` is not in an agent's read grants**, so
resolving these when the error arrives fails exactly the way the write-denial
advisory did in #1087. Same lesson, applied before it bit a second time.

`SecretRef`'s Display is the *reference* — `file:…`, `keychain:svc/acct`,
`env:VAR` — never the value. That is the form `mur agent doctor` already prints.

## Only `Auth` is decorated

Every other class either names its own cause (`model not found`, `rate
limited`) or is a candidate the fallback chain routes around. A paragraph about
credentials in front of a 413 explains the wrong thing, so a control test pins
that nothing else is touched.

Wrapping happens in `build_client_from_entry`, which all three construction
paths go through — single model, hot-switch, and fallback candidates.

## Why this and not a better `/login`

Same shape as the write-denial advisory and the schedule notes shipped earlier
today: **the surface that fails is the surface that explains.** A separate
diagnostic is a second answer to a question the failure already had the material
to answer — which is precisely how `/login` came to disagree with reality.

The residual half of #1100 — `/login` naming what it checked, and what this
agent actually uses — is smaller and stays open there.

## Verification

Mutation — dropping the decoration:

```
FAIL  an_auth_failure_gains_the_endpoint
PASS  every_other_class_is_left_untouched            ← control
PASS  the_context_names_endpoint_model_and_credential
PASS  the_context_carries_a_reference_never_a_value
PASS  an_entry_without_a_secret_says_so_rather_than_printing_nothing
```

`cargo nextest run -p mur-agent-runtime` → 950 passed.
`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → 0.

Not reproduced against a live 401: the credential that produced the original one
is user-side and has since been repaired. The context string is verified by unit
test; the wiring is the same `build_client_from_entry` every turn already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)