### PR TITLE
fix(login): /login says whose login it checked, and what this agent dials

### DIFF
--- a/mur-core/src/cmd/agent/cli/login.rs
+++ b/mur-core/src/cmd/agent/cli/login.rs
@@ -476,17 +476,62 @@ pub fn render_status_line(p: Provider, s: &OwnerStatus, stamped: bool) -> String
 
 /// The whole table. Blocking (shells out per provider via [`owner_status`]
 /// and, on macOS, [`store_stamp`]) — dispatch off the UI task.
-pub fn render_status_all() -> String {
-    let mut out = String::from("OAuth providers:\n");
+pub fn render_status_all(agent: &str) -> String {
+    let mut out = String::from("OAuth providers — the owner CLI's login:\n");
     for p in Provider::ALL {
         let s = owner_status(p);
         out.push_str(&render_status_line(p, &s, store_stamp(p).is_some()));
         out.push('\n');
     }
+    out.push_str(&agent_endpoint_line(agent));
     out.push_str(
         "\n(unrelated to `mur auth login`, which signs in to mur.run for the official catalog)",
     );
     out
+}
+
+/// What this agent's next turn will actually dial.
+///
+/// The table above is about the owner CLI's login. An agent reaches its model
+/// through the registry — provider, base URL, credential — and the two coincide
+/// only when the agent happens to use OAuth through that CLI. On any other
+/// setup a green tick above says nothing about whether the next turn works,
+/// which is how a healthy-looking `/login` came to sit next to a 401 (#1100).
+///
+/// The secret is NAMED, never resolved: a status line must not pop a keychain
+/// prompt. `mur agent doctor` resolves it deliberately, because it is
+/// interactive and a human asked it to check.
+fn agent_endpoint_line(agent: &str) -> String {
+    let path = crate::paths::mur_root(None)
+        .join("agents")
+        .join(agent)
+        .join("profile.yaml");
+    let Ok(yaml) = std::fs::read_to_string(&path) else {
+        return String::new();
+    };
+    let Ok(profile) = serde_yaml_ng::from_str::<mur_common::AgentProfile>(&yaml) else {
+        return String::new();
+    };
+    // The runtime's own resolution, so this cannot describe a different model
+    // than the one the turn will use.
+    match mur_agent_runtime::supervisor::resolve_model_entry(&profile) {
+        Ok(entry) => {
+            let endpoint = entry
+                .base_url
+                .as_deref()
+                .unwrap_or("the provider's default endpoint");
+            let credential = match &entry.secret {
+                Some(s) => s.to_string(),
+                None => "the agent's own credentials".to_string(),
+            };
+            format!(
+                "\n\nagent '{agent}' dials {endpoint} as {}/{}, carrying {credential}.\n\
+                 A ✓ above covers that only if this agent goes through the owner CLI.",
+                entry.provider, entry.model
+            )
+        }
+        Err(e) => format!("\n\nagent '{agent}' has no resolvable model: {e}"),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -752,3 +797,33 @@ fn request_login_handover(app: &mut crate::cmd::agent::cli::app::App, p: Provide
 #[cfg(test)]
 #[path = "login/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod endpoint_line_tests {
+    use super::*;
+
+    /// A status line must not resolve the credential: on macOS a `keychain:`
+    /// ref pops an authorization prompt, and typing `/login` to look at a table
+    /// is not asking for one. `mur agent doctor` resolves deliberately, because
+    /// a human asked it to check.
+    #[test]
+    fn the_endpoint_line_names_the_credential_without_resolving_it() {
+        let src = include_str!("login.rs");
+        let body = src
+            .split("fn agent_endpoint_line")
+            .nth(1)
+            .expect("function must exist");
+        let body = &body[..body.find("\n}\n").unwrap_or(body.len())];
+        assert!(
+            !body.contains("resolve_blocking"),
+            "a status line must not resolve a secret"
+        );
+    }
+
+    /// An unknown agent must produce nothing rather than an error banner: the
+    /// OAuth table above is still useful and this line is an addition to it.
+    #[test]
+    fn an_unknown_agent_adds_nothing() {
+        assert_eq!(agent_endpoint_line("no-such-agent-xyz"), "");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/login.rs
+++ b/mur-core/src/cmd/agent/cli/login.rs
@@ -520,8 +520,10 @@ fn agent_endpoint_line(agent: &str) -> String {
                 .base_url
                 .as_deref()
                 .unwrap_or("the provider's default endpoint");
+            // `label`, not `to_string`: a `cmd:` reference Displays its whole
+            // command line, which is where an inline credential lives.
             let credential = match &entry.secret {
-                Some(s) => s.to_string(),
+                Some(s) => s.label(),
                 None => "the agent's own credentials".to_string(),
             };
             format!(

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -2003,7 +2003,7 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
             }
         }
         SlashCmd::Login(arg) => match arg {
-            None => run_manage(app, move |_agent| Ok(login::render_status_all())).await,
+            None => run_manage(app, move |agent| Ok(login::render_status_all(&agent))).await,
             Some(word) => match login::Provider::parse(&word) {
                 None => app.push_error(format!(
                     "unknown provider {word:?} — try anthropic or chatgpt"


### PR DESCRIPTION
The residual half of #1100. Pairs with #1103.

## The disagreement

`/login` reported `Anthropic ✓ logged in` for an agent whose next turn returned
401. **Both were true.** The check reads the owner CLI's OAuth state; the agent
reaches its model through the registry — provider, base URL, credential ref.
Those coincide only when the agent goes through that CLI, and on a machine using
a gateway and an API key they do not.

## Live, on the machine where the 401 happened

```
OAuth providers — the owner CLI's login:
    Anthropic  ✓ logged in
    ChatGPT    not logged in (or the check timed out) — /login chatgpt

  agent 'mur' dials http://127.0.0.1:8088 as anthropic/claude-opus-5,
  carrying file:/Users/david/.mur/secrets/anthropic.key.
  A ✓ above covers that only if this agent goes through the owner CLI.
```

The tick and the reason it does not apply are now on the same screen.

## Two decisions worth naming

**The runtime's own resolution.** `resolve_model_entry`, not a private copy, so
this cannot describe a different model than the turn will use — the same
reasoning `mur agent doctor` already records for doing it that way.

**The credential is named, never resolved.** On macOS resolving a `keychain:`
ref pops an authorization prompt, and typing `/login` to look at a table is not
asking for a system dialog. Doctor resolving it is right *there*: it is
interactive and a human asked it to check. A test greps the function body for
`resolve_blocking` so the distinction cannot erode into a status command with
side effects.

An unresolvable agent or profile adds nothing rather than an error banner — the
table above it stands on its own.

`cargo clippy -p mur-core --all-targets -- -D warnings` → 0. Verified live
through the locally built CLI, not only by test.

## Why this is the smaller half

#1103 makes the **401 itself** name the endpoint. That is where the fact is
needed, because that is when the user is looking. This is what you see *before*
spending a turn — useful, but it was never going to be the fix on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)