### PR TITLE
chore(release): bump workspace version to 2.71.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.11"
+version = "2.71.12"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.11"
+version = "2.71.12"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.12 — four surfaces that asserted something they had not checked.

| PR | issue | what it asserted | what was true |
|---|---|---|---|
| #1101 | #1091 | grants "DROPPED WHOLE by the sandbox" | only under Landlock; macOS installs the grant and re-denies the paths inside it |
| #1102 | #1085 | bridge liveness from a `running.lock` mtime | nothing refreshes that mtime; the age measured was uptime, so every bridge read `Degraded` after 90 s |
| #1103 | #1100 | `401 API key is invalid` | which key? which endpoint? — now named, with the model entry |
| #1104 | #1100 | `Anthropic ✓ logged in` | that is the owner CLI's login, which covers this agent only if it goes through that CLI |

## Security

#1103 moves a credential *reference* into the turn error, which travels further
than `mur agent doctor`'s stdout. `SecretRef::Cmd` Displays its whole command
line, and a command line is where an inline credential lives, so
`SecretRef::label()` now drops the arguments structurally — pattern redaction
was not enough for that case, since `redact_secrets` matches known key shapes
and `--token=anything` is none of them. `redact_secrets` stays on top as a net.
Both printers use the safe label.

Found by review before merge, not after.

## Known and recorded, not shipped

- **#1105** — `grant_scope_verdict(&[], &[], _)` returns a failing check with an
  empty explanation. Unreachable behind the caller's early return, and exactly
  the shape #1095 removed from schedules two hours earlier.
- **#1106** — `/login` joins a raw agent name into a path instead of going
  through `canonicalize_agent_name` (CLAUDE.md rule 8). Latent: the only caller
  supplies a canonical name.

## Verified live before this release

On the running agent, after 2.71.11:

- `running.lock` carries the seal record — `enforcing: true`, `cc-proxy` dropped
  for read and write
- `mur agent perm list-paths mur` → `✗ …/cc-proxy — dropped — path does not exist on disk`
- schedules read `every 30m` with a note, not a bare dash
- the write-denial advisory names `perm allow-write` on the nearest existing
  ancestor

Not verifiable here: #1102 (no agent with `llm.mode = off` on this machine) and
#1103's live 401 (the credential that produced one has since been repaired).
Both are unit-tested and mutation-verified; neither has been observed end to end.

Merging this tags `v2.71.12` and dispatches `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)