### PR TITLE
fix(doctor,login): two review findings from the 2.71.12 batch

### DIFF
--- a/mur-core/src/cmd/agent/cli/login.rs
+++ b/mur-core/src/cmd/agent/cli/login.rs
@@ -502,10 +502,14 @@ pub fn render_status_all(agent: &str) -> String {
 /// prompt. `mur agent doctor` resolves it deliberately, because it is
 /// interactive and a human asked it to check.
 fn agent_endpoint_line(agent: &str) -> String {
-    let path = crate::paths::mur_root(None)
-        .join("agents")
-        .join(agent)
-        .join("profile.yaml");
+    // Through the canonicaliser, not straight into a path: agent lookup is
+    // case-insensitive on the CLI (CLAUDE.md rule 8), and a typed name that
+    // differs only in case would otherwise silently render nothing here. It
+    // also removes the question of what a name containing `..` would do,
+    // rather than leaving it to be reasoned about (#1106).
+    let home = crate::paths::mur_root(None);
+    let agent = crate::a2a_dial::canonicalize_agent_name(&home, agent);
+    let path = home.join("agents").join(&agent).join("profile.yaml");
     let Ok(yaml) = std::fs::read_to_string(&path) else {
         return String::new();
     };

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -448,18 +448,12 @@ fn check_dropped_launch_chain_grants(
     // the user-visible consequence is identical: the grant silently vanishes.
     let (_kept_r, dropped_reads) = chain.partition_read_grants(&reads);
 
-    if dropped.is_empty() && dropped_reads.is_empty() {
-        return Check::new(
-            "grant_scope",
-            true,
-            format!(
-                "{} write + {} read grant(s), none overlap a protected path",
-                writes.len(),
-                reads.len()
-            ),
-        );
-    }
-    let (ok, detail) = grant_scope_verdict(&dropped, &dropped_reads, cfg!(target_os = "linux"));
+    let (ok, detail) = grant_scope_verdict(
+        &dropped,
+        &dropped_reads,
+        (writes.len(), reads.len()),
+        cfg!(target_os = "linux"),
+    );
     Check::new("grant_scope", ok, detail)
 }
 
@@ -472,8 +466,21 @@ fn check_dropped_launch_chain_grants(
 fn grant_scope_verdict(
     dropped: &[std::path::PathBuf],
     dropped_reads: &[std::path::PathBuf],
+    (writes, reads): (usize, usize),
     landlock: bool,
 ) -> (bool, String) {
+    // The all-clear used to live in the caller as an early return, which left
+    // this function returning `(false, "")` when handed two empty lists — a
+    // failed check with nothing written beside it. Unreachable through that
+    // caller, and exactly the blank #1095 removed from schedules: a verdict
+    // must always arrive with its reason. Owning the whole decision here means
+    // there is no invariant to enforce elsewhere and forget (#1105).
+    if dropped.is_empty() && dropped_reads.is_empty() {
+        return (
+            true,
+            format!("{writes} write + {reads} read grant(s), none overlap a protected path"),
+        );
+    }
     let mut parts: Vec<String> = Vec::new();
     if !dropped.is_empty() {
         let names: Vec<String> = dropped.iter().map(|p| p.display().to_string()).collect();
@@ -516,7 +523,10 @@ fn grant_scope_verdict(
     // A write-only overlap is not a failure where the grant is installed.
     // Reporting it as one is how a check earns its way into the part of the
     // screen people stop reading.
-    let ok = dropped_reads.is_empty() && !dropped.is_empty() && !landlock;
+    // Reached only with something dropped, so this says what it means: a read
+    // overlap fails everywhere, a write overlap fails only where Landlock
+    // discards it.
+    let ok = dropped_reads.is_empty() && !landlock;
     (ok, parts.join("; "))
 }
 
@@ -693,6 +703,21 @@ pub fn run_agent(name: &str, json: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    /// #1105: handed nothing dropped, this used to return a failed check with
+    /// an empty explanation — the blank that #1095 removed from schedules,
+    /// reintroduced two hours later in the fix for #1091. It was unreachable
+    /// only because the caller guarded it, and nothing in the signature said so.
+    #[test]
+    fn nothing_dropped_is_a_pass_with_its_reason_not_a_blank_failure() {
+        for landlock in [true, false] {
+            let (ok, detail) = grant_scope_verdict(&[], &[], (3, 2), landlock);
+            assert!(ok, "landlock={landlock}: {detail}");
+            assert!(!detail.is_empty(), "a verdict must arrive with its reason");
+            assert!(detail.contains("3 write"), "{detail}");
+            assert!(detail.contains("2 read"), "{detail}");
+        }
+    }
+
     fn pb(p: &str) -> std::path::PathBuf {
         std::path::PathBuf::from(p)
     }
@@ -701,7 +726,7 @@ mod tests {
     /// user must narrow it.
     #[test]
     fn under_landlock_an_overlapping_write_grant_is_reported_as_lost() {
-        let (ok, detail) = grant_scope_verdict(&[pb("/home/d/.mur")], &[], true);
+        let (ok, detail) = grant_scope_verdict(&[pb("/home/d/.mur")], &[], (1, 0), true);
         assert!(!ok, "{detail}");
         assert!(detail.contains("DROPPED WHOLE"), "{detail}");
         assert!(detail.contains("specific subdirectory"), "{detail}");
@@ -712,7 +737,7 @@ mod tests {
     /// Telling the user it was dropped sends them to narrow a working grant.
     #[test]
     fn without_landlock_the_same_grant_is_installed_and_not_called_lost() {
-        let (ok, detail) = grant_scope_verdict(&[pb("/Users/d/.mur")], &[], false);
+        let (ok, detail) = grant_scope_verdict(&[pb("/Users/d/.mur")], &[], (1, 0), false);
         assert!(ok, "an installed grant is not a failure: {detail}");
         assert!(
             !detail.contains("DROPPED WHOLE"),
@@ -726,7 +751,7 @@ mod tests {
     #[test]
     fn a_read_overlap_fails_on_either_platform() {
         for landlock in [true, false] {
-            let (ok, detail) = grant_scope_verdict(&[], &[pb("/x/.mur")], landlock);
+            let (ok, detail) = grant_scope_verdict(&[], &[pb("/x/.mur")], (0, 1), landlock);
             assert!(!ok, "landlock={landlock}: {detail}");
             assert!(detail.contains("DROPPED WHOLE"), "{detail}");
         }


### PR DESCRIPTION
Fixes #1105 and #1106 — both found by reviewing the 2.71.12 batch before it
shipped, neither merge-blocking, both recorded rather than left in a
conversation.

## #1105 — a verdict with no reason

`grant_scope_verdict(&[], &[], _)` returned `(false, "")`. Measured with a probe
during review:

```
REVIEW PROBE: ok=false detail=""     // landlock = false
REVIEW PROBE: ok=false detail=""     // landlock = true
```

Unreachable, because the caller returned early for the all-clear case. But:

```rust
let ok = dropped_reads.is_empty() && !dropped.is_empty() && !landlock;
```

`!dropped.is_empty()` was always true there, so the term read as a condition
while acting as an **assertion about a guard in another function**. Move or
remove that guard and every healthy agent starts reporting a failure with
nothing written next to it.

The function now owns the whole decision — the counts come in as a parameter,
the early return is gone, and `ok` says what it means.

**Worth naming because of when it happened.** #1095 established the rule that a
verdict always arrives with its reason — *a blank is never a resting state*.
This was written two hours later, by the same hand, in the fix for #1091. A rule
does not transfer by having been learned once; it transfers by being tested.

## #1106 — a raw name in a path

`agent_endpoint_line` joined the agent name straight into
`<mur_home>/agents/<agent>/profile.yaml`, bypassing `canonicalize_agent_name`.
CLAUDE.md rule 8 requires that resolution, and a typed name differing only in
case would have rendered nothing. Latent — the only caller supplies a canonical
name — and routing through the canonicaliser also removes the `..` question
rather than leaving it to be reasoned about.

## Verification

Mutation — removing the all-clear branch:

```
FAIL  nothing_dropped_is_a_pass_with_its_reason_not_a_blank_failure
PASS  under_landlock_an_overlapping_write_grant_is_reported_as_lost   ← control
PASS  a_read_overlap_fails_on_either_platform                          ← control
PASS  without_landlock_the_same_grant_is_installed_and_not_called_lost ← control
```

14 grant-scope tests pass.
`cargo clippy -p mur-core --all-targets -- -D warnings` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)