### PR TITLE
feat(remind): an agent can ask for a schedule that actually fires

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -362,6 +362,25 @@ pub async fn build_provider_runner(
             );
         }
     }
+    // Built-in remind: an agent cannot create its own schedule — its entries
+    // live in a `profile.yaml` the sandbox denies it — so this writes a
+    // proposal into the agent home instead. Available like `open_item` rather
+    // than gated: it writes a file nothing acts on until a person runs
+    // `mur agent schedule accept`, and the alternative is what #1075 recorded,
+    // a timed request landing in a list with no clock. An explicit Deny still
+    // wins.
+    {
+        use crate::tools::remind::{REMIND, RemindTool};
+        use mur_common::agent::{ToolPolicy, resolve_tool_policy};
+        if resolve_tool_policy(&tools_policy, REMIND) != ToolPolicy::Deny {
+            tool_map.insert(
+                REMIND.to_string(),
+                Arc::new(RemindTool {
+                    agent_home: agent_home.to_path_buf(),
+                }),
+            );
+        }
+    }
     // Built-in remember (memory federation P2a): proactive capture of durable
     // user preferences/facts as agent-local Draft notes. Gated on the global
     // `memory.capture` config; an explicit Deny in the profile still wins.

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -10,6 +10,7 @@ pub mod read_file;
 pub mod recall;
 pub mod registry;
 pub mod remember;
+pub mod remind;
 pub(crate) mod suggest;
 pub mod write_file;
 

--- a/mur-agent-runtime/src/tools/remind.rs
+++ b/mur-agent-runtime/src/tools/remind.rs
@@ -1,0 +1,198 @@
+//! Built-in `remind` tool: let an agent ask for a schedule it cannot create.
+//!
+//! An agent's schedules live in `lifecycle.schedule` inside its own
+//! `profile.yaml`, and an agent may not write that file — the sandbox denies it
+//! unconditionally, so a running agent cannot widen its own entitlements and
+//! restart into them. "Remind me at 10 tomorrow" therefore cannot become a
+//! schedule from the inside, however well the agent understands the request.
+//!
+//! Before this, that request became an open item: free text, no due field,
+//! nothing to fire it. The one in issue #1075 sat for three weeks and was
+//! closed by hand as expired.
+//!
+//! Now it becomes a proposal — a file in the agent's own home, which it may
+//! write — that `mur agent schedule accept` turns into the real entry, on the
+//! real scheduler. The agent does not gain the ability to wake itself up; it
+//! gains the ability to ask, in a form a person can act on with one command.
+//!
+//! The cron expression comes from the model, not from a date parser here.
+//! Converting "tomorrow at 10" into `0 10 <dom> <mon> *` needs today's date and
+//! the user's intent, both of which the model has and this crate does not.
+
+use crate::tools::{ToolDef, ToolError, ToolExecutor, ToolOutput};
+
+pub const REMIND: &str = "remind";
+
+pub struct RemindTool {
+    pub agent_home: std::path::PathBuf,
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for RemindTool {
+    fn name(&self) -> &str {
+        REMIND
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: REMIND.into(),
+            description: "Ask for a recurring or one-off reminder that MUR's scheduler will \
+actually fire. Use this whenever a request has a time in it — \"remind me at 10 tomorrow\", \
+\"every weekday morning\", \"in an hour\". Recording a timed request as an open item instead \
+leaves it with nothing to fire it. This writes a PROPOSAL: the user runs `mur agent schedule \
+accept` to grant it, so say that you have asked rather than that it is set."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "required": ["cron", "message"],
+                "properties": {
+                    "cron": {
+                        "type": "string",
+                        "description": "Standard 5-field cron in the user's LOCAL time: minute hour day-of-month month day-of-week. Resolve relative words yourself — 'tomorrow at 10' is `0 10 <tomorrow's day> <month> *`, not a phrase. Use `*` in day-of-month and month for a recurring one."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "What to say when it fires, written as the reminder itself"
+                    },
+                    "asked_for": {
+                        "type": "string",
+                        "description": "The user's own words, verbatim. A cron expression is not reviewable on its own and the reviewer is being asked whether this is what they meant."
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
+        let field = |k: &str| -> Option<String> {
+            input
+                .get(k)
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        };
+        let cron = field("cron").ok_or_else(|| {
+            ToolError::InvalidInput("provide `cron` — 5 fields, local time".into())
+        })?;
+        let message = field("message").ok_or_else(|| {
+            ToolError::InvalidInput("provide `message` — what to say when it fires".into())
+        })?;
+
+        // Rejected here rather than at accept time: an agent that writes an
+        // unparseable proposal has told the user a reminder is pending, and the
+        // failure surfaces only when they try to grant it.
+        if cron.split_whitespace().count() != 5 {
+            return Err(ToolError::InvalidInput(format!(
+                "`cron` needs 5 space-separated fields (minute hour day-of-month month \
+                 day-of-week), got {:?}",
+                cron
+            )));
+        }
+
+        let dir = self
+            .agent_home
+            .join(mur_common::agent::SCHEDULE_PROPOSAL_DIR);
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| ToolError::Execution(format!("create proposal dir: {e}")))?;
+
+        let proposal = mur_common::agent::ScheduleProposal {
+            cron: cron.clone(),
+            message: message.clone(),
+            asked_for: field("asked_for"),
+            proposed_at: chrono::Utc::now().to_rfc3339(),
+        };
+        // Derived from the content, so the same request restated in one
+        // conversation folds onto one proposal instead of stacking.
+        let id = proposal_id(&cron, &message);
+        let body = serde_yaml_ng::to_string(&proposal)
+            .map_err(|e| ToolError::Execution(format!("serialise proposal: {e}")))?;
+        std::fs::write(dir.join(format!("{id}.yaml")), body)
+            .map_err(|e| ToolError::Execution(format!("write proposal: {e}")))?;
+
+        Ok(format!(
+            "Asked for a reminder ({id}): {cron:?} → {message:?}. This is a PROPOSAL — an agent \
+             cannot create its own schedule. It fires once the user runs:\n    mur agent schedule \
+             accept <agent> {id}\nSay that you have asked, not that it is set."
+        )
+        .into())
+    }
+}
+
+/// Stable across restatements of the same request within a conversation.
+fn proposal_id(cron: &str, message: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(cron.as_bytes());
+    h.update(b"\0");
+    h.update(message.trim().to_lowercase().as_bytes());
+    format!("{:x}", h.finalize())[..12].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(dir: &std::path::Path) -> RemindTool {
+        RemindTool {
+            agent_home: dir.to_path_buf(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_proposal_lands_where_the_cli_looks_for_it() {
+        let d = tempfile::tempdir().unwrap();
+        let out = tool(d.path())
+            .execute(serde_json::json!({
+                "cron": "0 10 9 8 *",
+                "message": "吃早餐",
+                "asked_for": "明天早上 10:00 提醒我吃早餐"
+            }))
+            .await
+            .unwrap();
+        assert!(out.text.contains("PROPOSAL"), "{}", out.text);
+        assert!(out.text.contains("schedule accept"), "{}", out.text);
+
+        let dir = d.path().join(mur_common::agent::SCHEDULE_PROPOSAL_DIR);
+        let files: Vec<_> = std::fs::read_dir(&dir).unwrap().flatten().collect();
+        assert_eq!(files.len(), 1, "{files:?}");
+        let p: mur_common::agent::ScheduleProposal =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(files[0].path()).unwrap()).unwrap();
+        assert_eq!(p.cron, "0 10 9 8 *");
+        // The user's words survive: a cron expression alone is not reviewable.
+        assert_eq!(p.asked_for.as_deref(), Some("明天早上 10:00 提醒我吃早餐"));
+    }
+
+    /// Restating the same reminder must not stack proposals — the same failure
+    /// `open_item`'s id-folding exists to prevent.
+    #[tokio::test]
+    async fn the_same_request_twice_is_one_proposal() {
+        let d = tempfile::tempdir().unwrap();
+        for _ in 0..2 {
+            tool(d.path())
+                .execute(serde_json::json!({"cron": "0 9 * * 1-5", "message": "standup"}))
+                .await
+                .unwrap();
+        }
+        let dir = d.path().join(mur_common::agent::SCHEDULE_PROPOSAL_DIR);
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 1);
+    }
+
+    /// A malformed cron must fail here, not at accept time: the agent has
+    /// already told the user a reminder is pending by then.
+    #[tokio::test]
+    async fn a_cron_that_is_not_five_fields_is_refused_at_the_tool() {
+        let d = tempfile::tempdir().unwrap();
+        let err = tool(d.path())
+            .execute(serde_json::json!({"cron": "tomorrow at 10", "message": "x"}))
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("5 space-separated"), "{err}");
+        assert!(
+            !d.path()
+                .join(mur_common::agent::SCHEDULE_PROPOSAL_DIR)
+                .exists(),
+            "nothing may be written for a refused proposal"
+        );
+    }
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1026,6 +1026,35 @@ pub enum ExecutionMode {
     OnDemand,
 }
 
+/// Where an agent leaves a schedule it wants but cannot create.
+///
+/// An agent's schedules live in `lifecycle.schedule` inside its own
+/// `profile.yaml`, and an agent may not write that file — the sandbox denies it
+/// unconditionally so a running agent cannot widen its own entitlements and
+/// restart into them. So "remind me at 10 tomorrow" cannot become a schedule
+/// from the inside, however much the agent understands the request.
+///
+/// It becomes a proposal instead: a file in the agent's own home, which it may
+/// write, that `mur agent schedule accept` turns into the real entry.
+///
+/// Public and shared because both halves must name the same directory. Two
+/// spellings would not fail loudly — the agent would write proposals nobody
+/// lists, which is the shape of failure this whole area keeps producing.
+pub const SCHEDULE_PROPOSAL_DIR: &str = "schedule-proposals";
+
+/// A schedule an agent asked for and a person has not yet granted.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScheduleProposal {
+    pub cron: String,
+    pub message: String,
+    /// What the user actually said, kept verbatim: a cron expression is not
+    /// reviewable on its own, and the reviewer is being asked whether this is
+    /// what they meant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asked_for: Option<String>,
+    pub proposed_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ScheduleEntry {
     pub cron: String,

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -634,6 +634,12 @@ pub enum AgentScheduleAction {
         #[arg(long, default_value_t = 5)]
         count: usize,
     },
+    /// Schedules this agent has asked for and not been granted
+    Proposals { name: String },
+    /// Grant a proposed schedule — it becomes a real entry and fires
+    Accept { name: String, id: String },
+    /// Refuse a proposed schedule
+    Decline { name: String, id: String },
     /// Add an idle trigger that fires when the agent has been idle for N seconds
     IdleAdd {
         /// Agent name

--- a/mur-core/src/cmd/agent_schedule.rs
+++ b/mur-core/src/cmd/agent_schedule.rs
@@ -28,6 +28,90 @@ pub fn cmd_schedule_add(
     Ok(())
 }
 
+/// Where an agent leaves schedules it wants but cannot create.
+fn proposal_dir(name: &str) -> std::path::PathBuf {
+    crate::paths::mur_root(None)
+        .join("agents")
+        .join(name)
+        .join(mur_common::agent::SCHEDULE_PROPOSAL_DIR)
+}
+
+fn read_proposals(name: &str) -> Vec<(String, mur_common::agent::ScheduleProposal)> {
+    let Ok(entries) = std::fs::read_dir(proposal_dir(name)) else {
+        return Vec::new();
+    };
+    let mut out: Vec<_> = entries
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "yaml"))
+        .filter_map(|e| {
+            let id = e.path().file_stem()?.to_string_lossy().into_owned();
+            let body = std::fs::read_to_string(e.path()).ok()?;
+            Some((
+                id,
+                serde_yaml_ng::from_str::<mur_common::agent::ScheduleProposal>(&body).ok()?,
+            ))
+        })
+        .collect();
+    out.sort_by(|a, b| a.1.proposed_at.cmp(&b.1.proposed_at));
+    out
+}
+
+/// List the schedules this agent has asked for and not been granted.
+pub fn cmd_schedule_proposals(name: &str) -> Result<()> {
+    let proposals = read_proposals(name);
+    if proposals.is_empty() {
+        println!("agent '{name}' has not asked for any schedules");
+        return Ok(());
+    }
+    for (id, p) in &proposals {
+        println!("{id}  {}  →  {}", p.cron, p.message);
+        // The cron is not reviewable on its own — the question being asked is
+        // whether it matches what was said, so what was said is printed.
+        if let Some(asked) = &p.asked_for {
+            println!("      asked for: {asked}");
+        }
+        match mur_agent_runtime::scheduler::next_n_fires(&p.cron, 1) {
+            Ok(f) if !f.is_empty() => println!("      would first fire: {}", f[0]),
+            _ => println!("      would first fire: never — this cron matches no time"),
+        }
+    }
+    println!("\naccept one with: mur agent schedule accept {name} <id>");
+    Ok(())
+}
+
+/// Grant a proposed schedule: the same write `add` performs, then the proposal
+/// is gone.
+///
+/// Deliberately the same call rather than a second writer — a second path into
+/// `lifecycle.schedule` is a second place for its validation to drift out of.
+pub fn cmd_schedule_accept(name: &str, id: &str) -> Result<()> {
+    let (_, p) = read_proposals(name)
+        .into_iter()
+        .find(|(pid, _)| pid == id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no proposal {id:?} for agent '{name}' — see `mur agent schedule proposals {name}`"
+            )
+        })?;
+    cmd_schedule_add(name, &p.cron, &p.message, None)?;
+    std::fs::remove_file(proposal_dir(name).join(format!("{id}.yaml")))
+        .with_context(|| format!("remove proposal {id}"))?;
+    println!("granted. Restart the agent for it to take effect: mur agent restart {name}");
+    Ok(())
+}
+
+/// Refuse a proposed schedule. The agent is not told; it asked, and the answer
+/// is that it does not happen.
+pub fn cmd_schedule_decline(name: &str, id: &str) -> Result<()> {
+    let path = proposal_dir(name).join(format!("{id}.yaml"));
+    if !path.is_file() {
+        anyhow::bail!("no proposal {id:?} for agent '{name}'");
+    }
+    std::fs::remove_file(&path).with_context(|| format!("remove proposal {id}"))?;
+    println!("declined {id}");
+    Ok(())
+}
+
 /// Print all schedule entries for the named agent.
 pub fn cmd_schedule_list(name: &str) -> Result<()> {
     let entries = read_schedule(name)?;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -2060,6 +2060,15 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 message,
                 sends_to,
             } => cmd::agent_schedule::cmd_schedule_add(&name, &cron, &message, sends_to)?,
+            AgentScheduleAction::Proposals { name } => {
+                cmd::agent_schedule::cmd_schedule_proposals(&name)?
+            }
+            AgentScheduleAction::Accept { name, id } => {
+                cmd::agent_schedule::cmd_schedule_accept(&name, &id)?
+            }
+            AgentScheduleAction::Decline { name, id } => {
+                cmd::agent_schedule::cmd_schedule_decline(&name, &id)?
+            }
             AgentScheduleAction::List { name } => cmd::agent_schedule::cmd_schedule_list(&name)?,
             AgentScheduleAction::Remove { name, index } => {
                 cmd::agent_schedule::cmd_schedule_remove(&name, index)?


### PR DESCRIPTION
Fixes #1075.

## The problem

"Remind me at 10 tomorrow" became an **open item** — free text, no due field,
nothing to fire it. The one in the issue sat three weeks and was closed by hand
as expired. #1083 made the agent *say* the list has no clock; this gives the
request somewhere to go.

## Why not just let the agent schedule

Agent schedules live in `lifecycle.schedule` inside `profile.yaml`, and **the
sandbox denies an agent that file unconditionally** — a running agent must not
be able to widen its own entitlements and restart into them. Third time today
that constraint has decided a design.

So the agent proposes, and a person grants:

```
$ mur agent schedule proposals mur
abc123def456  0 10 1 9 *  →  吃早餐
      asked for: 明天早上 10:00 提醒我吃早餐
      would first fire: 2026-09-01 10:00:00 +08:00

accept one with: mur agent schedule accept mur <id>

$ mur agent schedule accept mur abc123def456
added schedule entry [0]: "0 10 1 9 *"  →  "吃早餐"
granted. Restart the agent for it to take effect: mur agent restart mur
```

That also answers what #1075 left open. An agent creating recurring wake-ups on
its own is a spend-and-surprise surface; an agent **asking** is not, and the
person granting is the same gate every other risky action goes through.

## Two details that decide whether the review is real

- **The proposal keeps the user's own words.** A cron expression is not
  reviewable on its own — the question being asked is whether it matches what
  was said.
- **`proposals` prints when it would first fire, in local time.** `0 10 1 9 *`
  tells a reader nothing. `2026-09-01 10:00:00 +08:00` tells them whether the
  agent understood "tomorrow".

## Other choices

- **One writer.** `accept` calls the same `cmd_schedule_add` the CLI uses, not a
  second path into `lifecycle.schedule` whose validation can drift from it.
- **Cron comes from the model.** Resolving "tomorrow at 10" needs today's date
  and the user's intent; the model has both and this crate has neither.
- **Malformed cron is refused at the tool**, not at accept time — by then the
  agent has already told the user a reminder is pending.
- **The restart is named.** The runtime reads the profile only at startup, so a
  granted schedule that says nothing about restarting is another "set but never
  fires".

## Verification

4 tool tests, and end to end against a copy of a real profile: listed with its
fire time → accepted into `lifecycle.schedule` → proposal file gone.

An early run of that walkthrough failed on a hand-written fixture missing
`persona.category`, and `accept` refused rather than half-writing — which is the
right answer, and the reason the fixture is now a copy of a real profile.

`cargo clippy` on `mur-common`, `mur-agent-runtime`, `mur-core`, all
`--all-targets -- -D warnings` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)