### PR TITLE
chore(release): bump workspace version to 2.71.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.12"
+version = "2.71.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.12"
+version = "2.71.13"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.13 — the open-items and reminder work, and two review findings.

| PR | issue | |
|---|---|---|
| #1111 | **#1075** | an agent can ask for a schedule that actually fires — it proposes, you grant. It cannot create one itself: its entries live in a `profile.yaml` the sandbox denies it |
| #1109 | #1076 | `mur open --check` runs the observational subset of an item's own `next` (`ls`, `test -f`, `git log`), ranks by the result, and never closes anything |
| #1108 | #1105, #1106 | a verdict that arrived with no reason, and a raw agent name joined into a path |
| #1110, #1112 | — | README: the three new surfaces, and a platform claim the docs held independently of the code |

## New user-visible surfaces

- `mur agent schedule proposals <agent>` / `accept` / `decline`
- `mur open --check`
- `mur agent perm list-paths <agent>` (shipped 2.71.12, documented here)

## What the reminder path does not do

The agent does not gain the ability to wake itself up. It gains the ability to
**ask**, in a form a person can act on with one command — and the proposal
carries the user's own words plus the time the cron would first fire locally,
because `0 10 1 9 *` does not tell a reviewer whether the agent understood
"tomorrow".

## What `--check` does not do

It never resolves an item. A satisfied check marks and sorts; deciding on a
proxy that a person's record is wrong is the deletion the ageing half already
refuses. It also reports its own coverage — `checked 1 of 4 reported items` —
because a check silent about its reach cannot be told from one that found
nothing wrong.

Merging this tags `v2.71.13` and dispatches `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)