### PR TITLE
fix(retrieve): a note does not decay on a signal nothing writes

### DIFF
--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -234,6 +234,23 @@ impl Retrievable for LoadedSkill {
     }
 
     fn decay_half_life_days(&self) -> f64 {
+        // A note whose use was never recorded does not decay.
+        //
+        // The decay term reads `last_success_at` and falls back to creation
+        // when it is absent — which for a note is always. Nothing records a
+        // note as used: injection does not (it sorts by name and takes the
+        // first N, never consulting a score), and no retrieval path writes
+        // stats back. So the term was not measuring inactivity, it was
+        // measuring age and calling it inactivity, and a note the user wrote
+        // sank for a reason the system had no evidence of (#1062).
+        //
+        // Refusing to compute is the same answer this codebase now gives
+        // everywhere the input is missing rather than zero. When note usage is
+        // recorded, notes with a recorded use decay from it and this stops
+        // applying by itself — no second rule to remember to remove.
+        if self.is_note() && self.stats.last_success_at.is_none() {
+            return f64::INFINITY;
+        }
         // Per-kind curves (federation P1): rule notes decay fast, fact notes
         // linger. Uses the compile-time default factors — the config override
         // applies to the lifecycle sweep; retrieval uses the same defaults so
@@ -261,6 +278,63 @@ impl Retrievable for LoadedSkill {
 
 #[cfg(test)]
 mod tests {
+    /// Build one candidate from a written skill.yaml, so the fixture goes
+    /// through the same loader production does.
+    fn one_candidate(dir: &std::path::Path, yaml: &str) -> LoadedSkill {
+        let skills = dir.join("skills");
+        std::fs::create_dir_all(skills.join("subject")).unwrap();
+        std::fs::write(skills.join("subject").join("skill.yaml"), yaml).unwrap();
+        load_skill_candidates(&skills, dir).unwrap().pop().unwrap()
+    }
+
+    const A_NOTE: &str = "name: subject\nversion: 1.0.0\npublisher: agent:mur\n\
+         description: reply in zh-TW\ncategory: note\npriority: normal\n\
+         tags: [rule]\ncontent:\n  abstract: reply in zh-TW\n  context: x\n";
+
+    /// #1062: the decay term reads `last_success_at`, and nothing writes it for
+    /// a note — not injection (which sorts by name and never scores), not any
+    /// retrieval path. So it was measuring age and calling it inactivity, and a
+    /// note the user wrote sank for a reason the system had no evidence of.
+    #[test]
+    fn a_note_with_no_recorded_use_does_not_decay() {
+        let d = tempfile::tempdir().unwrap();
+        let c = one_candidate(d.path(), A_NOTE);
+        assert!(c.stats.last_success_at.is_none(), "fixture premise");
+        assert!(
+            c.decay_half_life_days().is_infinite(),
+            "a note with nothing recorded must not decay on it"
+        );
+    }
+
+    /// The exemption is not "notes never decay" — it lifts the moment there is
+    /// something real to measure, so it disappears on its own once note usage
+    /// is recorded rather than becoming a rule to remember to remove.
+    #[test]
+    fn a_note_with_a_recorded_use_decays_from_it() {
+        let d = tempfile::tempdir().unwrap();
+        let mut c = one_candidate(d.path(), A_NOTE);
+        c.stats.last_success_at = Some(chrono::Utc::now());
+        let h = c.decay_half_life_days();
+        assert!(h.is_finite(), "a measured note decays: {h}");
+        // `rule` halves the tier curve — the per-kind factor still applies.
+        assert!(h < c.tier().decay_half_life_days() as f64, "{h}");
+    }
+
+    /// Skills are untouched: they have a real activity signal, and widening the
+    /// exemption to them would stop recency ranking working at all.
+    #[test]
+    fn a_skill_with_no_recorded_use_still_decays() {
+        let d = tempfile::tempdir().unwrap();
+        let c = one_candidate(
+            d.path(),
+            "name: subject\nversion: 1.0.0\npublisher: human:test\n\
+             description: deploy\ncategory: context\npriority: normal\n\
+             tags: [x]\ncontent:\n  abstract: deploy\n  context: y\n",
+        );
+        assert!(c.stats.last_success_at.is_none(), "fixture premise");
+        assert!(c.decay_half_life_days().is_finite(), "skills still decay");
+    }
+
     use super::*;
     use crate::retrieve::scoring::ScoringHints;
     use chrono::Duration;


### PR DESCRIPTION
Fixes #1062 — after measuring the live store turned its question into a
narrower and more concrete one.

## What #1062 asked, and what is actually true

| the issue's concern | measured |
|---|---|
| decay deletes external notes | closed by #1063 — decay can no longer demote or delete a note nobody can regenerate |
| decay sinks them in ranking | **only in search.** Memory injection sorts by name and takes the first N (`injector.rs:91-93`); it never consults a score |
| imported external notes | still latent — nothing imports into `Category::Note` yet |

**I got the injection part wrong first and this corrects it.** A decaying memory
was never at risk of falling out of a prompt.

## What is real, and smaller, and worse

The decay term reads `last_success_at` and falls back to creation when it is
absent — which for a note is **always**. Nothing records a note as used: not
injection, not any retrieval path. So it was not measuring inactivity. It was
measuring age and calling it inactivity, and a note the user wrote sank for a
reason the system had no evidence of.

Live on this machine:

```
reply-in-zh-tw     tags: [rule]  →  0.5 × Draft(14d) = a seven-day half-life
                   last_success_at: null
                   usage_count: 0
```

That is the standing "reply in Chinese" instruction this session opened by
complaining about losing. Its decay clock had never been able to reset.

## The fix

A note with nothing recorded does not decay. Refusing to compute from a missing
input is the answer this codebase now gives everywhere it cannot measure the
thing a number claims to describe.

**Not "notes never decay":**

- a note **with** a recorded use decays from it, per-kind curves intact — so the
  exemption lifts by itself the day note usage is recorded, rather than becoming
  a rule someone has to remember to remove
- **skills are untouched** — they have a real activity signal, and widening this
  to them would switch off recency ranking

## Verification

```
FAIL  a_note_with_no_recorded_use_does_not_decay      ← exemption removed
PASS  a_note_with_a_recorded_use_decays_from_it       ← control
PASS  a_skill_with_no_recorded_use_still_decays       ← control
```

206 retrieval tests pass. `cargo clippy -p mur-core --all-targets -- -D warnings` → 0.

## Not done here

Recording note usage is the thing that would make this decay mean something, and
it is a separate change with its own question — for memories, injection is
unconditional and therefore carries no signal, so "used" needs a definition
before it can be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)