### PR TITLE
chore(release): bump workspace version to 2.71.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.13"
+version = "2.71.14"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.13"
+version = "2.71.14"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.14 — three fixes, all of the same shape: a surface asserting something it did not check.

- **#1114** `fix(retrieve)` — a note does not decay on a signal nothing writes. `last_success_at` is never set for notes, so decay was measuring age-since-creation, not disuse.
- **#1115** `fix(model-doctor)` — the keychain advice names what it needs to work. It had been recommending `keychain:` without saying it requires a session credential service, and calling `file:` worse when on a headless box it is the only available answer.
- **#1116** `fix(remind)` — a corrected reminder supersedes the one it corrects. Superseding keys on the user's words (`asked_for`), not the computed cron, so a correction replaces rather than accumulates.

Merging this IS the release: `tag.yml` tags the merge commit and dispatches `release.yml`.