### PR TITLE
fix(schedule): a one-off reminder stops instead of repeating every year

### DIFF
--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -216,7 +216,9 @@ mod tests {
     }
 
     fn at(s: &str) -> DateTime<Local> {
-        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Local)
+        DateTime::parse_from_rfc3339(s)
+            .unwrap()
+            .with_timezone(&Local)
     }
 
     #[test]
@@ -243,7 +245,10 @@ mod tests {
     #[test]
     fn the_firing_after_the_bound_retires_the_entry() {
         assert!(
-            bound_exhausted(at("2027-09-01T10:00:00+08:00"), Some("2026-09-01T10:00:00+08:00")),
+            bound_exhausted(
+                at("2027-09-01T10:00:00+08:00"),
+                Some("2026-09-01T10:00:00+08:00")
+            ),
             "cron has no year, so a dated request recurs annually — the bound is \
              the only thing that stops next September from firing too (#1119)"
         );

--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -9,7 +9,7 @@
 use crate::llm::{BackgroundKind, RequestIntent};
 use crate::task_runner::{TaskOutcome, TaskRunner, TaskSpec};
 use anyhow::{Context, Result};
-use chrono::Local;
+use chrono::{DateTime, Local};
 use cron::Schedule;
 use mur_common::a2a::{Message, MessagePart};
 use mur_common::agent::ScheduleEntry;
@@ -36,6 +36,43 @@ fn scheduled_task_spec(message: &str) -> TaskSpec {
         active_team: None,
         intent: RequestIntent::Background(BackgroundKind::Scheduled),
         output_artifact_path: None,
+    }
+}
+
+/// Whether a bounded entry has run out of firings — its next occurrence falls
+/// after the bound. `None` means unbounded, the shape every recurring entry has.
+///
+/// Extracted from the async loop for the same reason [`scheduled_task_spec`] is:
+/// nothing else can assert the boundary without driving a real cron wait.
+///
+fn bound_exhausted(next: DateTime<Local>, not_after: Option<&str>) -> bool {
+    parse_bound(not_after).is_some_and(|b| next > b)
+}
+
+/// A `not_after` bound as an instant — `None` for both "absent" and "does not
+/// parse".
+///
+/// Public because every surface that renders a schedule must read the bound the
+/// same way the scheduler does. Sharing this function makes that structural: a
+/// second parser could drift, and the drift would show an entry as finished on
+/// the Panel while the scheduler kept firing it.
+///
+/// Unparseable folding into `None` is deliberate — the two ways to be wrong are
+/// not symmetric. Ignoring a corrupt bound lets a one-shot repeat, which is
+/// visible in `mur agent schedule list` and one `remove` away. Honouring it
+/// would retire the entry, and a reminder that silently never fires is the
+/// failure the user has no way to notice.
+pub fn parse_bound(not_after: Option<&str>) -> Option<DateTime<Local>> {
+    let raw = not_after?;
+    match DateTime::parse_from_rfc3339(raw) {
+        Ok(b) => Some(b.with_timezone(&Local)),
+        Err(e) => {
+            warn!(
+                not_after = %raw, error = %e,
+                "not_after is not RFC3339; treating the entry as unbounded"
+            );
+            None
+        }
     }
 }
 
@@ -92,6 +129,15 @@ async fn run_entry(entry: ScheduleEntry, runner: Arc<TaskRunner>, cancel: Cancel
                 return;
             }
         };
+
+        if bound_exhausted(next, entry.not_after.as_deref()) {
+            info!(
+                cron = %entry.cron,
+                not_after = entry.not_after.as_deref().unwrap_or_default(),
+                "schedule retired — its last firing is past, so it will not repeat"
+            );
+            return;
+        }
 
         let delta = next - now;
 
@@ -166,6 +212,49 @@ mod tests {
             "cron-fired turns are unambiguously runtime-initiated — nobody is \
              synchronously waiting on them, so they must route through Smart \
              background candidates rather than the interactive default"
+        );
+    }
+
+    fn at(s: &str) -> DateTime<Local> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Local)
+    }
+
+    #[test]
+    fn an_unbounded_entry_never_retires() {
+        assert!(
+            !bound_exhausted(at("2099-01-01T00:00:00+08:00"), None),
+            "a recurring entry carries no bound and must keep firing forever"
+        );
+    }
+
+    #[test]
+    fn the_firing_a_bound_names_is_still_allowed() {
+        // The boundary case that makes a one-shot fire at all: `not_after` is
+        // set to the entry's own first firing, so that firing must be admitted
+        // and only the NEXT one retired. An off-by-one here turns every
+        // one-shot reminder into one that never arrives.
+        let fire = "2026-09-01T10:00:00+08:00";
+        assert!(
+            !bound_exhausted(at(fire), Some(fire)),
+            "the firing the bound names must happen"
+        );
+    }
+
+    #[test]
+    fn the_firing_after_the_bound_retires_the_entry() {
+        assert!(
+            bound_exhausted(at("2027-09-01T10:00:00+08:00"), Some("2026-09-01T10:00:00+08:00")),
+            "cron has no year, so a dated request recurs annually — the bound is \
+             the only thing that stops next September from firing too (#1119)"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_bound_leaves_the_entry_firing() {
+        assert!(
+            !bound_exhausted(at("2099-01-01T00:00:00+08:00"), Some("next tuesday")),
+            "a corrupt bound must not silently retire a reminder: a repeat is \
+             visible and removable, a reminder that never fires is not"
         );
     }
 }

--- a/mur-agent-runtime/src/tools/remind.rs
+++ b/mur-agent-runtime/src/tools/remind.rs
@@ -57,6 +57,10 @@ accept` to grant it, so say that you have asked rather than that it is set."
                     "asked_for": {
                         "type": "string",
                         "description": "The user's own words, verbatim. A cron expression is not reviewable on its own and the reviewer is being asked whether this is what they meant."
+                    },
+                    "once": {
+                        "type": "boolean",
+                        "description": "True when the request names ONE occasion — 'tomorrow at 10', 'on the 3rd', 'in an hour'. False for a recurrence — 'every weekday', 'each morning' — and also for a genuinely yearly one like a birthday. Cron has no year field, so a dated expression silently repeats every year; this is the only thing that stops it. Decide from the user's words, not from the cron: '0 9 15 3 *' is both 'remind me on March 15' and 'every year on my birthday', and the expression cannot tell you which."
                     }
                 }
             }),
@@ -96,10 +100,23 @@ accept` to grant it, so say that you have asked rather than that it is set."
         std::fs::create_dir_all(&dir)
             .map_err(|e| ToolError::Execution(format!("create proposal dir: {e}")))?;
 
+        // A one-shot is bounded by its own first firing. The scheduler admits
+        // the firing its bound names and retires the one after it, so this
+        // fires exactly once (#1119). An expression with no future firing
+        // yields no bound, which costs nothing: it never fires either.
+        let not_after = input
+            .get("once")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+            .then(|| crate::scheduler::next_n_fires(&cron, 1).ok())
+            .flatten()
+            .and_then(|v| v.first().map(|t| t.to_rfc3339()));
+
         let proposal = mur_common::agent::ScheduleProposal {
             cron: cron.clone(),
             message: message.clone(),
             asked_for: field("asked_for"),
+            not_after,
             proposed_at: chrono::Utc::now().to_rfc3339(),
         };
         // Derived from the content, so the same request restated in one
@@ -303,5 +320,49 @@ mod tests {
                 .exists(),
             "nothing may be written for a refused proposal"
         );
+    }
+
+    async fn only_proposal(d: &std::path::Path) -> mur_common::agent::ScheduleProposal {
+        let dir = d.join(mur_common::agent::SCHEDULE_PROPOSAL_DIR);
+        let files: Vec<_> = std::fs::read_dir(&dir).unwrap().flatten().collect();
+        assert_eq!(files.len(), 1, "{files:?}");
+        serde_yaml_ng::from_str(&std::fs::read_to_string(files[0].path()).unwrap()).unwrap()
+    }
+
+    /// The bug this whole field exists for: "remind me tomorrow at 10" has no
+    /// year to put in a cron, so `0 10 1 9 *` means every September 1st. The
+    /// bound is what turns that back into one morning (#1119).
+    #[tokio::test]
+    async fn a_one_off_is_bounded_by_its_own_first_firing() {
+        let d = tempfile::tempdir().unwrap();
+        tool(d.path())
+            .execute(serde_json::json!({
+                "cron": "0 10 1 9 *", "message": "breakfast",
+                "asked_for": "tomorrow at 10", "once": true
+            }))
+            .await
+            .unwrap();
+        let p = only_proposal(d.path()).await;
+        let first = crate::scheduler::next_n_fires("0 10 1 9 *", 1).unwrap()[0].to_rfc3339();
+        assert_eq!(
+            p.not_after.as_deref(),
+            Some(first.as_str()),
+            "the bound is the entry's own first firing — the scheduler admits \
+             the firing its bound names and retires the next one"
+        );
+    }
+
+    /// The control that keeps the bound from being applied to everything: a
+    /// recurrence must stay unbounded, or every standup reminder dies after one.
+    #[tokio::test]
+    async fn a_recurring_request_carries_no_bound() {
+        let d = tempfile::tempdir().unwrap();
+        tool(d.path())
+            .execute(serde_json::json!({
+                "cron": "0 9 * * 1-5", "message": "standup", "asked_for": "every weekday"
+            }))
+            .await
+            .unwrap();
+        assert!(only_proposal(d.path()).await.not_after.is_none());
     }
 }

--- a/mur-agent-runtime/tests/supervisor_cron_smoke.rs
+++ b/mur-agent-runtime/tests/supervisor_cron_smoke.rs
@@ -13,11 +13,13 @@ async fn cron_scheduler_spawns_and_aborts() {
             cron: "* * * * *".into(),
             message: "ping".into(),
             sends_to: None,
+            not_after: None,
         },
         ScheduleEntry {
             cron: "0 9 * * 1-5".into(),
             message: "morning brief".into(),
             sends_to: None,
+            not_after: None,
         },
     ];
     let runner = Arc::new(TaskRunner::new_stub_echo());
@@ -35,6 +37,7 @@ async fn cron_scheduler_skips_bad_entry() {
         cron: "not valid".into(),
         message: "should be skipped".into(),
         sends_to: None,
+        not_after: None,
     }];
     let runner = Arc::new(TaskRunner::new_stub_echo());
     let handle = CronScheduler::new(entries, runner).spawn();

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1052,6 +1052,11 @@ pub struct ScheduleProposal {
     /// what they meant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub asked_for: Option<String>,
+    /// Proposed bound, carried verbatim onto the accepted [`ScheduleEntry`].
+    /// Present exactly when the agent judged the request to name one occasion
+    /// rather than a recurrence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<String>,
     pub proposed_at: String,
 }
 
@@ -1061,6 +1066,19 @@ pub struct ScheduleEntry {
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sends_to: Option<String>,
+    /// Retire the entry once its next firing would fall after this instant
+    /// (RFC3339 with offset). How a one-shot reminder is expressed: cron has no
+    /// year field, so "tomorrow at 10:00" can only be written as an annual
+    /// recurrence, and unbounded it turns a request for one morning into a
+    /// perpetual commitment (#1119).
+    ///
+    /// A bound rather than a fired-yet flag, because the scheduler runs inside
+    /// the agent's own sandbox where `profile.yaml` is denied
+    /// (`SELF_PROTECTED_AGENT_FILES`, #712) — it cannot record that an entry has
+    /// fired. Comparing the next firing against a stored instant needs no write
+    /// at all, so the bound works where a flag structurally could not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mur-core/src/cmd/agent_schedule.rs
+++ b/mur-core/src/cmd/agent_schedule.rs
@@ -14,6 +14,7 @@ pub fn cmd_schedule_add(
     cron: &str,
     message: &str,
     sends_to: Option<String>,
+    not_after: Option<String>,
 ) -> Result<()> {
     validate_cron(cron)?;
     let (path, mut profile) = load_profile_for_edit(name)?;
@@ -21,6 +22,7 @@ pub fn cmd_schedule_add(
         cron: cron.to_string(),
         message: message.to_string(),
         sends_to,
+        not_after,
     });
     let idx = profile.lifecycle.schedule.len() - 1;
     save_profile(&path, &mut profile)?;
@@ -70,9 +72,17 @@ pub fn cmd_schedule_proposals(name: &str) -> Result<()> {
         if let Some(asked) = &p.asked_for {
             println!("      asked for: {asked}");
         }
+        // "would first fire" was true of both a one-off and an annual repeat,
+        // which is how a request for one morning was granted forever (#1119).
+        // The reviewer is told which one they are approving.
         match mur_agent_runtime::scheduler::next_n_fires(&p.cron, 1) {
-            Ok(f) if !f.is_empty() => println!("      would first fire: {}", f[0]),
-            _ => println!("      would first fire: never — this cron matches no time"),
+            Ok(f) if !f.is_empty() && p.not_after.is_some() => {
+                println!("      fires once, on {} — does not repeat", f[0])
+            }
+            Ok(f) if !f.is_empty() => {
+                println!("      first fires {}, and repeats on that cron", f[0])
+            }
+            _ => println!("      would never fire — this cron matches no time"),
         }
     }
     println!("\naccept one with: mur agent schedule accept {name} <id>");
@@ -93,7 +103,9 @@ pub fn cmd_schedule_accept(name: &str, id: &str) -> Result<()> {
                 "no proposal {id:?} for agent '{name}' — see `mur agent schedule proposals {name}`"
             )
         })?;
-    cmd_schedule_add(name, &p.cron, &p.message, None)?;
+    // The bound is part of what the reviewer approved: dropping it here would
+    // grant a perpetual schedule from a proposal that said "once".
+    cmd_schedule_add(name, &p.cron, &p.message, None, p.not_after.clone())?;
     std::fs::remove_file(proposal_dir(name).join(format!("{id}.yaml")))
         .with_context(|| format!("remove proposal {id}"))?;
     println!("granted. Restart the agent for it to take effect: mur agent restart {name}");
@@ -128,6 +140,14 @@ pub fn cmd_schedule_list(name: &str) -> Result<()> {
             e.message,
             e.sends_to.as_deref().unwrap_or("(self)")
         );
+        // A bare cron cannot show that an entry is spent or one-off, so a
+        // bounded entry gets the shared phrasing under its row.
+        if e.not_after.is_some() {
+            println!(
+                "     \u{21b3} {}",
+                crate::schedule_status::describe_bounded(&e.cron, e.not_after.as_deref())
+            );
+        }
     }
     Ok(())
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -2059,7 +2059,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 cron,
                 message,
                 sends_to,
-            } => cmd::agent_schedule::cmd_schedule_add(&name, &cron, &message, sends_to)?,
+            } => cmd::agent_schedule::cmd_schedule_add(&name, &cron, &message, sends_to, None)?,
             AgentScheduleAction::Proposals { name } => {
                 cmd::agent_schedule::cmd_schedule_proposals(&name)?
             }

--- a/mur-core/src/schedule_status.rs
+++ b/mur-core/src/schedule_status.rs
@@ -12,7 +12,7 @@
 
 use std::path::Path;
 
-use mur_agent_runtime::scheduler::next_n_fires;
+use mur_agent_runtime::scheduler::{next_n_fires, parse_bound};
 
 use crate::cmd::system_schedule::list_system_schedules_detailed;
 
@@ -169,9 +169,36 @@ fn trigger_note(trigger: &str) -> Option<String> {
 }
 
 fn fires(expr: &str) -> Vec<String> {
+    bounded_fires(expr, None)
+}
+
+/// Firings that will actually occur — anything past the entry's bound dropped.
+///
+/// A bare cron reading of a one-shot lists next year and the year after, times
+/// the scheduler retires the entry rather than reach (#1119). Showing them is
+/// the same failure the bound exists to fix, relocated into the UI.
+fn bounded_fires(expr: &str, not_after: Option<&str>) -> Vec<String> {
+    let bound = parse_bound(not_after);
     next_n_fires(expr, NEXT_FIRE_COUNT)
-        .map(|v| v.iter().map(|t| t.to_rfc3339()).collect())
+        .map(|v| {
+            v.iter()
+                .filter(|t| bound.is_none_or(|b| **t <= b))
+                .map(|t| t.to_rfc3339())
+                .collect()
+        })
         .unwrap_or_default()
+}
+
+/// Phrase what an entry will actually do, bound included.
+///
+/// One describer for every surface — `schedule list`, `schedule proposals`, the
+/// Panel and the Hub — so none of them can claim an entry repeats when it does
+/// not. Same discipline as #1095, applied to #1119's bound.
+pub fn describe_bounded(cron: &str, not_after: Option<&str>) -> String {
+    match parse_bound(not_after) {
+        Some(b) => format!("once, on {}", b.format("%Y-%m-%d %H:%M")),
+        None => describe_cron(cron),
+    }
 }
 
 fn collect_agents(
@@ -207,15 +234,22 @@ fn collect_agents(
         };
 
         for s in &profile.lifecycle.schedule {
-            let next_fires = fires(&s.cron);
+            let next_fires = bounded_fires(&s.cron, s.not_after.as_deref());
             out.push(ScheduleItem::AgentCron {
                 owner: name.clone(),
                 expr: s.cron.clone(),
                 message: s.message.clone(),
-                description: describe_cron(&s.cron),
-                next_note: next_fires
-                    .is_empty()
-                    .then(|| format!("could not read a schedule from `{}`", s.cron)),
+                description: describe_bounded(&s.cron, s.not_after.as_deref()),
+                // Two very different reasons produce no fire times, and a single
+                // note for both is exactly the lie this batch keeps finding: a
+                // spent one-off did its job, an unreadable cron never will.
+                next_note: next_fires.is_empty().then(|| {
+                    if parse_bound(s.not_after.as_deref()).is_some() {
+                        "already fired — this was a one-off and does not repeat".to_string()
+                    } else {
+                        format!("could not read a schedule from `{}`", s.cron)
+                    }
+                }),
                 next_fires,
                 status: "enabled".into(),
             });
@@ -414,6 +448,21 @@ mod tests {
 
     /// A cron string a reader can look up beats a sentence that is wrong, so
     /// anything unrecognised must come back verbatim rather than guessed at.
+    #[test]
+    fn a_bounded_entry_is_phrased_as_a_one_off_and_an_unreadable_bound_is_not() {
+        assert!(
+            describe_bounded("0 10 1 9 *", Some("2026-09-01T10:00:00+08:00")).starts_with("once,"),
+            "a bound is the difference between one morning and every September"
+        );
+        // Both sides read the bound through `scheduler::parse_bound`, so this
+        // cannot drift into showing a spent one-off while the entry keeps firing.
+        assert_eq!(
+            describe_bounded("0 9 * * *", Some("next tuesday")),
+            describe_cron("0 9 * * *"),
+            "an unreadable bound is no bound, on the surface as in the scheduler"
+        );
+    }
+
     #[test]
     fn an_unrecognised_cron_shape_is_returned_verbatim() {
         for expr in ["0 9 1 * *", "15 2 * 6 3", "not a cron", "0 9 * *"] {

--- a/mur-core/tests/cmd_agent_schedule.rs
+++ b/mur-core/tests/cmd_agent_schedule.rs
@@ -4,7 +4,8 @@
 //! MUR_HOME is a process-wide env var, so tests serialize via ENV_LOCK.
 
 use mur_core::cmd::agent_schedule::{
-    cmd_schedule_add, cmd_schedule_list, cmd_schedule_next, cmd_schedule_remove, read_schedule,
+    cmd_schedule_accept, cmd_schedule_add, cmd_schedule_list, cmd_schedule_next,
+    cmd_schedule_remove, read_schedule,
 };
 use std::fs;
 use std::sync::Mutex;
@@ -82,12 +83,13 @@ fn add_list_remove_roundtrip() {
     let _home_guard = MurHomeGuard;
 
     // Add two entries
-    cmd_schedule_add("sched_test", "0 9 * * 1-5", "morning brief", None).unwrap();
+    cmd_schedule_add("sched_test", "0 9 * * 1-5", "morning brief", None, None).unwrap();
     cmd_schedule_add(
         "sched_test",
         "0 18 * * 1-5",
         "end of day",
         Some("other_agent".to_string()),
+        None,
     )
     .unwrap();
 
@@ -134,7 +136,7 @@ fn schedule_next_does_not_error() {
         std::env::set_var("MUR_HOME", tmp.path());
     }
     let _home_guard = MurHomeGuard;
-    cmd_schedule_add("sched_next", "0 * * * *", "hourly ping", None).unwrap();
+    cmd_schedule_add("sched_next", "0 * * * *", "hourly ping", None, None).unwrap();
     // cmd_schedule_next prints to stdout — just verify it doesn't error.
     cmd_schedule_next("sched_next", 3).unwrap();
 }
@@ -147,7 +149,7 @@ fn add_invalid_cron_returns_err() {
         std::env::set_var("MUR_HOME", tmp.path());
     }
     let _home_guard = MurHomeGuard;
-    let result = cmd_schedule_add("sched_bad_cron", "not a cron", "msg", None);
+    let result = cmd_schedule_add("sched_bad_cron", "not a cron", "msg", None, None);
     assert!(result.is_err());
 }
 
@@ -159,6 +161,43 @@ fn schedule_list_does_not_error() {
         std::env::set_var("MUR_HOME", tmp.path());
     }
     let _home_guard = MurHomeGuard;
-    cmd_schedule_add("sched_list", "0 9 * * *", "daily check", None).unwrap();
+    cmd_schedule_add("sched_list", "0 9 * * *", "daily check", None, None).unwrap();
     cmd_schedule_list("sched_list").unwrap();
+}
+
+/// A proposal that says "once" must not be granted as a perpetual schedule.
+///
+/// The bound is part of what the reviewer approved, and `accept` is the one
+/// place it can be silently dropped — the same shape as #957, where a narrow
+/// DTO written back over a full record erased the fields it did not know about.
+#[test]
+fn accept_carries_the_one_shot_bound_onto_the_entry() {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = setup("sched_once");
+    unsafe {
+        std::env::set_var("MUR_HOME", tmp.path());
+    }
+    let _home_guard = MurHomeGuard;
+
+    let dir = tmp
+        .path()
+        .join("agents")
+        .join("sched_once")
+        .join(mur_common::agent::SCHEDULE_PROPOSAL_DIR);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("deadbeef1234.yaml"),
+        "cron: \"0 10 1 9 *\"\nmessage: breakfast\nasked_for: tomorrow at 10\nnot_after: \"2026-09-01T10:00:00+08:00\"\nproposed_at: \"2026-08-31T00:00:00+00:00\"\n",
+    )
+    .unwrap();
+
+    cmd_schedule_accept("sched_once", "deadbeef1234").unwrap();
+
+    let entries = read_schedule("sched_once").unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].not_after.as_deref(),
+        Some("2026-09-01T10:00:00+08:00"),
+        "granting a proposal must grant what it said, bound included"
+    );
 }


### PR DESCRIPTION
Fixes #1119.

`remind` translating 「明天早上 10:00 提醒我吃早餐」 into `0 10 1 9 *` was the best cron available — and cron has no year field, so it meant **every September 1st, forever**. A request for one morning became a perpetual commitment.

## The bound, not a flag

The obvious fix is `once: bool` plus "has it fired yet?" state. That cannot be built: the scheduler runs inside the agent's own sandbox, where `profile.yaml` is denied (`SELF_PROTECTED_AGENT_FILES`, #712), so it cannot record that an entry has fired. This is the same constraint that shaped #1090, #1098 and #1102.

So the entry stores **when it stops** instead:

```rust
pub not_after: Option<String>,   // RFC3339
```

`scheduler::run_entry` already computes the next firing before sleeping. One comparison there retires the entry — no write, no marker file, nothing the sandbox can refuse. `remind` sets the bound to the entry's *own first firing*, so the firing the bound names happens and the one after it does not.

## One reader, not two

`scheduler::parse_bound` is public and every surface goes through it. That is structural rather than asserted: a second parser in `schedule_status.rs` could drift, and the drift would show an entry as finished on the Panel while the scheduler kept firing it.

It folds an unparseable bound into `None` — deliberately, because the two ways to be wrong are not symmetric. Ignoring a corrupt bound lets a one-shot repeat, which is visible in `schedule list` and one `remove` away. Honouring it would retire the entry, and a reminder that silently never fires is the failure the user cannot notice.

## What each surface says now

| | before | after |
|---|---|---|
| `schedule proposals` | "would first fire: …" for both cases | "fires once, on … — does not repeat" / "first fires …, and repeats on that cron" |
| `schedule list` | bare cron | `↳ once, on 2026-09-01 10:00` under the row |
| Panel / Hub | three annual firings listed | firings past the bound dropped; a spent one-off says so |

The Panel and Hub needed no change: they render `description`/`next_note` derived in Rust (#1095/#1096), so one describer reached all of them.

`next_note` also stopped conflating two causes — "could not read a schedule" and "already fired, this was a one-off" are different facts and now read differently.

## Not this batch's usual shape

The other fixes this week were *a surface asserting something it did not check*. This one was not: "would **first** fire" was literally true. The failure was **a surface silently widening what the user asked for**, with one word carrying weight it could not.

`once` is decided from the user's words, never inferred from the cron — `0 9 15 3 *` is both "remind me on March 15" and "every year on my birthday", and the expression cannot tell you which. Inferring it would kill the birthday.

## Verification

Seven tests, and all five mutations below are measured — flipped, watched fail, restored, counts equal — flipped, watched fail, restored, counts equal:

| mutation | caught by | controls held |
|---|---|---|
| `next > bound` → `>=` | `the_firing_a_bound_names_is_still_allowed` | 2 |
| unparseable bound fails closed | `an_unparseable_bound_leaves_the_entry_firing` | 3 |
| `accept` passes `None` | `accept_carries_the_one_shot_bound_onto_the_entry` | — |
| `remind` cannot see `once` | `a_one_off_is_bounded_by_its_own_first_firing` | `a_recurring_request_carries_no_bound` |
| describer ignores the bound | `a_bounded_entry_is_phrased_as_a_one_off…` | — |

One round produced no output at all rather than a verdict — `env $E cargo …` does not word-split in zsh, so nothing ran. The run-happened assertion is why that read as void instead of as three passes.

## Deliberately not here

`mur agent schedule add --once`. `cmd_schedule_add` takes the bound already, so the flag is a few lines, but nothing in #1119 needs it — the bug was in the path the agent uses. Worth adding the first time someone wants to write a one-off by hand.
