### PR TITLE
docs(readme): the reminder bullet says which of the two a proposal is

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,10 +550,13 @@ Agent** wizard offers the same catalog as a source.
   entries live in a `profile.yaml` the sandbox denies it, deliberately, so a
   running agent cannot widen its own permissions and restart into them. So it
   asks: `mur agent schedule proposals <agent>` shows what it asked for, in its
-  own words alongside the cron and **when that cron would first fire in your
-  timezone**, because `0 10 1 9 *` tells a reviewer nothing about whether the
-  agent understood "tomorrow". `accept` turns it into a real entry on the real
-  scheduler.
+  own words alongside the cron, **when it would fire in your timezone, and which
+  of the two it is** — `fires once, on …` or `first fires …, and repeats` —
+  because `0 10 1 9 *` tells a reviewer nothing about whether the agent
+  understood "tomorrow". That distinction is load-bearing: cron has no year
+  field, so a request for one morning can only be written as an annual
+  recurrence, and without a bound it would arrive again every September. `accept`
+  turns it into a real entry on the real scheduler, bound included.
 - **An outstanding-work list that ages and checks itself** — agents record what
   they left undone, and that list used to only grow: it once carried items about
   a release six versions old next to a breakfast reminder three weeks past. A


### PR DESCRIPTION
The README's reminder bullet described the review surface as showing **"when that cron would first fire in your timezone"**.

That was true of both a one-off and an annual repeat — which is precisely how a request for one morning got granted forever (#1119). One word was carrying the whole distinction, and it could not.

It now names what the surface actually says (`fires once, on …` / `first fires …, and repeats`) and why the distinction has to exist at all: cron has no year field, so a dated request can only be written as an annual recurrence, and without a bound it arrives again every September.

Third leg of the docs update for 2.71.11–2.71.15. The `mur-server` legs (new **Agent Schedules** and **Filesystem Grants** pages, `open --check`, one product card) are mur-run/mur-server#66.

Only `README.md` is in this commit — `mur-core/src/cmd/agent/service.rs` has unrelated uncommitted work in this checkout and was left untouched.