### PR TITLE
fix(mcp): a MUR upgrade no longer bricks the servers MUR ships itself

### DIFF
--- a/docs/architecture/mcp-supply-chain.md
+++ b/docs/architecture/mcp-supply-chain.md
@@ -47,11 +47,24 @@ Both were written to `return Err(...)` from `B0SafetyHook::on_startup` with the 
 
 They now live in `verify_mcp_supply_chain` in `mur-agent-runtime/src/hooks/b0.rs`, which the supervisor calls with `?`. (#793)
 
-### MUR re-pins its own bundled MCP server
+### MUR re-pins the MCP servers it ships itself
 
 The supervisor refreshes `~/.mur/mcp-servers/mur-mcp-server` from the binary beside the running `mur` at every start, so **every upgrade drifts that pin by construction**. Enforcement without a re-pin would turn a routine `mur` upgrade into every agent refusing to start.
 
 This is not a weakening: that binary was written moments earlier by this runtime from its own installation. Its trust anchor is "same install as the runtime", not a hash recorded weeks ago, and anyone able to replace it has already replaced `mur`. Third-party entries are never re-pinned. (#793)
+
+The same reasoning covers MUR's **other** shipped servers, and originally did not reach them. `mur-research-gateway` — what `mur deep-research setup` installs — rides in the same release, lands in the same install directory, and is replaced by the same upgrade, but was pinned by a bare command name like any third-party entry. One `mur` upgrade left every deep-research worker crash-looping at boot on `B0 rule 6: MCP \`research-gateway\` changed since install`; launchd restarts it, it fail-closes again, and `mur agent status` reports only `stopped`.
+
+The exemption is a **property, not a list of names** — a list goes stale the day MUR ships another server. An entry is first-party when it resolves into the directory holding the running runtime's own executable **and** carries MUR's `mur-` name prefix. Both halves are load-bearing:
+
+- **Directory alone** would silently drop pin enforcement for an unrelated third-party MCP binary the user keeps in `~/.local/bin` — a crowded directory on a normal machine, unlike a Homebrew Cellar.
+- **Name alone** would trust any binary wearing MUR's name from anywhere on PATH.
+
+Resolution canonicalizes, so a symlinked install (Homebrew's `bin` into its Cellar) compares equal.
+
+### Rule 6 resolves against the PATH the spawn uses
+
+Rule 6 hashed the binary `mur_common::exec::resolve_command` found on the **ambient** PATH, while the spawn resolves against `augmented_path_var` (`protocol/mcp_client.rs`, `supervisor_runner.rs`). The two disagree exactly where it matters: `augmented_path_var` appends `~/.local/bin`, where an installed MUR lives since #935, and launchd/systemd hand the runtime a PATH without it. A first-party binary found only there resolved for the spawn but not for the check — verification soft-failed with "command not resolvable, continuing" and the binary then ran **entirely unpinned**. Both passes now consult one PATH.
 
 ### Interpreter-launched entries are reported, not enforced
 
@@ -114,7 +127,7 @@ The open follow-on is to connect the two: a server whose provenance cannot be ve
 |---|---|
 | Startup enforcement (rules 6 + 11) | `mur-agent-runtime/src/hooks/b0.rs` — `verify_mcp_supply_chain` |
 | Called by | `mur-agent-runtime/src/supervisor_runner.rs` (with `?`, before the hook chain) |
-| Re-pin of MUR's own bundle | `mur-agent-runtime/src/mcp_repin.rs` |
+| Re-pin of MUR's own servers (bundle + siblings) | `mur-agent-runtime/src/mcp_repin.rs` — `repin_first_party` |
 | Pin status classification | `mur-core/src/cmd/agent_mcp_pin.rs` — `binary_status` |
 | Vendoring + signature audit + provenance | `mur-core/src/cmd/agent_mcp_vendor.rs` |
 | Deep audit | `mur-core/src/cmd/agent_mcp_deep_audit.rs` |

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -151,16 +151,28 @@ pub fn verify_mcp_supply_chain(
             );
             continue;
         }
-        // Resolve via PATH exactly as install does (mur_common::exec) so both
-        // passes hash the same binary `Command::new` will spawn. A bare
+        // Resolve against the SAME augmented PATH the spawn uses
+        // (`protocol/mcp_client.rs`, `supervisor_runner.rs`), so the file
+        // hashed here is provably the file `Command::new` will exec. A bare
         // `node`/`npx` opened verbatim is a CWD-relative path that doesn't
         // exist, which previously soft-failed and skipped the pin entirely.
+        //
+        // Resolving against the ambient PATH instead was not merely cosmetic.
+        // `augmented_path_var` appends `~/.local/bin` — where an installed MUR
+        // lives since #935 — and launchd/systemd hand the runtime a PATH
+        // without it. So a first-party binary found only there resolved for the
+        // spawn but not for this check: verification soft-failed with "command
+        // not resolvable, continuing" and the binary then ran entirely
+        // unpinned. The two passes must consult one PATH.
         let prog = entry
             .command
             .split_whitespace()
             .next()
             .unwrap_or(&entry.command);
-        let path = match mur_common::exec::resolve_command(prog) {
+        let path = match mur_common::exec::resolve_command_in(
+            &mur_common::exec::augmented_path_var(),
+            prog,
+        ) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(

--- a/mur-agent-runtime/src/mcp_repin.rs
+++ b/mur-agent-runtime/src/mcp_repin.rs
@@ -1,53 +1,128 @@
-//! Re-pin MUR's own bundled MCP server after the supervisor refreshes it.
+//! Re-pin the MCP servers MUR ships itself, which every `mur` upgrade replaces.
 //!
-//! `mur_common::exec::ensure_bundled_mcp_server` copies the `mur-mcp-server`
-//! shipped beside the running `mur` into `~/.mur/mcp-servers/` whenever the two
-//! differ — so every `mur` upgrade changes that binary underneath every profile
-//! that pinned it at install time.
+//! Two shapes, one trust anchor.
 //!
-//! Nothing re-pinned it, which left B0 rule 6 permanently reporting drift for
-//! the one MCP MUR ships itself. That was survivable only because rule 6 never
-//! actually refused a startup; now that it does (#791), an upgrade without a
-//! re-pin would refuse to start the agent.
+//! **The bundled server.** `mur_common::exec::ensure_bundled_mcp_server` copies
+//! the `mur-mcp-server` shipped beside the running `mur` into
+//! `~/.mur/mcp-servers/` whenever the two differ — so every `mur` upgrade
+//! changes that binary underneath every profile that pinned it at install time.
 //!
-//! Re-pinning here is not a weakening of the control. The binary was just
-//! written by this runtime from its own installation — its trust anchor is
-//! "same install as the runtime", not a hash recorded weeks ago. Anyone able to
-//! swap it has already swapped `mur` itself. Third-party MCP entries, which are
-//! the reason rule 6 exists, are never touched.
+//! **Sibling first-party servers.** `mur-research-gateway` (what
+//! `mur deep-research setup` installs) is shipped in the same release, lands in
+//! the same install directory, and is replaced by the same upgrade — but is
+//! pinned by a bare command name like any third-party entry. Nothing exempted
+//! it, so after #791 made rule 6 actually refuse startup, one `mur` upgrade
+//! left every deep-research worker crash-looping at boot with `B0 rule 6: MCP
+//! `research-gateway` changed since install`. launchd/systemd restarts it, it
+//! fail-closes again, and `mur agent status` just says `stopped`.
+//!
+//! Re-pinning is not a weakening of the control. The anchor is "same install as
+//! this runtime", not a hash recorded weeks ago: the bundled copy was written
+//! moments ago by this runtime from its own installation, and a sibling is a
+//! file in the very directory this runtime's own executable lives in. Anyone
+//! able to swap either has already swapped the runtime itself.
+//!
+//! The anchor is deliberately a *property*, not a list of names — a list would
+//! go stale the day MUR ships another server. Both halves of it are load-bearing
+//! and neither is sufficient alone:
+//!
+//! * **Same directory as the running runtime.** A `mur-` prefixed binary found
+//!   anywhere else on PATH is a stranger wearing MUR's name and stays enforced.
+//! * **MUR's own `mur-` name prefix.** Without it, an unrelated third-party MCP
+//!   binary the user happens to keep in `~/.local/bin` — a crowded directory on
+//!   a normal machine, unlike a Homebrew Cellar — would silently stop being
+//!   pin-enforced. That is coverage rule 6 exists to provide.
+//!
+//! Everything else is untouched: third-party entries, interpreter-launched
+//! entries, and vendored packages.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Re-pin profile entries pointing at MUR's own bundled MCP server to the
-/// binary now on disk at `bundled`.
+/// The name prefix MUR's own shipped binaries carry (`mur-mcp-server`,
+/// `mur-research-gateway`, …). Half of the first-party test above; see the
+/// module docs for why matching on the directory alone is not enough.
+const MUR_BINARY_PREFIX: &str = "mur-";
+
+/// The first-party binary `entry` should be re-pinned to, or `None` when the
+/// entry is third-party and rule 6 must keep enforcing its install-time hash.
 ///
-/// Matches an entry when its command is that exact path, or the bare binary
-/// name (`mur-mcp-server`, as written by a capability install). Returns `true`
-/// when `profile.yaml` was rewritten.
-pub fn repin_bundled_mcp(agent_home: &Path, bundled: &Path) -> anyhow::Result<bool> {
-    let actual = crate::hooks::b0_helpers::binary_sha256(bundled)
-        .map_err(|e| anyhow::anyhow!("hash {}: {e}", bundled.display()))?;
+/// `bundled` is the refreshed `~/.mur/mcp-servers/mur-mcp-server`, when the
+/// supervisor refreshed one this start. `runtime_dir` is the directory holding
+/// this runtime's own executable.
+fn first_party_target(
+    command: &str,
+    bundled: Option<&Path>,
+    runtime_dir: &Path,
+) -> Option<PathBuf> {
+    if let Some(bundled) = bundled {
+        let c = Path::new(command);
+        if c == bundled || c.file_name() == bundled.file_name() {
+            return Some(bundled.to_path_buf());
+        }
+    }
 
+    // Resolve exactly as the spawn does, so the file re-pinned is the file that
+    // will run. Resolution canonicalizes, so a symlinked install (Homebrew's
+    // `bin` into its Cellar) compares equal to the runtime's own resolved dir.
+    let prog = command.split_whitespace().next()?;
+    if !Path::new(prog)
+        .file_name()?
+        .to_str()?
+        .starts_with(MUR_BINARY_PREFIX)
+    {
+        return None;
+    }
+    let resolved =
+        mur_common::exec::resolve_command_in(&mur_common::exec::augmented_path_var(), prog).ok()?;
+    (resolved.parent()? == runtime_dir).then_some(resolved)
+}
+
+/// Re-pin every profile entry that resolves to one of MUR's own binaries.
+///
+/// `bundled` is the refreshed `~/.mur/mcp-servers/mur-mcp-server` when the
+/// supervisor refreshed one this start, `None` otherwise. `runtime_dir` is the
+/// directory holding this runtime's own executable. Returns `true` when
+/// `profile.yaml` was rewritten.
+pub fn repin_first_party(
+    agent_home: &Path,
+    bundled: Option<&Path>,
+    runtime_dir: &Path,
+) -> anyhow::Result<bool> {
     let profile_path = agent_home.join("profile.yaml");
     let yaml = std::fs::read_to_string(&profile_path)?;
     let mut profile: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&yaml)?;
 
     let mut changed = false;
     for entry in &mut profile.mcp_servers {
-        let command = Path::new(&entry.command);
-        if command != bundled && command.file_name() != bundled.file_name() {
+        let Some(target) = first_party_target(&entry.command, bundled, runtime_dir) else {
             continue;
-        }
+        };
+        let actual = match crate::hooks::b0_helpers::binary_sha256(&target) {
+            Ok(a) => a,
+            // Unreadable is the same call rule 6 makes for a missing binary:
+            // far more likely "the user deleted it" than an attack, and a hard
+            // error here would strand the agent with no way back in.
+            Err(e) => {
+                tracing::warn!(
+                    mcp = %entry.name,
+                    path = %target.display(),
+                    error = %e,
+                    "could not hash first-party MCP binary; leaving its pin alone",
+                );
+                continue;
+            }
+        };
         if entry.binary_sha256.as_deref() == Some(actual.as_str()) {
             continue;
         }
         tracing::info!(
             mcp = %entry.name,
+            path = %target.display(),
             from = entry.binary_sha256.as_deref().unwrap_or("<unpinned>"),
             to = %actual,
-            "re-pinned bundled mcp-server after refresh",
+            "re-pinned first-party MCP binary shipped with this runtime",
         );
-        entry.binary_sha256 = Some(actual.clone());
+        entry.binary_sha256 = Some(actual);
         changed = true;
     }
     if !changed {
@@ -104,6 +179,94 @@ mod tests {
             .unwrap()
     }
 
+    /// For the bundled-arm tests: a runtime dir nothing resolves into, so only
+    /// the `bundled` match can fire.
+    fn no_runtime_dir() -> PathBuf {
+        PathBuf::from("/nonexistent/runtime/dir")
+    }
+
+    /// Writes `name` into `dir` with `body` and returns its canonical path.
+    fn sibling(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, body).unwrap();
+        p.canonicalize().unwrap()
+    }
+
+    /// Writes a profile with one entry and returns (tempdir, canonical runtime dir).
+    fn one_entry(command_from: impl FnOnce(&Path) -> String) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime_dir = dir.path().join("bin");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+        let runtime_dir = runtime_dir.canonicalize().unwrap();
+
+        let yaml = include_str!("../tests/fixtures/profile_minimal.yaml");
+        let mut profile: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+        profile.mcp_servers = vec![entry(
+            "gw",
+            &command_from(&runtime_dir),
+            Some(&"b".repeat(64)),
+        )];
+        std::fs::write(
+            dir.path().join("profile.yaml"),
+            serde_yaml_ng::to_string(&profile).unwrap(),
+        )
+        .unwrap();
+        (dir, runtime_dir)
+    }
+
+    /// The regression this arm exists for: `mur-research-gateway` ships in the
+    /// same release as the runtime, so every upgrade drifts its pin. Before
+    /// this, rule 6 refused startup and every deep-research worker crash-looped.
+    #[test]
+    fn repins_a_first_party_sibling_shipped_with_this_runtime() {
+        let (dir, runtime_dir) = one_entry(|rt| {
+            sibling(rt, "mur-research-gateway", b"gateway v2")
+                .display()
+                .to_string()
+        });
+
+        assert!(repin_first_party(dir.path(), None, &runtime_dir).unwrap());
+
+        let gw = runtime_dir.join("mur-research-gateway");
+        let expected = crate::hooks::b0_helpers::binary_sha256(&gw).unwrap();
+        assert_eq!(
+            reload(dir.path()).mcp_servers[0].binary_sha256.as_deref(),
+            Some(expected.as_str()),
+        );
+    }
+
+    /// Directory alone is not the test. A binary wearing MUR's name from
+    /// somewhere else on PATH is a stranger, and rule 6 must keep enforcing it.
+    #[test]
+    fn a_mur_named_binary_outside_the_runtime_dir_stays_enforced() {
+        let elsewhere = tempfile::tempdir().unwrap();
+        let (dir, runtime_dir) = one_entry(|_| {
+            sibling(elsewhere.path(), "mur-research-gateway", b"impostor")
+                .display()
+                .to_string()
+        });
+
+        assert!(!repin_first_party(dir.path(), None, &runtime_dir).unwrap());
+        assert_eq!(
+            reload(dir.path()).mcp_servers[0].binary_sha256.as_deref(),
+            Some("b".repeat(64).as_str()),
+        );
+    }
+
+    /// Nor is the name alone. `~/.local/bin` is a crowded directory on a normal
+    /// machine; a third-party MCP binary parked there must not lose its pin.
+    #[test]
+    fn a_third_party_binary_sharing_the_runtime_dir_stays_enforced() {
+        let (dir, runtime_dir) =
+            one_entry(|rt| sibling(rt, "weather-mcp", b"vendor").display().to_string());
+
+        assert!(!repin_first_party(dir.path(), None, &runtime_dir).unwrap());
+        assert_eq!(
+            reload(dir.path()).mcp_servers[0].binary_sha256.as_deref(),
+            Some("b".repeat(64).as_str()),
+        );
+    }
+
     #[test]
     fn repins_the_bundled_entry_and_leaves_third_party_pins_alone() {
         let third_party_pin = "a".repeat(64);
@@ -115,7 +278,7 @@ mod tests {
             ]
         });
 
-        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+        assert!(repin_first_party(dir.path(), Some(&bundled), &no_runtime_dir()).unwrap());
 
         let after = reload(dir.path());
         let expected = crate::hooks::b0_helpers::binary_sha256(&bundled).unwrap();
@@ -135,7 +298,7 @@ mod tests {
     fn matches_a_bare_binary_name_as_written_by_capability_installs() {
         let (dir, bundled) = fixture(|_| vec![entry("media", "mur-mcp-server", None)]);
 
-        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+        assert!(repin_first_party(dir.path(), Some(&bundled), &no_runtime_dir()).unwrap());
 
         let expected = crate::hooks::b0_helpers::binary_sha256(&bundled).unwrap();
         assert_eq!(
@@ -147,11 +310,11 @@ mod tests {
     #[test]
     fn is_idempotent_and_does_not_rewrite_when_already_current() {
         let (dir, bundled) = fixture(|_| vec![entry("media", "mur-mcp-server", None)]);
-        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+        assert!(repin_first_party(dir.path(), Some(&bundled), &no_runtime_dir()).unwrap());
 
         let before = std::fs::read_to_string(dir.path().join("profile.yaml")).unwrap();
         assert!(
-            !repin_bundled_mcp(dir.path(), &bundled).unwrap(),
+            !repin_first_party(dir.path(), Some(&bundled), &no_runtime_dir()).unwrap(),
             "second run has nothing to change"
         );
         assert_eq!(

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -226,29 +226,48 @@ pub async fn entrypoint() -> anyhow::Result<()> {
             // resolve to the bundled copy, so both should trigger the refresh.
             c == bundled || c.file_name() == bundled.file_name()
         });
+        let mut bundled_refreshed = None;
         if uses_bundled {
             match mur_common::exec::ensure_bundled_mcp_server() {
                 Ok(p) => {
                     info!(path = %p.display(), "ensured bundled mcp-server");
-                    // Re-pin: we just put this binary there ourselves, from the
-                    // `mur-mcp-server` shipped beside the running `mur`. Its
-                    // trust anchor is "same install as this runtime", not a
-                    // hash recorded weeks ago — an attacker who can swap it has
-                    // already swapped `mur` itself.
-                    //
-                    // Without this, every `mur` upgrade leaves the profile
-                    // pinned to the previous binary, so B0 rule 6 (now
-                    // enforcing, #791) would refuse to start the agent after a
-                    // routine upgrade. Third-party MCP entries are untouched.
-                    if let Err(e) = crate::mcp_repin::repin_bundled_mcp(&agent_home, &p) {
-                        warn!(error = %e, "could not re-pin bundled mcp-server");
-                    }
+                    bundled_refreshed = Some(p);
                 }
                 Err(e) => warn!(
                     error = %e,
                     "could not refresh bundled mcp-server; using existing copy if present"
                 ),
             }
+        }
+
+        // Re-pin the MCP servers MUR ships itself, whose trust anchor is "same
+        // install as this runtime" rather than a hash recorded weeks ago: an
+        // attacker who can swap one has already swapped the runtime. Without
+        // this, every `mur` upgrade leaves the profile pinned to the previous
+        // binary and B0 rule 6 (enforcing since #791) refuses to start the
+        // agent after a routine upgrade. Third-party entries are untouched.
+        //
+        // Runs whether or not the bundled server was refreshed: a profile can
+        // carry a first-party sibling (`mur-research-gateway`) and no
+        // `mur-mcp-server` at all — that is exactly the deep-research worker
+        // shape that crash-looped.
+        match std::env::current_exe().ok().and_then(|e| {
+            e.canonicalize()
+                .ok()
+                .and_then(|c| c.parent().map(Path::to_path_buf))
+        }) {
+            Some(runtime_dir) => {
+                if let Err(e) = crate::mcp_repin::repin_first_party(
+                    &agent_home,
+                    bundled_refreshed.as_deref(),
+                    &runtime_dir,
+                ) {
+                    warn!(error = %e, "could not re-pin first-party MCP binaries");
+                }
+            }
+            None => warn!(
+                "could not locate this runtime's own directory; skipped first-party MCP re-pin"
+            ),
         }
     }
 

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -142,7 +142,7 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
 
     #[cfg(target_os = "macos")]
     {
-        let plist = darwin_plist(name, &symlink, &derive_service_path());
+        let plist = darwin_plist(name, &symlink, &derive_service_path(&bin_dir));
         if dry_run {
             print!("{plist}");
             return Ok(());
@@ -171,7 +171,7 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
     }
     #[cfg(target_os = "linux")]
     {
-        let unit = linux_unit(name, &symlink, &derive_service_path());
+        let unit = linux_unit(name, &symlink, &derive_service_path(&bin_dir));
         if dry_run {
             print!("{unit}");
             return Ok(());
@@ -216,11 +216,21 @@ const LAUNCHD_DEFAULT_PATH_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/sbin", "/
 /// binaries (npm/homebrew) resolve when launchd/systemd starts the agent
 /// with its minimal default PATH.
 ///
-/// Includes, in order: `<npm global prefix>/bin` (best-effort, skipped
-/// gracefully if npm is absent or fails), `/opt/homebrew/bin`,
-/// `/usr/local/bin`, then the launchd default dirs.
-fn derive_service_path() -> String {
-    let mut dirs: Vec<String> = Vec::new();
+/// Includes, in order: `bin_dir` (where MUR installed its own binaries),
+/// `<npm global prefix>/bin` (best-effort, skipped gracefully if npm is
+/// absent or fails), `/opt/homebrew/bin`, `/usr/local/bin`, then the launchd
+/// default dirs.
+///
+/// `bin_dir` leads for a reason. Since #935 an installed MUR lives in
+/// `~/.local/bin`, which is in the user's interactive PATH but in neither
+/// launchd's nor systemd's. Without it a sibling binary the agent pins --
+/// `mur-research-gateway` is the one that bit -- resolves to whatever OLD
+/// copy is left in `/opt/homebrew/bin` under the service and to the current
+/// one in an interactive shell. Two different binaries for the same agent
+/// depending on how it was launched, so the B0 rule 6 pin verifies
+/// interactively and fail-closes under launchd, crash-looping the agent.
+fn derive_service_path(bin_dir: &Path) -> String {
+    let mut dirs: Vec<String> = vec![bin_dir.to_string_lossy().into_owned()];
 
     if let Ok(output) = std::process::Command::new("npm")
         .args(["config", "get", "prefix"])
@@ -237,6 +247,9 @@ fn derive_service_path() -> String {
     dirs.push("/usr/local/bin".to_string());
     dirs.extend(LAUNCHD_DEFAULT_PATH_DIRS.iter().map(|d| d.to_string()));
 
+    // `bin_dir` is often one of the constants below it (a brew install).
+    let mut seen = std::collections::HashSet::new();
+    dirs.retain(|d| seen.insert(d.clone()));
     dirs.join(":")
 }
 
@@ -324,10 +337,41 @@ mod tests {
 
     #[test]
     fn derive_service_path_always_has_launchd_defaults() {
-        let path = derive_service_path();
+        let path = derive_service_path(Path::new("/Users/x/.local/bin"));
         for dir in LAUNCHD_DEFAULT_PATH_DIRS {
             assert!(path.contains(dir), "missing {dir} in {path}");
         }
+    }
+
+    /// The service must resolve sibling binaries out of the SAME directory the
+    /// runtime was installed into, ahead of any older copy left on the system
+    /// PATH. When it did not, a pinned `mur-research-gateway` resolved to the
+    /// stale `/opt/homebrew/bin` copy under launchd while an interactive start
+    /// got `~/.local/bin`, and the pin check fail-closed into a crash loop.
+    #[test]
+    fn install_dir_leads_the_service_path() {
+        let path = derive_service_path(Path::new("/Users/x/.local/bin"));
+        assert!(
+            path.starts_with("/Users/x/.local/bin:"),
+            "install dir must lead: {path}"
+        );
+        assert!(
+            path.find("/Users/x/.local/bin").unwrap() < path.find("/opt/homebrew/bin").unwrap(),
+            "install dir must outrank homebrew: {path}"
+        );
+    }
+
+    /// A brew install has `bin_dir == /opt/homebrew/bin`; it must appear once.
+    #[test]
+    fn a_bin_dir_that_repeats_a_constant_is_not_duplicated() {
+        let path = derive_service_path(Path::new("/opt/homebrew/bin"));
+        assert_eq!(
+            path.split(':')
+                .filter(|d| *d == "/opt/homebrew/bin")
+                .count(),
+            1,
+            "duplicated entry in {path}"
+        );
     }
 
     /// The label `stop_service` boots out is derived separately from the path


### PR DESCRIPTION
## What broke

`mcp_repin.rs` (#793) exempts MUR's own bundled `mur-mcp-server` from B0 rule 6, because every upgrade replaces that binary by construction. It only ever recognised **that one name**.

`mur-research-gateway` — what `mur deep-research setup` installs — ships in the same release, lands in the same install directory, and is replaced by the same upgrade, but was pinned by a bare command name like any third-party entry. Since #791 made rule 6 actually refuse startup, **one `mur update` leaves every deep-research worker crash-looping at boot**:

```
Error: B0 rule 6: MCP `research-gateway` changed since install — run `mur agent mcp inspect …`
```

launchd restarts it, it fail-closes again, and `mur agent status` reports only `stopped`. Observed on this machine: three workers, `launchctl list` exit status 1, a restart every 10s in `/tmp/mur-agent-dr_worker_*.err.log`.

## The fix

The exemption is now a **property, not a list of names** — a list goes stale the day MUR ships another server. An entry is first-party when it resolves into the directory holding the running runtime's own executable **and** carries MUR's `mur-` name prefix.

Both halves are load-bearing, and each has a test that fails when its guard is removed (verified by mutation, not by assumption):

| Guard removed | Test that fails |
|---|---|
| `mur-` prefix | `a_third_party_binary_sharing_the_runtime_dir_stays_enforced` |
| same directory | `a_mur_named_binary_outside_the_runtime_dir_stays_enforced` |

Directory alone would silently drop pin enforcement for an unrelated third-party MCP binary a user keeps in `~/.local/bin` — a crowded directory on a normal machine, unlike a Homebrew Cellar. Name alone would trust any binary wearing MUR's name from anywhere on PATH.

The trust anchor is the one already recorded in `docs/architecture/mcp-supply-chain.md`: *same install as the runtime*. Anyone able to replace such a binary has already replaced the runtime. Third-party, interpreter-launched, and vendored entries are untouched.

## Two adjacent defects the same failure exposed

**Rule 6 and the spawn consulted different PATHs.** `b0.rs` resolved on the ambient PATH; `protocol/mcp_client.rs` and `supervisor_runner.rs` resolve against `augmented_path_var`, which appends `~/.local/bin` (where an installed MUR lives since #935). launchd hands the runtime a PATH without it, so a binary found only there resolved for the spawn but not for the check — verification soft-failed with *"command not resolvable, continuing"* and the binary then ran **entirely unpinned**. The `resolve_command_in` doc comment claimed both passes shared one PATH; they did not. They do now.

**`derive_service_path` never included MUR's own install directory.** Under launchd a stale `/opt/homebrew/bin` copy from an earlier keg outranked the current `~/.local/bin` one, so the same agent resolved a different gateway binary depending on how it was launched, and a pin that verified interactively fail-closed as a service. The install dir now leads the derived PATH, which is also what lets the re-pin above resolve the right binary under launchd.

## Verification

- `cargo test -p mur-agent-runtime --lib` — 623 passed
- `cargo test -p mur-core --lib -- cmd::agent::service cmd::deep_research` — 32 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p mur-agent-runtime -p mur-core --all-targets -- -D warnings` — clean
- Both new guards mutation-tested; each mutant kills exactly its own test

Decisions recorded in `docs/architecture/mcp-supply-chain.md` per the repo rule that the doc, not the code, is where these live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
