### PR TITLE
fix(agent): re-running install-service actually applies the new descriptor

### DIFF
--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -154,6 +154,13 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent)?;
         }
+        // Unload any job already running under this label first. `launchctl
+        // load -w` is a no-op against a loaded job, so without this a re-install
+        // rewrote the plist on disk and launchd went right on using the
+        // environment it had read at first load — the new descriptor only took
+        // effect at the next login. Re-running install-service is exactly what
+        // an upgrade tells you to do, so the fix silently did not apply.
+        stop_service(name);
         write_atomic(&dest, plist.as_bytes())?;
         let load_output = std::process::Command::new("launchctl")
             .args(["load", "-w"])
@@ -183,6 +190,10 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
         if let Some(parent) = dest.parent() {
             fs::create_dir_all(parent)?;
         }
+        // Same reason as the launchd leg above: `daemon-reload` makes systemd
+        // re-read the unit file, but a unit that is already running keeps the
+        // settings it started with until it is stopped.
+        stop_service(name);
         write_atomic(&dest, unit.as_bytes())?;
         let _ = std::process::Command::new("systemctl")
             .args(["--user", "daemon-reload"])


### PR DESCRIPTION
## What broke

`cmd_install_service` writes the descriptor and then runs `launchctl load -w`. That is a **no-op against a job that is already loaded**. The plist on disk changes; launchd goes on using the environment it read at first load. The new descriptor only takes effect at the next login.

This is not an edge case: re-running `mur agent install-service` is exactly what an upgrade tells you to do, so the upgrade's fix silently does not apply — and nothing says so.

Found while deploying #1123 on a real machine. All three symptoms were present at once:

```
$ cat ~/Library/LaunchAgents/run.mur.agent.dr_worker_1.plist   # corrected PATH ✓
  <string>/Users/david/.local/bin:/Users/david/.npm-global/bin:/opt/homebrew/bin:…</string>

$ launchctl print gui/501/run.mur.agent.dr_worker_1            # stale PATH ✗
  PATH => /Users/david/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:…
```

and the agent kept crash-looping on a pin that the corrected PATH would have resolved. **The failure is indistinguishable from "the fix does not work"** — which is how I read it for a full cycle before checking `launchctl print`.

## The fix

`stop_service` already unloads correctly on both platforms (`launchctl bootout` / `systemctl --user stop`) and no-ops when no descriptor is installed. The install path simply never called it. Now it does, before writing the new descriptor.

systemd has the same shape: `daemon-reload` makes systemd re-read the unit file, but a unit that is **already running** keeps the settings it started with until it is stopped. The same call guards that leg.

## Verification

- `cargo test -p mur-core --lib -- cmd::agent::service` — 6 passed, exit 0
- `cargo clippy -p mur-core --lib --all-targets -- -D warnings` — clean
- `cargo fmt` — clean

**Not unit-tested, deliberately and stated rather than papered over.** This is an ordering of `launchctl`/`systemctl` shell-outs; the tests in this module cover descriptor *text*, not process control, and a test that mocked the shell-out would assert my own call order back at me. The evidence is an end-to-end run: three agents crash-looping under a stale in-memory job came up within 5s once the job was booted out and bootstrapped from the rewritten plist, and the pin re-pinned itself as #1123 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
