### PR TITLE
test(voice): stop opening a second write handle to a live NamedTempFile

### DIFF
--- a/mur-agent-runtime/src/voice/download.rs
+++ b/mur-agent-runtime/src/voice/download.rs
@@ -137,6 +137,24 @@ mod tests {
         p
     }
 
+    /// A named temp file holding `content`, written through the handle
+    /// `tempfile` already owns.
+    ///
+    /// `fs::write(src.path(), …)` opens a SECOND write handle to a path the
+    /// `NamedTempFile` still holds open. POSIX allows that; Windows
+    /// intermittently refuses it with `Access is denied` (os error 5), which
+    /// reddened a CI run on a PR that touched none of this code and passed on
+    /// a bare re-run — the worst shape of flake, since it reads as "your change
+    /// broke Windows".
+    ///
+    /// The file lives only as long as the returned handle, so callers must bind
+    /// it for the duration of the test rather than drop it on the spot.
+    fn temp_file_with(content: &[u8]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content).unwrap();
+        f
+    }
+
     #[test]
     fn already_present_matching_hash_skips_download() {
         let tmp = tempfile::tempdir().unwrap();
@@ -161,9 +179,8 @@ mod tests {
 
     #[test]
     fn file_url_copies_content() {
-        let src = tempfile::NamedTempFile::new().unwrap();
         let content = b"kokoro model data";
-        std::fs::write(src.path(), content).unwrap();
+        let src = temp_file_with(content);
         // Box::leak is required: ModelSpec.sha256 is &'static str, but the hash
         // is computed at runtime in this test — leak produces a 'static reference.
         let expected_sha: &'static str = Box::leak(sha256_hex(content).into_boxed_str());
@@ -185,8 +202,7 @@ mod tests {
 
     #[test]
     fn hash_mismatch_returns_error() {
-        let src = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(src.path(), b"real content").unwrap();
+        let src = temp_file_with(b"real content");
         let url: &'static str =
             Box::leak(format!("file://{}", src.path().display()).into_boxed_str());
 


### PR DESCRIPTION
## The flake

Two tests in `voice/download.rs` built their fixture as:

```rust
let src = tempfile::NamedTempFile::new().unwrap();
std::fs::write(src.path(), content).unwrap();
```

That opens a **second write handle** to a path the `NamedTempFile` still holds open. POSIX allows it, so this passes every single time on macOS and Linux. Windows intermittently refuses:

```
voice::download::tests::hash_mismatch_returns_error
panicked at mur-agent-runtime\src\voice\download.rs:188:50
PathError { path: "…\Temp\.tmpl8FHtx",
            err: Os { code: 5, kind: PermissionDenied, message: "Access is denied." } }
```

## Why it was worth a PR of its own

It reddened CI on #1124 — a PR whose **entire diff was eleven lines inside `#[cfg(target_os = "macos")]` and `#[cfg(target_os = "linux")]`**, code Windows does not compile. A bare re-run went green.

That is the worst shape of flake. It does not just cost a re-run; it reads as *"your change broke Windows"* on a platform most of us cannot reproduce locally, and the only way to disprove it is a full CI cycle. Left alone it will keep landing on whoever is unlucky, and each time it argues against a correct change.

## The fix

Both fixtures now write through the handle `tempfile` already owns, so the second open never happens. The shared helper carries the reason in a doc comment — without it, `fs::write` is the obvious "simplification" to revert to.

```rust
fn temp_file_with(content: &[u8]) -> tempfile::NamedTempFile {
    let mut f = tempfile::NamedTempFile::new().unwrap();
    f.write_all(content).unwrap();
    f
}
```

## Evidence, stated at its real strength

- macOS: 4 `voice::download` tests pass, `clippy --all-targets -D warnings` clean, `fmt` clean.

**That is not evidence the Windows failure is gone.** The old code also passed here every time — that is precisely the problem. The argument for this fix is structural, not empirical: os error 5 came from the `fs::write` line, and that line no longer exists. A green Windows job on this PR is weak confirmation at best, since the failure was intermittent to begin with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
