### PR TITLE
fix(schedule): a fired schedule leaves its reply where it can be found

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
+++ b/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
@@ -82,7 +82,7 @@ pub fn append_self_reply(
 /// Extract the agent's reply text from a finished [`Task`](mur_common::a2a::Task):
 /// the last message's first text part. Returns an empty string if the task has
 /// no messages or the final message carries no text part.
-fn reply_text_of(task: &mur_common::a2a::Task) -> String {
+pub(crate) fn reply_text_of(task: &mur_common::a2a::Task) -> String {
     task.messages
         .last()
         .and_then(|m| {

--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -370,7 +370,10 @@ mod tests {
         assert_eq!(first, second, "the second firing must reuse the channel");
         assert_eq!(
             std::fs::read_to_string(
-                tmp.path().join("agents").join("probe").join(SCHEDULE_CHANNEL_FILE)
+                tmp.path()
+                    .join("agents")
+                    .join("probe")
+                    .join(SCHEDULE_CHANNEL_FILE)
             )
             .unwrap()
             .trim(),

--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -11,8 +11,11 @@ use crate::task_runner::{TaskOutcome, TaskRunner, TaskSpec};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Local};
 use cron::Schedule;
+use mur_channel::ChannelService;
 use mur_common::a2a::{Message, MessagePart};
-use mur_common::agent::ScheduleEntry;
+use mur_common::agent::{SCHEDULE_CHANNEL_FILE, ScheduleEntry};
+use mur_common::identity::AgentIdentity;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -76,14 +79,101 @@ pub fn parse_bound(not_after: Option<&str>) -> Option<DateTime<Local>> {
     }
 }
 
+/// Where a fired entry leaves its reply.
+///
+/// Before #1125 a completed scheduled turn was discarded: the scheduler warned
+/// on failure and did nothing at all with success, so a reminder fired on the
+/// second and reached nobody. The reply is now appended to a channel, which the
+/// Hub, the Panel and `mur channel` already read — one write, every surface.
+pub struct ScheduleSink {
+    pub mur_home: PathBuf,
+    pub agent: String,
+    pub identity: Arc<AgentIdentity>,
+    pub key_version: u32,
+}
+
+/// The channel a fired entry writes to — created once, then remembered in the
+/// agent's home.
+///
+/// Deliberately not `ChannelService::latest_for_agent`: that returns whatever
+/// conversation the agent last took part in, so a breakfast reminder would land
+/// in the middle of an unrelated fleet thread, and in a different thread each
+/// time it fired. A remembered id keeps every firing in one findable place.
+///
+/// A marker naming a channel that no longer loads is replaced rather than
+/// treated as an error — deleting a channel must not silently stop an agent's
+/// schedules from being recorded anywhere.
+fn schedule_channel(svc: &ChannelService, mur_home: &Path, agent: &str) -> Result<String> {
+    let marker = mur_home
+        .join("agents")
+        .join(agent)
+        .join(SCHEDULE_CHANNEL_FILE);
+    if let Ok(raw) = std::fs::read_to_string(&marker) {
+        let id = raw.trim();
+        if !id.is_empty() && svc.exists(id) {
+            return Ok(id.to_string());
+        }
+    }
+    let ch = svc.create_for_agent(agent)?;
+    if let Some(dir) = marker.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    std::fs::write(&marker, &ch.id).context("record the schedule channel id")?;
+    Ok(ch.id)
+}
+
+/// Append a completed scheduled turn's reply to the agent's schedule channel.
+///
+/// Best-effort, like the `channel/delegate` write it mirrors: a schedule that
+/// fired must not be reported as failed because the channel store was busy.
+fn record_reply(sink: &ScheduleSink, task: &mur_common::a2a::Task, cron: &str) {
+    let text = crate::protocol::methods::channel_delegate::reply_text_of(task);
+    if text.trim().is_empty() {
+        return;
+    }
+    let write = || -> Result<()> {
+        let svc = ChannelService::open(&sink.mur_home)?;
+        let channel_id = schedule_channel(&svc, &sink.mur_home, &sink.agent)?;
+        crate::protocol::methods::channel_delegate::append_self_reply(
+            &sink.mur_home,
+            &channel_id,
+            &sink.agent,
+            &sink.identity,
+            sink.key_version,
+            &text,
+            &task.id,
+            Some(format!("sched:{}:{}", task.id, cron)),
+        )
+    };
+    if let Err(e) = write() {
+        warn!(
+            error = %e, cron = %cron, task_id = %task.id,
+            "cron-triggered turn completed but its reply could not be recorded"
+        );
+    }
+}
+
 pub struct CronScheduler {
     entries: Vec<ScheduleEntry>,
     runner: Arc<TaskRunner>,
+    /// `None` leaves the pre-#1125 behaviour — a fired turn is run and its
+    /// reply discarded. Only tests construct the scheduler that way.
+    sink: Option<Arc<ScheduleSink>>,
 }
 
 impl CronScheduler {
     pub fn new(entries: Vec<ScheduleEntry>, runner: Arc<TaskRunner>) -> Self {
-        Self { entries, runner }
+        Self {
+            entries,
+            runner,
+            sink: None,
+        }
+    }
+
+    /// Record each fired turn's reply into the agent's schedule channel.
+    pub fn with_sink(mut self, sink: ScheduleSink) -> Self {
+        self.sink = Some(Arc::new(sink));
+        self
     }
 
     /// Spawn an outer tokio task that fans out one loop per entry.
@@ -98,8 +188,9 @@ impl CronScheduler {
             for entry in self.entries {
                 let runner = self.runner.clone();
                 let child_cancel = cancel.clone();
+                let sink = self.sink.clone();
                 handles.push(tokio::spawn(async move {
-                    run_entry(entry, runner, child_cancel).await;
+                    run_entry(entry, runner, child_cancel, sink).await;
                 }));
             }
             // Wait for all inner loops — they exit when cancelled.
@@ -110,7 +201,12 @@ impl CronScheduler {
     }
 }
 
-async fn run_entry(entry: ScheduleEntry, runner: Arc<TaskRunner>, cancel: CancellationToken) {
+async fn run_entry(
+    entry: ScheduleEntry,
+    runner: Arc<TaskRunner>,
+    cancel: CancellationToken,
+    sink: Option<Arc<ScheduleSink>>,
+) {
     let expr = format!("0 {}", entry.cron);
     let schedule = match Schedule::from_str(&expr) {
         Ok(s) => s,
@@ -164,13 +260,21 @@ async fn run_entry(entry: ScheduleEntry, runner: Arc<TaskRunner>, cancel: Cancel
 
         let outcome = runner.run_sync(scheduled_task_spec(&entry.message)).await;
 
-        // M2: surface LLM failures in supervisor logs
-        if let TaskOutcome::Failed(ref t) = outcome {
-            warn!(
+        match &outcome {
+            // M2: surface LLM failures in supervisor logs
+            TaskOutcome::Failed(t) => warn!(
                 cron = %entry.cron,
                 task_id = %t.id,
                 "cron-triggered task failed"
-            );
+            ),
+            // #1125: a completed turn used to end here, which is how a reminder
+            // fired on the second and reached nobody.
+            TaskOutcome::Completed(t) => {
+                if let Some(sink) = sink.as_deref() {
+                    record_reply(sink, t, &entry.cron);
+                }
+            }
+            TaskOutcome::Cancelled(_) => {}
         }
     }
 }
@@ -252,6 +356,42 @@ mod tests {
             "cron has no year, so a dated request recurs annually — the bound is \
              the only thing that stops next September from firing too (#1119)"
         );
+    }
+
+    #[test]
+    fn the_schedule_channel_is_created_once_and_remembered() {
+        // Every firing must land in the same place. Creating a channel per
+        // firing would bury a daily reminder under a new thread each morning,
+        // which is why this does not just call `create_for_agent` (#1125).
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let first = schedule_channel(&svc, tmp.path(), "probe").unwrap();
+        let second = schedule_channel(&svc, tmp.path(), "probe").unwrap();
+        assert_eq!(first, second, "the second firing must reuse the channel");
+        assert_eq!(
+            std::fs::read_to_string(
+                tmp.path().join("agents").join("probe").join(SCHEDULE_CHANNEL_FILE)
+            )
+            .unwrap()
+            .trim(),
+            first,
+            "the marker records the channel it handed out"
+        );
+    }
+
+    #[test]
+    fn a_marker_naming_a_channel_that_is_gone_is_replaced() {
+        // Deleting a channel must not permanently stop an agent's schedules
+        // from being recorded anywhere — the marker is a cache, not a claim.
+        let tmp = tempfile::tempdir().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let dir = tmp.path().join("agents").join("probe");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(SCHEDULE_CHANNEL_FILE), "no-such-channel").unwrap();
+
+        let id = schedule_channel(&svc, tmp.path(), "probe").unwrap();
+        assert_ne!(id, "no-such-channel", "a dead id must not be handed back");
+        assert!(svc.exists(&id), "the replacement must be real");
     }
 
     #[test]

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -730,7 +730,15 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     //     Each loop selects on a shared CancellationToken so SIGTERM (which
     //     calls t.abort() on all transport_tasks) also stops in-flight entries.
     if !profile.inner.lifecycle.schedule.is_empty() {
-        let cs = CronScheduler::new(profile.inner.lifecycle.schedule.clone(), runner.clone());
+        // #1125: give the scheduler somewhere to leave each fired turn's
+        // reply. Without a sink the turn runs and its output is discarded.
+        let cs = CronScheduler::new(profile.inner.lifecycle.schedule.clone(), runner.clone())
+            .with_sink(crate::scheduler::ScheduleSink {
+                mur_home: mur_home.clone(),
+                agent: profile.inner.name.clone(),
+                identity: identity.clone(),
+                key_version: profile.inner.identity.key_version,
+            });
         transport_tasks.push(cs.spawn());
         info!(
             count = profile.inner.lifecycle.schedule.len(),

--- a/mur-channel/src/service.rs
+++ b/mur-channel/src/service.rs
@@ -372,6 +372,15 @@ impl ChannelService {
         self.store.load_events(channel_id)
     }
 
+    /// Whether a channel exists, judged by its manifest.
+    ///
+    /// `load_events` is not an existence check: a missing event log reads as an
+    /// empty one, so it returns `Ok(vec![])` for a channel that was never
+    /// created. Callers holding a remembered channel id need this instead.
+    pub fn exists(&self, channel_id: &str) -> bool {
+        self.store.load_manifest(channel_id).is_ok()
+    }
+
     pub fn list(&self, limit: usize) -> Result<Vec<ChannelRow>> {
         self.index.list(limit)
     }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1042,6 +1042,11 @@ pub enum ExecutionMode {
 /// lists, which is the shape of failure this whole area keeps producing.
 pub const SCHEDULE_PROPOSAL_DIR: &str = "schedule-proposals";
 
+/// File in the agent's home holding the id of the channel a fired schedule
+/// leaves its reply in. One stable channel per agent, remembered rather than
+/// re-derived (#1125).
+pub const SCHEDULE_CHANNEL_FILE: &str = "schedule-channel";
+
 /// A schedule an agent asked for and a person has not yet granted.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ScheduleProposal {


### PR DESCRIPTION
Fixes #1125.

A completed scheduled turn was discarded. `run_entry` warned on `TaskOutcome::Failed` and did **nothing at all** with success, so a reminder fired on the second and reached nobody.

Measured on a live agent with a probe entry three minutes ahead:

```
01:05:00.003 INFO scheduler: cron trigger firing cron=5 9 * * * DELIVERY-PROBE-1119
01:05:00.029 INFO skills:    skill tree changed on disk; reloaded skills=66
```

Then nothing — no task record, no channel entry, no file written under the agent home, no further log. `notifications.on_task_complete` has no consumer anywhere in the workspace, and `sends_to` says so itself: *cross-agent dispatch not yet implemented*.

## The reply goes to a channel

Not to a notification backend. The Hub, the Panel and `mur channel` already read channels, so one write reaches every surface, and the runtime already has a signed append — `channel/delegate`'s `append_self_reply` — so this adds no new trust boundary.

A channel entry is **not** a push notification, and this does not claim to be one. It makes the result *findable*, which is the part that can be built without first deciding how to interrupt someone.

## Two decisions worth stating

**Not `latest_for_agent`.** It returns whatever conversation the agent last took part in, so a breakfast reminder would land in the middle of an unrelated fleet thread — and a different one each morning. The channel is created once and its id remembered in the agent home.

**The marker is a cache, not a claim.** A marker naming a channel that no longer exists is replaced rather than treated as an error: deleting one channel must not permanently stop an agent's schedules from being recorded anywhere.

## `ChannelService::exists` is new, and the test is why

The first implementation checked existence with `svc.load_events(id).is_ok()`. That is **always true** — a missing event log reads as an empty one, so it returns `Ok(vec![])` for a channel that was never created. The dead id would have been handed straight back and every firing written into nothing.

That is the same shape as the bug this PR fixes: a call reporting success for something it never checked. The self-healing test caught it before it shipped; without that test the "created once and remembered" test alone passes happily.

```rust
/// `load_events` is not an existence check: a missing event log reads as an
/// empty one, so it returns `Ok(vec![])` for a channel that was never created.
pub fn exists(&self, channel_id: &str) -> bool {
    self.store.load_manifest(channel_id).is_ok()
}
```

## Verification

Both new tests **mutation-verified** — flipped, watched fail, restored, tree confirmed clean:

| mutation | fails | control holds |
|---|---|---|
| `exists` back to `load_events().is_ok()` | `a_marker_naming_a_channel_that_is_gone_is_replaced` | remembered ✓ |
| marker never read (always create) | `the_schedule_channel_is_created_once_and_remembered` | self-healing ✓ |

Each mutation fails exactly one test and leaves the other green, so the two cross-check each other.

One mutation attempt did not compile and produced no FAIL line at all — caught by the run-happened assertion, not by reading the absence of failures as a pass.

`cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets -- -D warnings` both exit 0. The existing `supervisor_cron_smoke.rs` tests are untouched: `CronScheduler::new` keeps its signature and the sink is opt-in via `with_sink`.

## Still not done

This does not notify. A reminder at 10:00 still requires you to look. The remaining options — wiring `notifications.on_task_complete`, or a default local channel (macOS notification / terminal bell) — are recorded in #1125 and deliberately left for a separate decision.