### PR TITLE
chore(release): bump workspace version to 2.71.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.15"
+version = "2.71.16"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6785,7 +6785,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.15"
+version = "2.71.16"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.16 — six commits since 2.71.15.

- **#1127** `fix(schedule)` — a fired schedule leaves its reply where it can be found. A completed scheduled turn was discarded outright; it now goes to a channel the Hub, Panel and `mur channel` already read. Fixes #1125.
- **#1123** `fix(mcp)` — a MUR upgrade no longer bricks the servers MUR ships itself.
- **#1124** `fix(agent)` — re-running `install-service` actually applies the new descriptor.
- **#1117** Hub/Dashboard surface split: local schedules endpoint, Panel fixes, Dashboard reachability.
- **#1122** `docs(readme)` — the reminder bullet says which of the two a proposal is.
- **#1126** `test(voice)` — stop opening a second write handle to a live `NamedTempFile`.

The #1119 bound shipped in 2.71.15 and ran in production this morning, unprompted:

```
02:00:00.002Z cron trigger firing   cron=0 10 1 9 *  該吃早餐了 🥐
02:00:02.781Z schedule retired — its last firing is past, so it will not repeat
```

Fired once on the named date, then retired instead of scheduling itself for next September. It reached nobody, which is what #1127 in this release addresses.

Merging this IS the release: `tag.yml` tags the merge commit and dispatches `release.yml`.