### PR TITLE
feat(schedule): `mur agent schedule add --once`

### DIFF
--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -290,6 +290,21 @@ pub fn next_n_fires(cron_expr: &str, count: usize) -> Result<Vec<chrono::DateTim
     Ok(schedule.upcoming(Local).take(count).collect())
 }
 
+/// The bound a one-off entry carries: its own first firing.
+///
+/// Shared by `mur agent schedule add --once` and the agent's `remind` tool, so
+/// the two cannot drift on what "once" means. Two derivations of the same idea
+/// would each pass their own tests while disagreeing with each other, and
+/// nothing would report it.
+///
+/// `None` for a recurring entry, and also when the expression has no future
+/// firing — an entry that never fires needs no bound.
+pub fn one_off_bound(cron_expr: &str, once: bool) -> Option<String> {
+    once.then(|| next_n_fires(cron_expr, 1).ok())
+        .flatten()
+        .and_then(|v| v.first().map(|t| t.to_rfc3339()))
+}
+
 /// Next fire time strictly after `after`, for a 5-field POSIX cron expression
 /// (seconds = 0, same grammar as [`next_n_fires`]). `None` when the expression
 /// is invalid or yields no future time. Used by the daemon's fleet auto-run to
@@ -356,6 +371,34 @@ mod tests {
             "cron has no year, so a dated request recurs annually — the bound is \
              the only thing that stops next September from firing too (#1119)"
         );
+    }
+
+    #[test]
+    fn a_recurring_entry_gets_no_bound() {
+        assert_eq!(one_off_bound("0 9 * * 1-5", false), None);
+    }
+
+    #[test]
+    fn a_one_off_bound_is_the_expression_own_first_firing() {
+        let cron = "0 10 1 9 *";
+        let bound = one_off_bound(cron, true).expect("a dated cron has a next firing");
+        assert_eq!(
+            bound,
+            next_n_fires(cron, 1).unwrap()[0].to_rfc3339(),
+            "the bound must be the firing the scheduler will admit, not a \
+             recomputation that could round differently"
+        );
+        // And the scheduler must agree that this firing still happens.
+        assert!(
+            !bound_exhausted(next_n_fires(cron, 1).unwrap()[0], Some(&bound)),
+            "the bound `--once` writes must let its own firing through"
+        );
+    }
+
+    #[test]
+    fn an_expression_with_no_future_firing_gets_no_bound() {
+        // 31 February. It never fires, so a bound would guard nothing.
+        assert_eq!(one_off_bound("0 10 31 2 *", true), None);
     }
 
     #[test]

--- a/mur-agent-runtime/src/tools/remind.rs
+++ b/mur-agent-runtime/src/tools/remind.rs
@@ -104,13 +104,10 @@ accept` to grant it, so say that you have asked rather than that it is set."
         // the firing its bound names and retires the one after it, so this
         // fires exactly once (#1119). An expression with no future firing
         // yields no bound, which costs nothing: it never fires either.
-        let not_after = input
-            .get("once")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-            .then(|| crate::scheduler::next_n_fires(&cron, 1).ok())
-            .flatten()
-            .and_then(|v| v.first().map(|t| t.to_rfc3339()));
+        let not_after = crate::scheduler::one_off_bound(
+            &cron,
+            input.get("once").and_then(|v| v.as_bool()).unwrap_or(false),
+        );
 
         let proposal = mur_common::agent::ScheduleProposal {
             cron: cron.clone(),

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -613,6 +613,10 @@ pub enum AgentScheduleAction {
         /// Send the message to a different agent instead of self (optional)
         #[arg(long)]
         sends_to: Option<String>,
+        /// Fire once, then retire. Cron has no year field, so a dated
+        /// expression like `0 10 1 9 *` otherwise repeats every September.
+        #[arg(long)]
+        once: bool,
     },
     /// List all schedule entries for an agent
     List {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -2059,7 +2059,15 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 cron,
                 message,
                 sends_to,
-            } => cmd::agent_schedule::cmd_schedule_add(&name, &cron, &message, sends_to, None)?,
+                once,
+            } => {
+                // The bound is the entry's own first firing — the scheduler
+                // admits the firing its bound names and retires the one after
+                // it. Same derivation as the `remind` tool, so `--once` and an
+                // agent's own one-off proposal cannot disagree (#1119).
+                let not_after = mur_agent_runtime::scheduler::one_off_bound(&cron, once);
+                cmd::agent_schedule::cmd_schedule_add(&name, &cron, &message, sends_to, not_after)?
+            }
             AgentScheduleAction::Proposals { name } => {
                 cmd::agent_schedule::cmd_schedule_proposals(&name)?
             }


### PR DESCRIPTION
A one-off schedule could only be created by an agent, through the `remind` tool. Writing one by hand was impossible — `cmd_schedule_add` has taken the bound since #1120, but nothing on the CLI could supply it.

```bash
mur agent schedule add mur --cron "0 10 2 9 *" --message "該吃早餐了 🥐" --once
```

## One derivation, not two

The obvious implementation computes the bound inline in `dispatch.rs`. That would leave two answers to "what bound does `once` mean" — one for the CLI, one for `remind` — and **two derivations of the same idea each pass their own tests while disagreeing with each other, with nothing to report it.**

So it is extracted: `scheduler::one_off_bound(cron, once)` is the single place, and both callers use it.

That claim is not left as a comment. Mutating `one_off_bound` to write the bound one second early fails **both**:

```
FAIL scheduler::tests::a_one_off_bound_is_the_expression_own_first_firing
FAIL tools::remind::tests::a_one_off_is_bounded_by_its_own_first_firing
```

Separate derivations would have failed one. That is the evidence the sharing is real — stronger than any assertion I could have written, and I did not design the test for it.

## The bound test does not stop at equality

Comparing the bound to the first firing proves the value. It does not prove the scheduler will honour it. So the test feeds the bound back:

```rust
assert!(
    !bound_exhausted(next_n_fires(cron, 1).unwrap()[0], Some(&bound)),
    "the bound `--once` writes must let its own firing through"
);
```

An off-by-one here writes a reminder that never fires — silent, and indistinguishable from "the schedule was never set".

## Verification

| mutation | fails | controls hold |
|---|---|---|
| `once` ignored, bound always computed | `a_recurring_entry_gets_no_bound` | 3 ✓ |
| bound written one second early | both one-off tests (see above) | 2 ✓ |

Three new tests: a recurring entry gets no bound; a one-off bound is its own first firing *and* the scheduler admits that firing; an expression with no future firing (31 February) gets no bound, because an entry that never fires needs no guard.

`cargo clippy --workspace --all-targets -- -D warnings` exits 0. Tree confirmed clean after both restores.