### PR TITLE
feat(companion): a fired schedule reaches the inbox, not just the channel

### DIFF
--- a/mur-agent-runtime/src/companion/situations.rs
+++ b/mur-agent-runtime/src/companion/situations.rs
@@ -45,3 +45,38 @@ pub fn pick_for_hour<R: RngCore>(
         _ => unreachable!(),
     })
 }
+
+#[cfg(test)]
+mod scheduled_is_unreachable_tests {
+    use super::*;
+    use chrono::TimeZone;
+    use rand::SeedableRng;
+
+    /// `Situation::Scheduled` is supplied directly by the scheduler and must
+    /// never be produced by the hourly picker — the picker answers "say
+    /// something? say what?", and a schedule already has both answers.
+    ///
+    /// This pins the claim in the enum's own doc comment. The guarantee is
+    /// structural (`weights_by_hour` returns a fixed 5-wide table and the
+    /// sample arms stop at index 4), but a sixth weight added later would
+    /// silently make it reachable, and nothing else would notice.
+    #[test]
+    fn the_hourly_picker_never_yields_scheduled() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xB0A7);
+        let mut seen = 0usize;
+        for hour in 0..24 {
+            let now = Local.with_ymd_and_hms(2026, 9, 1, hour, 0, 0).unwrap();
+            for _ in 0..200 {
+                if let Some(s) = pick_for_hour(now, None, &mut rng) {
+                    seen += 1;
+                    assert_ne!(
+                        s,
+                        Situation::Scheduled,
+                        "the picker reached Scheduled at hour {hour}"
+                    );
+                }
+            }
+        }
+        assert!(seen > 0, "the loop must actually have picked something");
+    }
+}

--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -9,7 +9,7 @@
 use crate::llm::{BackgroundKind, RequestIntent};
 use crate::task_runner::{TaskOutcome, TaskRunner, TaskSpec};
 use anyhow::{Context, Result};
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, Utc};
 use cron::Schedule;
 use mur_channel::ChannelService;
 use mur_common::a2a::{Message, MessagePart};
@@ -90,6 +90,45 @@ pub struct ScheduleSink {
     pub agent: String,
     pub identity: Arc<AgentIdentity>,
     pub key_version: u32,
+    /// The agent's BCP-47 locale, written into the inbox entry's front matter.
+    /// Carried rather than guessed: the entry claims a locale either way, and a
+    /// guessed one is a small lie in a file the Hub renders.
+    pub locale: String,
+}
+
+/// Put the reply in the companion inbox, where the Hub already shows what an
+/// agent has said to you.
+///
+/// This reuses the companion's `Notifier` and deliberately skips its `Outbox`.
+/// The outbox exists to decide *whether* to speak (quiet hours, rhythm, earned
+/// permission) and *what* to say (situation weights, template cooldowns). A
+/// schedule has answers to both, supplied by the person who wrote it — running
+/// it through gates built to govern unprompted chatter would let a reminder be
+/// dropped for being the wrong topic at the wrong hour.
+///
+/// Skipping those gates is not a privilege. Quiet hours exist so the agent does
+/// not start conversations while you sleep; a 10:00 reminder you set is not
+/// that.
+async fn notify_inbox(sink: &ScheduleSink, task_id: &str, body: &str, now: DateTime<Utc>) {
+    use crate::companion::notifier::{CompanionMessage, Notifier, StdoutNotifier};
+
+    let inbox = sink
+        .mur_home
+        .join("agents")
+        .join(&sink.agent)
+        .join("companion/inbox");
+    let msg = CompanionMessage {
+        id: task_id.to_string(),
+        situation: mur_common::companion::Situation::Scheduled,
+        // No template was picked — the text is the schedule's own message.
+        template_id: "scheduled".to_string(),
+        locale: sink.locale.clone(),
+        body: body.to_string(),
+        generated_at: now,
+    };
+    if let Err(e) = StdoutNotifier::new(inbox).send(&msg).await {
+        warn!(error = %e, task_id = %task_id, "scheduled reply reached the channel but not the inbox");
+    }
 }
 
 /// The channel a fired entry writes to — created once, then remembered in the
@@ -126,7 +165,7 @@ fn schedule_channel(svc: &ChannelService, mur_home: &Path, agent: &str) -> Resul
 ///
 /// Best-effort, like the `channel/delegate` write it mirrors: a schedule that
 /// fired must not be reported as failed because the channel store was busy.
-fn record_reply(sink: &ScheduleSink, task: &mur_common::a2a::Task, cron: &str) {
+async fn record_reply(sink: &ScheduleSink, task: &mur_common::a2a::Task, cron: &str) {
     let text = crate::protocol::methods::channel_delegate::reply_text_of(task);
     if text.trim().is_empty() {
         return;
@@ -151,6 +190,10 @@ fn record_reply(sink: &ScheduleSink, task: &mur_common::a2a::Task, cron: &str) {
             "cron-triggered turn completed but its reply could not be recorded"
         );
     }
+
+    // The channel makes the reply findable; the inbox is where a person is
+    // already looking. Both, because neither replaces the other.
+    notify_inbox(sink, &task.id, &text, chrono::Utc::now()).await;
 }
 
 pub struct CronScheduler {
@@ -271,7 +314,7 @@ async fn run_entry(
             // fired on the second and reached nobody.
             TaskOutcome::Completed(t) => {
                 if let Some(sink) = sink.as_deref() {
-                    record_reply(sink, t, &entry.cron);
+                    record_reply(sink, t, &entry.cron).await;
                 }
             }
             TaskOutcome::Cancelled(_) => {}

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -738,6 +738,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 agent: profile.inner.name.clone(),
                 identity: identity.clone(),
                 key_version: profile.inner.identity.key_version,
+                locale: profile.inner.companion.locale.clone(),
             });
         transport_tasks.push(cs.spawn());
         info!(

--- a/mur-common/src/companion/mod.rs
+++ b/mur-common/src/companion/mod.rs
@@ -32,6 +32,12 @@ pub enum Situation {
     ShareQuote,
     ShareLink,
     WorkflowNudge,
+    /// A schedule the user set fired. Unlike every variant above, this one is
+    /// never chosen by `situations::pick_for_hour` — the picker samples a fixed
+    /// weight table and cannot reach it. It is supplied directly, because both
+    /// questions the picker exists to answer (say something? say what?) were
+    /// already answered by the person who wrote the schedule.
+    Scheduled,
 }
 
 #[cfg(test)]

--- a/mur-core/src/cmd/agent_companion/preview.rs
+++ b/mur-core/src/cmd/agent_companion/preview.rs
@@ -398,6 +398,11 @@ fn situation_to_slug(s: &Situation) -> &'static str {
         Situation::ShareQuote => "share_quote",
         Situation::ShareLink => "share_link",
         Situation::WorkflowNudge => "workflow_nudge",
+        // Unreachable from here in practice: a scheduled reminder skips the
+        // outbox, so it never writes the ledger events these functions read.
+        // The arm exists because the enum is exhaustive, not because the
+        // outbox handles schedules.
+        Situation::Scheduled => "scheduled",
     }
 }
 

--- a/mur-core/src/cmd/agent_companion/why.rs
+++ b/mur-core/src/cmd/agent_companion/why.rs
@@ -330,6 +330,11 @@ fn situation_to_slug(s: &mur_common::companion::Situation) -> &'static str {
         Situation::ShareQuote => "share_quote",
         Situation::ShareLink => "share_link",
         Situation::WorkflowNudge => "workflow_nudge",
+        // Unreachable from here in practice: a scheduled reminder skips the
+        // outbox, so it never writes the ledger events these functions read.
+        // The arm exists because the enum is exhaustive, not because the
+        // outbox handles schedules.
+        Situation::Scheduled => "scheduled",
     }
 }
 


### PR DESCRIPTION
#1127 made a scheduled turn's reply **findable** — it goes to a channel. It still required you to go looking.

The Hub already has an Inbox. Its empty state reads *"The companion will appear here when the agent sends you a message."* This puts scheduled replies there.

## Reuse the `Notifier`, skip the `Outbox`

They are separable, and only one of them is about delivery.

| outbox step | what it asks |
|---|---|
| 1 `earned_permission` | enabled / paused / learning / **quiet hours** |
| 4 `should_send_new` | rhythm — is now a good moment to speak unprompted |
| 5 `pick_for_hour` | **what topic** |
| 6 `Picker::pick` | which phrasing, not on cooldown |
| 11 `deliver` | send it |

Steps 1 and 4 decide *whether* to speak; 5 and 6 decide *what* to say. **A schedule has answers to both, supplied by the person who wrote it.** Routing a reminder through gates built to govern unprompted chatter would let it be dropped for being the wrong topic at the wrong hour — a new silent failure of exactly the kind #1125 was about.

Skipping those gates is not a privilege. Quiet hours exist so the agent does not start conversations while you sleep; a 10:00 reminder you set is not that.

`StdoutNotifier` writes `<agent_home>/companion/inbox/<id>.md` and nothing else — no OS-specific code — so this is cross-platform by construction rather than by porting. An OS-native notifier (osascript / `notify-send` / toast) can be a second `Notifier` impl later; the trait is already the seam. It would fail on a headless Linux box, which is a real MUR target, so it is not the right first step.

## `Situation::Scheduled`

New, so the inbox front matter says what the entry is instead of borrowing a situation it isn't.

It is **unreachable** from `pick_for_hour`: `weights_by_hour` returns a fixed `[f32; 5]` and the sample arms stop at index 4. That is structural — but a sixth weight added later would silently make it reachable, and the picker would start offering "scheduled" as a morning topic. A test pins it: 24 hours × 200 samples, plus an assertion that the loop actually picked something, so it cannot pass by picking nothing.

Two `situation_to_slug` match arms were required. Both are unreachable in practice — a scheduled reminder never writes the outbox ledger events those functions read — and say so. **Noted, not fixed:** those two functions are byte-identical duplicates across `preview.rs` and `why.rs`; deduplicating them is its own change.

## Locale

Carried from `companion.locale` rather than guessed. The front matter claims a locale either way, and a guessed one is a small lie in a file the Hub renders. `default_locale()` reads the OS locale, so the value is right even under launchd where `LANG` is unset — and it does not depend on `companion.enabled`, because this path uses the notifier, not the companion loop.

## Both writes stay

The channel is the record — signed, auditable, readable by every surface. The inbox is where a person is already looking. Neither replaces the other.

## Verification

`cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets -- -D warnings` both exit 0. 27 tests pass.

The unreachability test is mutation-verified: pointing sample arm `1` (non-zero weight in two hour bands) at `Scheduled` fails it. Arm `4` would have been a useless mutation — its weight is zero in every band, so the test would have passed against a broken picker.