### PR TITLE
feat(hub): raise a system notification when a companion inbox entry arrives

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6288,6 +6288,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6829,6 +6843,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -7013,6 +7028,20 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -10695,6 +10724,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10886,6 +10934,17 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
+dependencies = [
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-notification = "2"
 notify = "6"
 
 # Workspace siblings — reused from the root repo via relative path.

--- a/mur-hub-gui/src-tauri/capabilities/default.json
+++ b/mur-hub-gui/src-tauri/capabilities/default.json
@@ -2,7 +2,9 @@
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "default",
   "description": "Default capability set for MUR Hub. M-h0 starts with shell/open only; later milestones add fs, dialog, autostart, etc.",
-  "windows": ["dashboard"],
+  "windows": [
+    "dashboard"
+  ],
   "permissions": [
     "core:default",
     "core:window:allow-set-size",
@@ -13,6 +15,7 @@
     "dialog:allow-save",
     "deep-link:default",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "notification:default"
   ]
 }

--- a/mur-hub-gui/src-tauri/src/companion_notify.rs
+++ b/mur-hub-gui/src-tauri/src/companion_notify.rs
@@ -1,0 +1,255 @@
+//! System notifications for companion inbox entries (#1125 follow-on).
+//!
+//! The agent writes `<agent_home>/companion/inbox/<id>.md` when a schedule
+//! fires. That makes the message *findable*; this makes it *arrive*.
+//!
+//! ## Why the Hub raises it and not the agent
+//!
+//! A MUR agent cannot post a macOS notification. Its `osascript` is refused by
+//! TCC, and the runtime's TCC identity is whichever terminal first launched it
+//! — a launchd-started agent has no bundle identity of its own to be granted.
+//! The Hub is a signed `.app` with its own identity, so the notification is
+//! raised from the one process that is allowed to.
+//!
+//! ## The gap this deliberately makes visible
+//!
+//! A notification only fires while the Hub is running. Anything that arrived
+//! while it was closed would otherwise be silently absorbed into "unread", so
+//! [`catch_up`] reports those separately on startup: a missed reminder should
+//! read as missed, not as one you have already seen.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+use tauri_plugin_notification::NotificationExt;
+
+/// Marker holding the ids the Hub has already raised a notification for.
+/// Lives beside the other Hub state rather than in an agent's home, because it
+/// records what *this machine's Hub* has shown, not anything about the agent.
+fn seen_path(mur_home: &Path) -> PathBuf {
+    mur_home.join("hub").join("notified-inbox-ids")
+}
+
+fn load_seen(mur_home: &Path) -> HashSet<String> {
+    std::fs::read_to_string(seen_path(mur_home))
+        .map(|s| s.lines().map(|l| l.trim().to_string()).filter(|l| !l.is_empty()).collect())
+        .unwrap_or_default()
+}
+
+fn mark_seen(mur_home: &Path, id: &str) -> Result<()> {
+    let p = seen_path(mur_home);
+    if let Some(d) = p.parent() {
+        std::fs::create_dir_all(d)?;
+    }
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new().create(true).append(true).open(&p)?;
+    writeln!(f, "{id}").context("record a notified inbox id")
+}
+
+/// One inbox entry, reduced to what a notification needs.
+pub struct InboxEntry {
+    pub id: String,
+    pub agent: String,
+    pub situation: String,
+    pub body: String,
+}
+
+/// Parse the front matter `inbox::render` writes. Returns `None` for a file
+/// that does not look like one of ours rather than guessing at its shape.
+fn parse_entry(agent: &str, path: &Path) -> Option<InboxEntry> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let rest = raw.strip_prefix("---\n")?;
+    let (front, body) = rest.split_once("\n---\n")?;
+    let field = |k: &str| -> Option<String> {
+        front
+            .lines()
+            .find_map(|l| l.strip_prefix(&format!("{k}: ")))
+            .map(|v| v.trim().to_string())
+    };
+    Some(InboxEntry {
+        id: field("id")?,
+        agent: agent.to_string(),
+        situation: field("situation").unwrap_or_default(),
+        body: body.trim().trim_end_matches(">>> response: <unset>").trim().to_string(),
+    })
+}
+
+/// Every agent's inbox directory that exists right now.
+fn inbox_dirs(mur_home: &Path) -> Vec<(String, PathBuf)> {
+    let agents = mur_home.join("agents");
+    let Ok(rd) = std::fs::read_dir(&agents) else {
+        return Vec::new();
+    };
+    rd.flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let dir = e.path().join("companion/inbox");
+            dir.is_dir().then_some((name, dir))
+        })
+        .collect()
+}
+
+/// Raise one notification and record that it was raised.
+///
+/// Best-effort: a notification that cannot be shown must not stop the next one,
+/// and must not mark itself seen — otherwise a transient failure would silently
+/// consume the message.
+fn raise(app: &AppHandle, mur_home: &Path, e: &InboxEntry, missed: bool) {
+    let title = if missed {
+        format!("{} — while MUR Hub was closed", e.agent)
+    } else {
+        e.agent.clone()
+    };
+    match app
+        .notification()
+        .builder()
+        .title(title)
+        .body(&e.body)
+        .show()
+    {
+        Ok(()) => {
+            if let Err(err) = mark_seen(mur_home, &e.id) {
+                tracing::warn!("notified {} but could not record it: {err:#}", e.id);
+            }
+        }
+        Err(err) => tracing::warn!("could not show notification for {}: {err:#}", e.id),
+    }
+}
+
+/// Notify for everything that arrived while the Hub was not running.
+///
+/// Labelled as missed rather than shown as ordinary new mail. A reminder you
+/// were never told about at the time is a different fact from one you have just
+/// been told, and collapsing the two is how a delivery gap stays invisible.
+pub fn catch_up(app: &AppHandle, mur_home: &Path) -> usize {
+    let seen = load_seen(mur_home);
+    let mut n = 0;
+    for (agent, dir) in inbox_dirs(mur_home) {
+        let Ok(rd) = std::fs::read_dir(&dir) else { continue };
+        let mut entries: Vec<_> = rd
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+            .filter_map(|e| parse_entry(&agent, &e.path()))
+            .filter(|e| !seen.contains(&e.id))
+            .collect();
+        // Oldest first, so a burst reads in the order it happened.
+        entries.sort_by(|a, b| a.id.cmp(&b.id));
+        for e in entries {
+            raise(app, mur_home, &e, true);
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Watch every agent's inbox and notify as entries appear.
+///
+/// One watcher per agent rather than a single recursive watch on `agents/`:
+/// that tree churns constantly (locks, logs, telemetry) and on Linux inotify
+/// would take a descriptor per subdirectory. An agent created after the Hub
+/// started is picked up at the next Hub start — which is also when `catch_up`
+/// would report anything it missed, so nothing is lost, only delayed.
+pub fn watch_inboxes(
+    app: AppHandle,
+    mur_home: &Path,
+) -> Result<Vec<notify::RecommendedWatcher>> {
+    let mut watchers = Vec::new();
+    for (agent, dir) in inbox_dirs(mur_home) {
+        let app = app.clone();
+        let home = mur_home.to_path_buf();
+        let who = agent.clone();
+        let mut w = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            let Ok(ev) = res else { return };
+            let seen = load_seen(&home);
+            for p in ev.paths.iter().filter(|p| p.extension().is_some_and(|x| x == "md")) {
+                if let Some(e) = parse_entry(&who, p)
+                    && !seen.contains(&e.id)
+                {
+                    raise(&app, &home, &e, false);
+                }
+            }
+        })
+        .with_context(|| format!("create inbox watcher for {agent}"))?;
+        notify::Watcher::watch(&mut w, &dir, notify::RecursiveMode::NonRecursive)
+            .with_context(|| format!("watch inbox for {agent}"))?;
+        watchers.push(w);
+    }
+    Ok(watchers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_agent_runtime::companion::inbox::write_inbox_md;
+    use mur_agent_runtime::companion::notifier::CompanionMessage;
+    use mur_common::companion::Situation;
+
+    fn written(dir: &Path, id: &str, body: &str) -> PathBuf {
+        let msg = CompanionMessage {
+            id: id.to_string(),
+            situation: Situation::Scheduled,
+            template_id: "scheduled".into(),
+            locale: "zh-TW".into(),
+            body: body.to_string(),
+            generated_at: chrono::Utc::now(),
+        };
+        write_inbox_md(dir, &msg).unwrap()
+    }
+
+    /// The writer lives in `mur-agent-runtime` and the reader here; nothing
+    /// else connects the two. Parsing a hand-written fixture would keep passing
+    /// after the real format drifted, so this round-trips through the actual
+    /// writer.
+    #[test]
+    fn an_entry_the_runtime_wrote_parses_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = written(tmp.path(), "task-abc", "該吃早餐了 🥐");
+        let e = parse_entry("mur", &p).expect("the real writer's output must parse");
+        assert_eq!(e.id, "task-abc");
+        assert_eq!(e.agent, "mur");
+        assert_eq!(e.situation, "scheduled");
+        assert_eq!(
+            e.body, "該吃早餐了 🥐",
+            "the response placeholder must not reach the notification body"
+        );
+    }
+
+    /// A file that is not ours yields `None` rather than a notification built
+    /// from guesses.
+    #[test]
+    fn a_file_that_is_not_ours_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("stray.md");
+        std::fs::write(&p, "# just a markdown file\n\nno front matter here").unwrap();
+        assert!(parse_entry("mur", &p).is_none());
+    }
+
+    /// Only ids that were actually notified are recorded, and `catch_up` skips
+    /// them next time. Without this a restart re-announces every reminder the
+    /// user has already seen.
+    #[test]
+    fn a_recorded_id_is_not_offered_again() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        assert!(load_seen(home).is_empty());
+        mark_seen(home, "task-abc").unwrap();
+        mark_seen(home, "task-def").unwrap();
+        let seen = load_seen(home);
+        assert!(seen.contains("task-abc") && seen.contains("task-def"));
+        assert_eq!(seen.len(), 2, "the marker must not accumulate blank lines");
+    }
+
+    /// Inbox discovery finds an agent's directory and ignores an agent that has
+    /// never had one.
+    #[test]
+    fn only_agents_with_an_inbox_are_watched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(agents.join("has-one/companion/inbox")).unwrap();
+        std::fs::create_dir_all(agents.join("has-none")).unwrap();
+        let found: Vec<_> = inbox_dirs(tmp.path()).into_iter().map(|(a, _)| a).collect();
+        assert_eq!(found, vec!["has-one".to_string()]);
+    }
+}

--- a/mur-hub-gui/src-tauri/src/companion_notify.rs
+++ b/mur-hub-gui/src-tauri/src/companion_notify.rs
@@ -34,7 +34,12 @@ fn seen_path(mur_home: &Path) -> PathBuf {
 
 fn load_seen(mur_home: &Path) -> HashSet<String> {
     std::fs::read_to_string(seen_path(mur_home))
-        .map(|s| s.lines().map(|l| l.trim().to_string()).filter(|l| !l.is_empty()).collect())
+        .map(|s| {
+            s.lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -44,7 +49,10 @@ fn mark_seen(mur_home: &Path, id: &str) -> Result<()> {
         std::fs::create_dir_all(d)?;
     }
     use std::io::Write;
-    let mut f = std::fs::OpenOptions::new().create(true).append(true).open(&p)?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&p)?;
     writeln!(f, "{id}").context("record a notified inbox id")
 }
 
@@ -72,7 +80,11 @@ fn parse_entry(agent: &str, path: &Path) -> Option<InboxEntry> {
         id: field("id")?,
         agent: agent.to_string(),
         situation: field("situation").unwrap_or_default(),
-        body: body.trim().trim_end_matches(">>> response: <unset>").trim().to_string(),
+        body: body
+            .trim()
+            .trim_end_matches(">>> response: <unset>")
+            .trim()
+            .to_string(),
     })
 }
 
@@ -127,7 +139,9 @@ pub fn catch_up(app: &AppHandle, mur_home: &Path) -> usize {
     let seen = load_seen(mur_home);
     let mut n = 0;
     for (agent, dir) in inbox_dirs(mur_home) {
-        let Ok(rd) = std::fs::read_dir(&dir) else { continue };
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
         let mut entries: Vec<_> = rd
             .flatten()
             .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
@@ -151,10 +165,7 @@ pub fn catch_up(app: &AppHandle, mur_home: &Path) -> usize {
 /// would take a descriptor per subdirectory. An agent created after the Hub
 /// started is picked up at the next Hub start — which is also when `catch_up`
 /// would report anything it missed, so nothing is lost, only delayed.
-pub fn watch_inboxes(
-    app: AppHandle,
-    mur_home: &Path,
-) -> Result<Vec<notify::RecommendedWatcher>> {
+pub fn watch_inboxes(app: AppHandle, mur_home: &Path) -> Result<Vec<notify::RecommendedWatcher>> {
     let mut watchers = Vec::new();
     for (agent, dir) in inbox_dirs(mur_home) {
         let app = app.clone();
@@ -163,7 +174,11 @@ pub fn watch_inboxes(
         let mut w = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
             let Ok(ev) = res else { return };
             let seen = load_seen(&home);
-            for p in ev.paths.iter().filter(|p| p.extension().is_some_and(|x| x == "md")) {
+            for p in ev
+                .paths
+                .iter()
+                .filter(|p| p.extension().is_some_and(|x| x == "md"))
+            {
                 if let Some(e) = parse_entry(&who, p)
                     && !seen.contains(&e.id)
                 {

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod chat;
 pub mod chat_window;
 pub mod cli_tools;
 pub mod companion;
+pub mod companion_notify;
 pub mod dashboard;
 pub mod detail;
 pub mod export_muragent;
@@ -17,7 +18,6 @@ pub mod fleet;
 mod geometry;
 pub mod hitl;
 pub mod import_muragent;
-pub mod companion_notify;
 mod install_inbox;
 pub mod mcp_skills;
 pub mod memory;
@@ -603,7 +603,10 @@ pub fn run() {
                 // missed rather than absorbed into "unread" (#1125).
                 let missed = crate::companion_notify::catch_up(&app.handle().clone(), &home);
                 if missed > 0 {
-                    tracing::info!(missed, "companion inbox entries arrived while the Hub was closed");
+                    tracing::info!(
+                        missed,
+                        "companion inbox entries arrived while the Hub was closed"
+                    );
                 }
                 match crate::companion_notify::watch_inboxes(app.handle().clone(), &home) {
                     Ok(ws) => {

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -17,7 +17,8 @@ pub mod fleet;
 mod geometry;
 pub mod hitl;
 pub mod import_muragent;
-pub mod install_inbox;
+pub mod companion_notify;
+mod install_inbox;
 pub mod mcp_skills;
 pub mod memory;
 pub mod mlx_sidecar;
@@ -248,6 +249,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(
@@ -594,6 +596,22 @@ pub fn run() {
                         app.manage(std::sync::Mutex::new(Some(InstallInboxWatcher(watcher))));
                     }
                     Err(e) => tracing::warn!("install-inbox watcher failed to start: {e:#}"),
+                }
+
+                // Companion inbox → system notification. Catch up first, so a
+                // reminder that fired while the Hub was closed is reported as
+                // missed rather than absorbed into "unread" (#1125).
+                let missed = crate::companion_notify::catch_up(&app.handle().clone(), &home);
+                if missed > 0 {
+                    tracing::info!(missed, "companion inbox entries arrived while the Hub was closed");
+                }
+                match crate::companion_notify::watch_inboxes(app.handle().clone(), &home) {
+                    Ok(ws) => {
+                        #[allow(dead_code)] // held only to keep the watchers alive
+                        struct CompanionInboxWatchers(Vec<notify::RecommendedWatcher>);
+                        app.manage(std::sync::Mutex::new(Some(CompanionInboxWatchers(ws))));
+                    }
+                    Err(e) => tracing::warn!("companion inbox watchers failed to start: {e:#}"),
                 }
             }
 


### PR DESCRIPTION
#1127 made a fired schedule's reply findable (a channel). #1131 put it where you are already looking (the Hub Inbox). Both still wait for you to look. This one interrupts you, which is what a reminder is for.

## The Hub raises it because the agent cannot

Not a preference. A MUR agent's `osascript` is refused by TCC, and the runtime's TCC identity is **whichever terminal first launched it** — a launchd-started agent has no bundle identity of its own to be granted. The Hub is a signed `.app` with its own identity, and it was already reading `<agent_home>/companion/inbox`.

Cross-platform falls out of this rather than being ported: `tauri-plugin-notification` covers macOS, Linux and Windows, and the agent side stays a plain file write.

## The gap this makes visible instead of hiding

A notification only fires while the Hub is running. Anything that arrived while it was closed would otherwise be quietly absorbed into "unread", so `catch_up` raises those on startup under a distinct title — *"<agent> — while MUR Hub was closed"*.

A reminder you were never told about at the time is a different fact from one you have just been told. Collapsing the two is precisely how a delivery gap stays invisible, which is the failure #1125 was filed for.

A failed notification does **not** mark the id seen: a transient failure must not silently consume the message.

## One watcher per inbox

Rather than a recursive watch on `agents/`. That tree churns constantly (locks, logs, telemetry) and Linux inotify would take a descriptor per subdirectory. An agent created after the Hub started is picked up at the next start — which is also when `catch_up` reports anything it missed, so nothing is lost, only delayed. Stated in the module doc rather than left for someone to rediscover.

## The test round-trips through the real writer

The format is written by `inbox::render` in `mur-agent-runtime` and read by `parse_entry` here. **Nothing else connects the two crates** — no shared type, no schema. A hand-written fixture would keep passing after the real format drifted, with the symptom being blank or mangled notifications and no red test anywhere.

So the test calls the actual `write_inbox_md` and parses its output back. It also pins that `>>> response: <unset>` never reaches the notification body.

Three more: a file that is not ours yields `None` rather than a notification assembled from guesses; a recorded id is not offered again (so a restart does not re-announce everything you have seen); only agents that actually have an inbox are watched.

## Verification

`cargo check --all-targets` and `cargo clippy --all-targets -- -D warnings` both exit 0. `test result: ok. 4 passed`.

## Known limit

macOS requires the user to authorise notifications once. Until that is granted, `show()` can succeed while nothing appears on screen — so post-deploy verification of this path will say "could not confirm" rather than claiming success, unless a notification is actually observed.