### PR TITLE
feat(llm): one table owns which reasoning levels a model takes

### DIFF
--- a/mur-agent-runtime/src/llm/ollama.rs
+++ b/mur-agent-runtime/src/llm/ollama.rs
@@ -59,6 +59,39 @@ impl OllamaClient {
     }
 }
 
+/// The value for Ollama's top-level `think` field, or `None` to omit it.
+///
+/// Ollama accepts `low | medium | high | max` as well as a boolean, and detects
+/// reasoning support from the model's GGUF metadata — so a level sent to a
+/// model without it is ignored rather than rejected. We still gate on
+/// [`mur_common::llm::effort_shape`] so behavior matches every other client: a
+/// model MUR knows takes no reasoning control is not sent one, and an
+/// `AlwaysOn` model is never sent a value anywhere.
+///
+/// This client previously read `message.thinking` off responses while never
+/// sending `think` at all, so local models had no effort control on a runtime
+/// that supports one.
+fn ollama_think(model: &str, want: Option<mur_common::llm::Effort>) -> Option<&'static str> {
+    use mur_common::llm::Effort;
+    let want = want?;
+    let levels = mur_common::llm::effort_shape(model).levels();
+    if levels.is_empty() {
+        return None;
+    }
+    let level = if levels.contains(&want) {
+        want
+    } else {
+        levels.iter().rev().find(|l| **l < want).copied()?
+    };
+    Some(match level {
+        Effort::Low => "low",
+        Effort::Medium => "medium",
+        Effort::High => "high",
+        // Ollama's top scale ends at `max`; xhigh has no separate step.
+        Effort::Xhigh | Effort::Max => "max",
+    })
+}
+
 #[async_trait]
 impl LlmClient for OllamaClient {
     fn model_name(&self) -> &str {
@@ -69,6 +102,9 @@ impl LlmClient for OllamaClient {
         let url = format!("{}/api/chat", self.base_url);
         let messages = to_ollama_messages(&req.messages);
         let mut body = json!({"model": self.model, "messages": messages, "stream": false});
+        if let Some(think) = ollama_think(&self.model, req.effort) {
+            body["think"] = json!(think);
+        }
         if let Some(t) = req.temperature {
             body["options"]["temperature"] = json!(t);
         }
@@ -124,6 +160,9 @@ impl LlmClient for OllamaClient {
         let url = format!("{}/api/chat", self.base_url);
         let messages = to_ollama_messages(&req.messages);
         let mut body = json!({"model": self.model, "messages": messages, "stream": true});
+        if let Some(think) = ollama_think(&self.model, req.effort) {
+            body["think"] = json!(think);
+        }
         if let Some(t) = req.temperature {
             body["options"]["temperature"] = json!(t);
         }
@@ -218,6 +257,23 @@ impl LlmClient for OllamaClient {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn think_is_sent_only_for_models_that_take_it() {
+        use mur_common::llm::{Effort, EffortShape, effort_shape};
+        // A local model with a level set gets the level name Ollama documents.
+        assert_eq!(
+            super::ollama_think("qwen3-32b", Some(Effort::High)),
+            Some("high")
+        );
+        // A model MUR knows has no reasoning control is not sent one.
+        assert!(super::ollama_think("llama3.2:3b", Some(Effort::High)).is_none());
+        // No effort requested: send nothing.
+        assert_eq!(super::ollama_think("qwen3-32b", None), None);
+        // AlwaysOn must never be sent a value, on any transport.
+        assert!(matches!(effort_shape("magistral"), EffortShape::AlwaysOn));
+        assert!(super::ollama_think("magistral", Some(Effort::Max)).is_none());
+    }
+
     use super::*;
 
     #[test]

--- a/mur-common/src/llm.rs
+++ b/mur-common/src/llm.rs
@@ -292,31 +292,31 @@ pub fn effort_shape(model: &str) -> EffortShape {
 /// list, one place to edit when a model ships, rather than a literal model ID
 /// buried in a conditional that goes stale on the next release.
 pub fn supported_effort(model: &str, want: Effort) -> Option<Effort> {
-    /// Accept every level including `xhigh` (Opus 4.7 and later lines).
-    const FULL_SCALE: &[&str] = &[
-        "claude-opus-5",
-        "claude-opus-4-8",
-        "claude-opus-4-7",
-        "claude-sonnet-5",
-        "claude-fable-5",
-        "claude-mythos-5",
-    ];
-    /// Accept effort but have no `xhigh` step.
-    const NO_XHIGH: &[&str] = &["claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5"];
+    /// This mapper is Anthropic's. [`effort_shape`] is vendor-neutral — it
+    /// answers "which levels", never "whose client is this" — so the vendor
+    /// gate stays here, symmetric with `openai_reasoning_effort`'s family
+    /// gate. Without it a delegated `supported_effort` starts claiming
+    /// `gpt-5`, which an existing test caught immediately.
+    const ANTHROPIC: &str = "claude-";
 
     let m = model.to_lowercase();
-    if FULL_SCALE.iter().any(|p| m.starts_with(p)) {
+    let bare = m.rsplit('/').next().unwrap_or(&m);
+    if !bare.starts_with(ANTHROPIC) {
+        return None;
+    }
+    let levels = match effort_shape(model) {
+        EffortShape::Graded(l) => l,
+        // Anthropic is Graded or nothing. Budget/Binary models never reach this
+        // client, and AlwaysOn must be sent nothing anywhere.
+        _ => return None,
+    };
+    if levels.contains(&want) {
         return Some(want);
     }
-    if NO_XHIGH.iter().any(|p| m.starts_with(p)) {
-        return Some(match want {
-            Effort::Xhigh => Effort::High,
-            other => other,
-        });
-    }
-    // Everything else — older Claude models, and any non-Anthropic model that
-    // reaches this path — takes no effort parameter.
-    None
+    // Degrade to the most expensive level this model DOES accept rather than
+    // send one it will 400 on. `levels` is a subset, not a prefix, so this
+    // steps over holes (pre-4.7 Anthropic has `max` but no `xhigh`).
+    levels.iter().rev().find(|l| **l < want).copied()
 }
 
 /// The `reasoning_effort` value to send for an OpenAI-compatible model, or
@@ -351,6 +351,11 @@ pub fn openai_reasoning_effort(model: &str, want: Effort) -> Option<&'static str
     if !REASONING_FAMILIES.iter().any(|f| bare.starts_with(f)) {
         return None;
     }
+    // Second gate: the table is the owner, so a family member the table has
+    // demoted (or that becomes AlwaysOn) stops being sent a value here too.
+    if !matches!(effort_shape(model), EffortShape::Graded(_)) {
+        return None;
+    }
     Some(match want {
         Effort::Low => "low",
         Effort::Medium => "medium",
@@ -361,6 +366,38 @@ pub fn openai_reasoning_effort(model: &str, want: Effort) -> Option<&'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Delegation must not change what the mappers return. This pins the exact
+    /// case a first draft of this plan got wrong: Anthropic's pre-4.7 lines keep
+    /// `max` and lack only `xhigh`, so a level set expressed as a ceiling
+    /// silently downgrades `max` to `high` here.
+    #[test]
+    fn delegation_preserves_the_hole_in_the_pre_4_7_scale() {
+        // The hole: xhigh absent, max present.
+        assert_eq!(
+            supported_effort("claude-opus-4-6", Effort::Xhigh),
+            Some(Effort::High)
+        );
+        assert_eq!(
+            supported_effort("claude-opus-4-6", Effort::Max),
+            Some(Effort::Max)
+        );
+        // The full scale is unaffected.
+        assert_eq!(
+            supported_effort("claude-opus-5", Effort::Xhigh),
+            Some(Effort::Xhigh)
+        );
+        // A model the table calls AlwaysOn must get nothing from either mapper,
+        // because sending it anything is a 422.
+        assert_eq!(
+            supported_effort("magistral-small-latest", Effort::High),
+            None
+        );
+        assert_eq!(
+            openai_reasoning_effort("magistral-small-latest", Effort::High),
+            None
+        );
+    }
 
     #[test]
     fn effort_shape_covers_each_vendor_tier() {

--- a/mur-common/src/llm.rs
+++ b/mur-common/src/llm.rs
@@ -277,6 +277,52 @@ pub fn effort_shape(model: &str) -> EffortShape {
     EffortShape::None
 }
 
+/// Where the effort in force came from, so a surface can say so instead of
+/// showing a bare level the user cannot account for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffortSource {
+    /// Set for this conversation only (murmur `/effort`).
+    SessionOverride,
+    /// Stored on the agent profile.
+    Profile,
+    /// Nothing set — the provider's own default applies. Note that is not
+    /// "no effort": the API default is high.
+    Unset,
+}
+
+/// The effort actually in force for `model`, and where it came from.
+///
+/// The ONLY derivation of this. murmur and the Hub both call it; neither
+/// computes its own, because two surfaces answering one question differently
+/// is a failure this codebase has already shipped twice.
+///
+/// A stored level the model cannot accept is narrowed to the nearest level it
+/// can, and the source is preserved — the user did set it; they are simply
+/// getting the closest thing that will not 400.
+pub fn effective_effort(
+    session: Option<Effort>,
+    profile: Option<Effort>,
+    model: &str,
+) -> (Option<Effort>, EffortSource) {
+    let (want, source) = match (session, profile) {
+        (Some(e), _) => (e, EffortSource::SessionOverride),
+        (None, Some(e)) => (e, EffortSource::Profile),
+        (None, None) => return (None, EffortSource::Unset),
+    };
+    let levels = effort_shape(model).levels();
+    if levels.is_empty() {
+        return (None, EffortSource::Unset);
+    }
+    if levels.contains(&want) {
+        return (Some(want), source);
+    }
+    match levels.iter().rev().find(|l| **l < want).copied() {
+        Some(narrowed) => (Some(narrowed), source),
+        // `want` is below every level this model offers; take its cheapest.
+        None => (levels.first().copied(), source),
+    }
+}
+
 /// The effort level to actually send for `model`, or `None` when the model
 /// takes no effort parameter at all.
 ///
@@ -366,6 +412,35 @@ pub fn openai_reasoning_effort(model: &str, want: Effort) -> Option<&'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn effective_effort_reports_value_and_where_it_came_from() {
+        use EffortSource::*;
+        // Session beats profile.
+        assert_eq!(
+            effective_effort(Some(Effort::Low), Some(Effort::Max), "claude-opus-5"),
+            (Some(Effort::Low), SessionOverride)
+        );
+        // Profile when there is no session override.
+        assert_eq!(
+            effective_effort(None, Some(Effort::Max), "claude-opus-5"),
+            (Some(Effort::Max), Profile)
+        );
+        // Neither set.
+        assert_eq!(effective_effort(None, None, "claude-opus-5"), (None, Unset));
+        // A value the model cannot take is narrowed, and the SOURCE is
+        // preserved: the user still set it, they just get the nearest level
+        // that works. DeepSeek V4 has no medium step.
+        assert_eq!(
+            effective_effort(None, Some(Effort::Medium), "deepseek-v4-pro"),
+            (Some(Effort::Low), Profile)
+        );
+        // A model with no control reports nothing regardless of what is stored.
+        assert_eq!(
+            effective_effort(Some(Effort::Max), Some(Effort::Max), "gpt-4o"),
+            (None, Unset)
+        );
+    }
 
     /// Delegation must not change what the mappers return. This pins the exact
     /// case a first draft of this plan got wrong: Anthropic's pre-4.7 lines keep

--- a/mur-common/src/llm.rs
+++ b/mur-common/src/llm.rs
@@ -128,6 +128,155 @@ impl std::str::FromStr for Effort {
     }
 }
 
+/// What form of reasoning control a model accepts.
+///
+/// Provider controls do not share a shape, and three of these cannot be
+/// expressed by a level-to-string table:
+///
+/// * [`EffortShape::AlwaysOn`] is not [`EffortShape::None`]. Mistral's
+///   Magistral models always reason and reject `reasoning_effort` with HTTP
+///   422 — a hard failure, not a degradation. `None` means "passing nothing is
+///   correct"; `AlwaysOn` means "passing anything breaks every call".
+/// * [`EffortShape::Binary`] is not a degenerate `Graded`. Qwen and GLM have a
+///   switch, not a dial, and spell it differently (`chat_template_kwargs`
+///   versus `thinking: {type}`). Two other agent products shipped that exact
+///   confusion.
+/// * [`EffortShape::Budget`] takes an integer on the wire but still carries a
+///   level list, because the user and both UIs deal in levels — only the
+///   client converts, at the last possible moment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffortShape {
+    /// Levels this model accepts, cheapest first.
+    Graded(&'static [Effort]),
+    /// Thinking is a switch; `on_at` is the lowest level that turns it on.
+    Binary { on_at: Effort },
+    /// Wants an integer token budget; these are the levels to offer.
+    Budget(&'static [Effort]),
+    /// Always reasons and rejects the parameter. Send nothing.
+    AlwaysOn,
+    /// No reasoning control.
+    None,
+}
+
+/// A level set is an arbitrary SUBSET of [`Effort::ALL`], not a prefix of it.
+/// Two tiers below have holes: Anthropic's pre-4.7 lines have `max` but no
+/// `xhigh` (that step was inserted between them in 4.7), and DeepSeek V4
+/// publishes low/high/max with no medium. Naming these by a ceiling —
+/// `LEVELS_TO_HIGH` and the like — is what produced a first draft that silently
+/// downgraded `max` to `high` on Opus 4.6. Name the membership, not a bound.
+const LEVELS_ALL: &[Effort] = &[
+    Effort::Low,
+    Effort::Medium,
+    Effort::High,
+    Effort::Xhigh,
+    Effort::Max,
+];
+/// Anthropic before 4.7: the whole scale except the `xhigh` step.
+const LEVELS_NO_XHIGH: &[Effort] = &[Effort::Low, Effort::Medium, Effort::High, Effort::Max];
+const LEVELS_LMHX: &[Effort] = &[Effort::Low, Effort::Medium, Effort::High, Effort::Xhigh];
+const LEVELS_LMH: &[Effort] = &[Effort::Low, Effort::Medium, Effort::High];
+/// DeepSeek V4 publishes low / high / max — there is no medium step.
+const LEVELS_DEEPSEEK: &[Effort] = &[Effort::Low, Effort::High, Effort::Max];
+/// A switch has two positions and must offer two, not three that collapse to
+/// two. `Low` is off, `High` is on; the threshold lives in `Binary::on_at`.
+const LEVELS_BINARY: &[Effort] = &[Effort::Low, Effort::High];
+
+impl EffortShape {
+    /// The levels a UI should offer. Empty for the two shapes that take no
+    /// level from the user.
+    pub fn levels(&self) -> &'static [Effort] {
+        match self {
+            EffortShape::Graded(l) | EffortShape::Budget(l) => l,
+            EffortShape::Binary { .. } => LEVELS_BINARY,
+            EffortShape::AlwaysOn | EffortShape::None => &[],
+        }
+    }
+}
+
+/// Which reasoning control `model` accepts.
+///
+/// Keyed on the model id with any `vendor/` prefix stripped, never on the
+/// registry's `provider:` field — that records the wire protocol, so DeepSeek,
+/// Qwen and every other OpenAI-compatible third party all read `openai`.
+///
+/// Capability is version-scoped, not family-scoped: grok-4.3, 4.5 and 4.6 each
+/// accept a different set, exactly as the Claude 4-5 / 4-6 / 4-7 / 5 lines do.
+/// Named const lists per tier, so a new model is one edit in one place.
+///
+/// Vendor levels below `Low` (`none`, `minimal`) are deliberately dropped:
+/// MUR's scale starts at `Low`, and a level MUR cannot name is a level MUR
+/// does not offer. Nothing is mis-sent.
+pub fn effort_shape(model: &str) -> EffortShape {
+    /// Anthropic lines with the `xhigh` step (Opus 4.7 and later).
+    const ANTHROPIC_FULL: &[&str] = &[
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    ];
+    /// Anthropic lines that take effort but have no `xhigh` step.
+    const ANTHROPIC_NO_XHIGH: &[&str] =
+        &["claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5"];
+    /// OpenAI reasoning families. `xhigh`/`max` clamp to `high` at the wire.
+    const OPENAI_REASONING: &[&str] = &["gpt-5", "o1", "o3", "o4"];
+    /// DeepSeek V4 thinking effort.
+    const DEEPSEEK_GRADED: &[&str] = &["deepseek-v4"];
+    /// Grok lines that added the `xhigh` step.
+    const GROK_XHIGH: &[&str] = &["grok-4.6", "grok-4.7"];
+    /// Grok lines with low/medium/high only.
+    const GROK_GRADED: &[&str] = &["grok-4.3", "grok-4.5"];
+    /// Gemini 3+ takes `thinkingConfig.thinkingLevel` — a level name.
+    const GEMINI_LEVEL: &[&str] = &["gemini-3"];
+    /// Gemini 2.5 takes `thinkingConfig.thinkingBudget` — an integer.
+    const GEMINI_BUDGET: &[&str] = &["gemini-2.5"];
+    /// Mistral hybrids where `reasoning_effort` enables reasoning.
+    const MISTRAL_GRADED: &[&str] = &["mistral-small-3", "mistral-small-4"];
+    /// Dedicated reasoning models that REJECT the parameter with HTTP 422.
+    const ALWAYS_ON: &[&str] = &["magistral"];
+    /// Models whose only control is an on/off switch.
+    const BINARY: &[&str] = &["qwen3", "glm-"];
+
+    let m = model.to_lowercase();
+    let bare = m.rsplit('/').next().unwrap_or(&m);
+    let has = |prefixes: &[&str]| prefixes.iter().any(|p| bare.starts_with(p));
+
+    // AlwaysOn is checked first: sending anything to these is a hard error, so
+    // no later arm may claim them.
+    if has(ALWAYS_ON) {
+        return EffortShape::AlwaysOn;
+    }
+    if has(ANTHROPIC_FULL) {
+        return EffortShape::Graded(LEVELS_ALL);
+    }
+    // Anthropic pre-4.7 keeps `max`; it is only the `xhigh` step it lacks.
+    if has(ANTHROPIC_NO_XHIGH) {
+        return EffortShape::Graded(LEVELS_NO_XHIGH);
+    }
+    if has(OPENAI_REASONING) || has(GROK_GRADED) {
+        return EffortShape::Graded(LEVELS_LMH);
+    }
+    if has(GROK_XHIGH) {
+        return EffortShape::Graded(LEVELS_LMHX);
+    }
+    if has(DEEPSEEK_GRADED) {
+        return EffortShape::Graded(LEVELS_DEEPSEEK);
+    }
+    if has(GEMINI_LEVEL) || has(MISTRAL_GRADED) {
+        return EffortShape::Graded(LEVELS_LMH);
+    }
+    if has(GEMINI_BUDGET) {
+        return EffortShape::Budget(LEVELS_LMH);
+    }
+    if has(BINARY) {
+        return EffortShape::Binary {
+            on_at: Effort::Medium,
+        };
+    }
+    EffortShape::None
+}
+
 /// The effort level to actually send for `model`, or `None` when the model
 /// takes no effort parameter at all.
 ///
@@ -212,6 +361,61 @@ pub fn openai_reasoning_effort(model: &str, want: Effort) -> Option<&'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn effort_shape_covers_each_vendor_tier() {
+        use EffortShape::*;
+        assert!(matches!(effort_shape("claude-opus-5"), Graded(l) if l.len() == 5));
+        // Four, not three: 4.6 keeps `max` and lacks only the `xhigh` step that
+        // 4.7 inserted between them. A level set is a subset, not a prefix.
+        assert!(matches!(effort_shape("claude-opus-4-6"), Graded(l) if l.len() == 4));
+        assert!(matches!(effort_shape("claude-opus-4-6"), Graded(l) if l.contains(&Effort::Max)));
+        assert!(
+            matches!(effort_shape("claude-opus-4-6"), Graded(l) if !l.contains(&Effort::Xhigh))
+        );
+        assert!(matches!(effort_shape("gpt-5"), Graded(_)));
+        assert!(matches!(effort_shape("grok-4.6"), Graded(l) if l.contains(&Effort::Xhigh)));
+        assert!(matches!(effort_shape("grok-4.5"), Graded(l) if !l.contains(&Effort::Xhigh)));
+        assert!(matches!(effort_shape("gemini-3-pro"), Graded(_)));
+        assert!(matches!(effort_shape("gemini-2.5-pro"), Budget(_)));
+        assert!(matches!(effort_shape("qwen3-32b"), Binary { .. }));
+        // A switch offers exactly two positions, never three that collapse to two.
+        assert_eq!(effort_shape("qwen3-32b").levels().len(), 2);
+        assert!(matches!(effort_shape("glm-4.6"), Binary { .. }));
+        assert!(matches!(effort_shape("magistral-medium-latest"), AlwaysOn));
+        assert!(matches!(effort_shape("gpt-4o"), None));
+        assert!(matches!(effort_shape("llama3.2:3b"), None));
+    }
+
+    /// The three cases the design turns on. Each must fail if its guard is removed.
+    #[test]
+    fn effort_shape_negative_cases() {
+        use EffortShape::*;
+        // 1. DeepSeek V4 has low/high/max and NO medium. Offering medium is a 400.
+        let EffortShape::Graded(levels) = effort_shape("deepseek-v4-pro") else {
+            panic!("deepseek-v4-pro must be Graded");
+        };
+        assert!(
+            !levels.contains(&Effort::Medium),
+            "deepseek has no medium: {levels:?}"
+        );
+        assert_eq!(levels, &[Effort::Low, Effort::High, Effort::Max]);
+
+        // 2. A vendor prefix must be stripped before matching, and a Google model
+        //    must never match an OpenAI family prefix.
+        assert!(matches!(effort_shape("openai/gpt-5"), Graded(_)));
+        assert!(matches!(effort_shape("google/gemini-3.6-flash"), Graded(_)));
+        assert!(!matches!(
+            effort_shape("google/gemini-2.5-flash"),
+            Graded(_)
+        ));
+
+        // 3. Magistral REJECTS the parameter (HTTP 422). AlwaysOn is not None:
+        //    None means "send nothing and that is correct", AlwaysOn means
+        //    "send nothing or every call fails".
+        assert!(matches!(effort_shape("magistral-small-latest"), AlwaysOn));
+        assert!(effort_shape("magistral-small-latest").levels().is_empty());
+    }
 
     #[test]
     fn supported_effort_narrows_per_model_capability() {


### PR DESCRIPTION
Phase 1 of the plan in #1129. Two files, no new surfaces — the `/effort` slash command and the Hub control come later, against signatures this PR creates rather than predicted ones.

Design: `docs/superpowers/specs/2026-09-01-murmur-effort-design.md`
Plan: `docs/superpowers/plans/2026-09-01-murmur-effort.md` (both in #1129)

## What this fixes today, before any UI exists

`mur agent effort` has existed for a while and the runtime applies it per call — but the mapping from MUR's scale to a provider's wire parameter covered exactly **two** vendors. Everything else silently discarded the setting.

- Grok, Gemini, DeepSeek V4 and Mistral users now get their effort mapped instead of dropped.
- **Ollama users get reasoning control at all.** That client read `message.thinking` off responses and never sent the `think` parameter, on a runtime that supports one.

## Five shapes, because provider controls do not share one

Three cannot be expressed by a level→string table, which is why this is an enum:

| Shape | Why it needs its own case |
|---|---|
| `AlwaysOn` | Magistral **rejects** the parameter with HTTP 422. A hard failure, not a degradation — and no cell in a mapping table says *send nothing*. |
| `Binary` | Qwen and GLM have a switch, not a dial, and spell it differently. Pi (#2025) and OpenClaw (#97772) both shipped this exact confusion. |
| `Budget` | Gemini 2.5 takes an integer where Gemini 3 takes a name. Same vendor, different parameter across generations. |

## Level sets are subsets, not prefixes

The most useful thing this PR learned. **Two of the eight tiers have holes:**

- Anthropic before 4.7 has `max` but **no** `xhigh` — that step was *inserted between them* in 4.7, so 4.6 is a set with a gap, not a scale with a ceiling.
- DeepSeek V4 publishes low/high/max with **no medium**.

A first draft named the constants for a ceiling (`LEVELS_TO_HIGH`), which silently downgraded `max` to `high` on Opus 4.6 and broke an existing assertion in the file. The constants are now named for their membership, and the doc comment says why — the ceiling name is what produced the error, so it is the thing worth warning the next reader about.

## An existing test caught a real refactor error

`effort_shape` is vendor-**neutral**: it answers "which levels", never "whose client is this". A naive delegation made the Anthropic mapper start claiming `gpt-5` and broke `assert_eq!(supported_effort("gpt-5", Effort::Low), None)`. Each mapper keeps its own vendor gate; the table owns levels only.

## Verification

- `cargo nextest run --workspace` — **8053 passed, 0 failed**, 30 skipped
- `cargo clippy -p mur-common -p mur-agent-runtime --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- The pre-4.7 guard was mutation-tested **after** the delegation landed (it cannot fail before it): removing `Max` from `LEVELS_NO_XHIGH` produces `left: Some(High), right: Some(Max)`, the exact silent downgrade it exists to catch.

`body["think"]` appears **twice** on purpose — both Ollama request builders. Patching only the non-streaming one would leave effort applying to some turns and not others, which reads as intermittent model behavior rather than a missed edit.

## Review focus

The vendor table is the part most likely to be wrong or to age, and where being wrong is a 400 or a 422 in someone's face. Every tier is sourced from vendor documentation read on 2026-09-01, but read it skeptically — none of it was exercised against a live endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
