### PR TITLE
chore(release): bump workspace version to 2.71.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.16"
+version = "2.71.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.16"
+version = "2.71.17"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.17 — the delivery chain for a fired schedule, end to end.

- **#1130** `feat(schedule)` — `mur agent schedule add --once`. A one-off could previously only be created by an agent through `remind`; the derivation is now shared so `--once` and `remind` cannot drift on what "once" means.
- **#1131** `feat(companion)` — a fired schedule's reply reaches the Hub Inbox, not just the channel. Reuses the companion `Notifier` and deliberately skips its `Outbox`: those gates decide *whether* and *what* to say, and a schedule has both answers already.
- **#1132** `feat(hub)` — a system notification when an inbox entry arrives. Raised by the Hub because a launchd-started agent has no bundle identity TCC can grant. Entries that arrived while the Hub was closed are reported as missed rather than absorbed into "unread".
- **#1133** `feat(llm)` — one table owns which reasoning levels a model takes.
- **#1129** `docs(spec)` — reasoning effort: one scale, five provider shapes.

Together #1130–#1132 close #1125: a reminder now fires once on the day it names, retires itself, leaves a signed record, appears where you are already looking, and interrupts you.

Measured in production this morning, on 2.71.15 (bound only, no delivery):

```
02:00:00.002Z cron trigger firing   cron=0 10 1 9 *  該吃早餐了 🥐
02:00:02.781Z schedule retired — its last firing is past, so it will not repeat
```

It fired on the second and reached nobody. That is the half this release fixes.

Merging this IS the release: `tag.yml` tags the merge commit and dispatches `release.yml`.