### PR TITLE
feat(murmur): /effort sets reasoning effort without leaving the conversation

### DIFF
--- a/docs/superpowers/plans/2026-09-01-murmur-effort.md
+++ b/docs/superpowers/plans/2026-09-01-murmur-effort.md
@@ -612,270 +612,99 @@ fn ollama_think(model: &str, want: Option<mur_common::llm::Effort>) -> Option<&'
 
 ---
 
-# Phase 2 — not yet executable
+# Phase 2a — specified 2026-09-01 against the merged Phase 1
 
-**Stop after Task 4.** Everything below describes behavior rather than showing
-code, which `mur-writing-plans` names as a plan failure, and this section is
-marked rather than pretended to be ready.
+The blocking note here said Tasks 5–8 described behavior instead of showing
+code and predicted signatures in files the plan had not read. Phase 1 is
+merged, the files are read, and Tasks 5–6 are rewritten below. **Tasks 7–8
+(the Hub) stay unspecified** and are Phase 2b.
 
-Three specific things are missing, and each one is a place where writing the
-step blind produces a wrong step:
+Reading the code made the design SMALLER, which is the whole reason the note
+existed.
 
-1. **Task 5 widens `TaskRunner`'s `effort` field to a shared cell.** The exact
-   edit depends on how the supervisor constructs the runner and on every other
-   caller of `with_effort` (there is at least one in `task_runner.rs`'s own
-   tests, around line 1962). That is a cross-file change in a 2800-line file;
-   it needs the real signatures in front of it.
-2. **Task 5 assumes `model_name` is in scope** at the `model/set` registration
-   in `supervisor.rs`. Never verified. The first draft of this plan invented a
-   filename the same way (`agent_detail.rs` for `detail.rs`), which is what
-   this note exists to prevent repeating.
-3. **Tasks 6 and 7** describe the murmur slash handling and the Hub Rust edits
-   in prose. Both need their insertion points read first.
+**What was predicted, and what is actually there:**
 
-**Phase 1 stands alone and is worth shipping alone.** After Task 4,
-`mur agent effort` maps correctly for Grok, Gemini, DeepSeek and Mistral users
-instead of silently discarding the setting, and Ollama users get reasoning
-control for the first time. The surfaces in Phase 2 are UX on top of a
-foundation that will then exist — and their signatures will be real rather than
-predicted.
+| Plan predicted | Tree |
+|---|---|
+| thread a `SessionEffort` cell from the supervisor | `build_dispatcher` already has `runner: &Arc<TaskRunner>`; every other handler takes `runner.clone()` |
+| `model_name` in scope at the `model/set` registration | not in scope — the model lives inside `backend: RunnerBackend` |
+| the handler narrows the level to what the model accepts | **the handler must not narrow at all** |
 
-Specify Phase 2 against the merged Phase 1, not against this draft.
+That last row is the real find. `supported_effort`'s own doc states the
+architecture: *"requests state the effort they want and this narrows it."*
+Narrowing already happens at the wire, in each client. A handler that narrowed
+too would be a second derivation of the same rule — the exact duplication this
+design exists to prevent.
 
-## Task 5 — `effort/set` A2A method
+So `effort/set` needs **no knowledge of the model at all**. It stores what was
+asked for. The murmur TUI, which already resolves the current model per turn,
+does its own display math with the `mur-common` functions Phase 1 shipped.
 
-**Interfaces**
+**Real signatures, verified in the tree:**
 
-Consumes: `Effort`, `effort_shape`, `EffortShape` (Task 1). Mirrors the
-existing `model/set` registration at `supervisor.rs:1065`.
+- `TaskRunner.effort: Option<Effort>` — field `task_runner.rs:225`, defaulted
+  `:339`, set by `with_effort` `:433`, read into `LlmRequest` at `:1164` and
+  `:1667`. Five sites, all in one file.
+- `TaskRunner` is used as `Arc<TaskRunner>`, so the cell is interior:
+  `RwLock<Option<Effort>>` on the struct, not an `Arc` threaded from outside.
+- `build_dispatcher(profile, runner, mur_home, notifier, pending_approvals,
+  identity, agent_name, key_version, model_switch, runtime_skills)` —
+  `supervisor.rs:994`.
+- `SlashCmd::Model` is handled at `cli/mod.rs:1951` using
+  `model_cmd::current_model_ref(&app.home, &app.agent)` and
+  `dial_method(&h, &ag, "model/set", json, DialMode::Auto)`.
+- `mur_core::cmd::agent::cmd_effort(name, Option<String>, bool)` already
+  persists to the profile — `--save` calls it rather than reimplementing it.
 
-Produces: A2A method `effort/set`, params `{"level": "<low|medium|high|xhigh|max>"}`,
-result `{"applied": "<level>", "narrowed": <bool>}`. Errors with
-`-32602` when the level does not parse and when the model takes no effort.
+## Tasks 5 and 6 — DONE, and not as drafted
 
-**Steps**
+Both are implemented. The drafted steps below were replaced, because reading
+the tree changed the design — see the Phase 2a section above for the three
+predictions that were wrong. Recording what was ACTUALLY built, since a plan
+that describes work nobody did is worse than no plan.
 
-- [ ] Create `mur-agent-runtime/src/protocol/methods/effort_set.rs` with:
+### Task 5 — `effort/set` (done)
 
-```rust
-//! `effort/set` — change the running agent's reasoning effort for this
-//! session, without a restart.
-//!
-//! Effort is a per-call parameter (`task_runner.rs`, `with_effort`), so unlike
-//! a model swap this needs no reconstruction: set the field and the next turn
-//! carries it. The value is deliberately NOT written to `profile.yaml` — the
-//! persistent form is `mur agent effort`, and murmur's `--save` calls that.
+- [x] `TaskRunner.effort` is now `RwLock<Option<Effort>>` — interior-mutable
+      because the runner is shared as `Arc<TaskRunner>` and `/effort` changes
+      it on a RUNNING agent. Five sites in one file: field, default,
+      `with_effort`, and the two `LlmRequest` reads, which became
+      `self.effort()`.
+- [x] `TaskRunner::effort()` / `set_effort()`. A poisoned lock reports `None`
+      rather than panicking: losing a session override costs a different
+      reasoning budget, panicking takes down a running agent mid-turn.
+- [x] `protocol/methods/effort_set.rs`. Holds `Arc<TaskRunner>` like every
+      other handler in `build_dispatcher` — no separate `SessionEffort` cell
+      threaded from the supervisor, which is what the draft predicted.
+- [x] **It does not narrow, and it does not know the model.** Narrowing
+      happens at the wire in each client; a second one here would be a second
+      derivation of one rule.
+- [x] It does not write `profile.yaml`. That is `mur agent effort`, which
+      `/effort --save` calls.
+- [x] Registered unconditionally, unlike `model/set`: there is no client to
+      rebuild and no agent shape that cannot accept a per-call parameter.
+- [x] 5 tests on `parse_level`, split out so argument handling is testable
+      without standing up a runner. `cargo test -p mur-agent-runtime --lib
+      effort_set` — 5 passed.
 
-use std::sync::Arc;
+### Task 6 — murmur `/effort` (done)
 
-use mur_common::llm::{Effort, EffortShape, effort_shape};
-
-/// Session effort, shared with the task runner.
-pub type SessionEffort = Arc<std::sync::RwLock<Option<Effort>>>;
-
-pub struct EffortSetHandler {
-    session: SessionEffort,
-    model: String,
-}
-
-impl EffortSetHandler {
-    pub fn new(session: SessionEffort, model: String) -> Self {
-        Self { session, model }
-    }
-
-    /// Split out from the handler so it is testable without a dispatcher.
-    pub fn apply(&self, raw: &str) -> Result<serde_json::Value, String> {
-        let want: Effort = raw.parse()?;
-        let levels = effort_shape(&self.model).levels();
-        if levels.is_empty() {
-            return Err(format!(
-                "model '{}' takes no reasoning effort parameter",
-                self.model
-            ));
-        }
-        let applied = if levels.contains(&want) {
-            want
-        } else {
-            levels
-                .iter()
-                .rev()
-                .find(|l| **l < want)
-                .copied()
-                .or_else(|| levels.first().copied())
-                .ok_or_else(|| "no usable level".to_string())?
-        };
-        *self.session.write().map_err(|e| e.to_string())? = Some(applied);
-        Ok(serde_json::json!({
-            "applied": applied.as_str(),
-            "narrowed": applied != want,
-        }))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn handler(model: &str) -> EffortSetHandler {
-        EffortSetHandler::new(Arc::new(std::sync::RwLock::new(None)), model.to_string())
-    }
-
-    #[test]
-    fn a_supported_level_applies_verbatim() {
-        let h = handler("claude-opus-5");
-        let out = h.apply("xhigh").unwrap();
-        assert_eq!(out["applied"], "xhigh");
-        assert_eq!(out["narrowed"], false);
-        assert_eq!(*h.session.read().unwrap(), Some(Effort::Xhigh));
-    }
-
-    #[test]
-    fn an_unsupported_level_narrows_and_says_so() {
-        // DeepSeek V4 has no medium step.
-        let out = handler("deepseek-v4-pro").apply("medium").unwrap();
-        assert_eq!(out["applied"], "low");
-        assert_eq!(out["narrowed"], true);
-    }
-
-    #[test]
-    fn a_model_without_effort_is_an_error_not_a_silent_success() {
-        let err = handler("gpt-4o").apply("high").unwrap_err();
-        assert!(err.contains("takes no reasoning effort"), "{err}");
-    }
-
-    #[test]
-    fn an_always_on_model_is_refused_rather_than_sent_a_value() {
-        assert!(matches!(effort_shape("magistral"), EffortShape::AlwaysOn));
-        assert!(handler("magistral").apply("high").is_err());
-    }
-
-    #[test]
-    fn a_typo_is_reported_with_the_valid_set() {
-        let err = handler("claude-opus-5").apply("hgih").unwrap_err();
-        assert!(err.contains("valid:"), "{err}");
-    }
-}
-```
-
-- [ ] Add `pub mod effort_set;` to `mur-agent-runtime/src/protocol/methods/mod.rs`,
-      in the existing alphabetical run of `pub mod` lines.
-- [ ] Run `ORT_STRATEGY=download cargo test -p mur-agent-runtime --lib
-      protocol::methods::effort_set` and watch all five tests pass.
-- [ ] Wire the handler into the dispatcher in `mur-agent-runtime/src/supervisor.rs`,
-      directly after the `model/set` registration block:
-
-```rust
-    // murmur /effort. Unlike model/set this needs no rebuild — effort is a
-    // per-call parameter, so the next turn picks it up.
-    d.register(
-        "effort/set",
-        Box::new(crate::protocol::methods::effort_set::EffortSetHandler::new(
-            session_effort.clone(),
-            model_name.clone(),
-        )),
-    );
-```
-
-- [ ] Thread `session_effort: SessionEffort` from the supervisor into
-      `TaskRunner::with_effort`'s call site so the runner reads the shared cell
-      instead of a fixed `Option<Effort>`: change `task_runner.rs`'s `effort`
-      field to `SessionEffort`, seeded from the profile value at construction.
-- [ ] Run `ORT_STRATEGY=download cargo test -p mur-agent-runtime --lib` — the
-      full crate suite, because this task changed a field type the runner uses.
-- [ ] Run `cargo fmt -p mur-agent-runtime` and
-      `ORT_STRATEGY=download cargo clippy -p mur-agent-runtime --all-targets -- -D warnings`.
-- [ ] Commit: `feat(a2a): effort/set changes reasoning effort without a restart`
-
----
-
-## Task 6 — murmur `/effort`
-
-**Interfaces**
-
-Consumes: the `effort/set` A2A method (Task 5), `effective_effort` and
-`EffortSource` (Task 3), `effort_shape` (Task 1).
-
-Produces: `SlashCmd::Effort { level: Option<String>, save: bool }`.
-
-**Steps**
-
-- [ ] Add this test beside the existing `parse_slash` tests in
-      `mur-core/src/cmd/agent/cli/app.rs` (the block containing
-      `assert_eq!(parse_slash("/model"), Some(SlashCmd::Model(None)));`):
-
-```rust
-#[test]
-fn effort_parses_bare_level_and_save() {
-    assert_eq!(
-        parse_slash("/effort"),
-        Some(SlashCmd::Effort { level: None, save: false })
-    );
-    assert_eq!(
-        parse_slash("/effort high"),
-        Some(SlashCmd::Effort { level: Some("high".into()), save: false })
-    );
-    assert_eq!(
-        parse_slash("/effort high --save"),
-        Some(SlashCmd::Effort { level: Some("high".into()), save: true })
-    );
-    // Order must not matter, and --save alone is a listing, not a write.
-    assert_eq!(
-        parse_slash("/effort --save xhigh"),
-        Some(SlashCmd::Effort { level: Some("xhigh".into()), save: true })
-    );
-    assert_eq!(
-        parse_slash("/effort --save"),
-        Some(SlashCmd::Effort { level: None, save: true })
-    );
-}
-```
-
-- [ ] Run `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist
-      cargo test -p mur-core --lib effort_parses_bare_level` and watch it fail
-      to compile (`no variant named Effort`).
-
-- [ ] Add to the `SlashCmd` enum in `app.rs`, directly after the `Model` variant:
-
-```rust
-    /// `/effort [level] [--save]` — list the levels this model accepts, or set
-    /// one. Session-scoped unless `--save` also writes the profile.
-    Effort {
-        level: Option<String>,
-        save: bool,
-    },
-```
-
-- [ ] Add to `parse_slash`'s match, directly after the `"model" =>` arm:
-
-```rust
-        "effort" => {
-            let args: Vec<&str> = words.collect();
-            SlashCmd::Effort {
-                level: args
-                    .iter()
-                    .find(|s| !s.starts_with("--"))
-                    .map(|s| (*s).to_string()),
-                save: args.iter().any(|s| *s == "--save"),
-            }
-        }
-```
-
-- [ ] Run the parse test and watch it pass.
-- [ ] Handle the variant where `SlashCmd::Model` is handled, using this
-      behavior: with `level: None`, print the levels from
-      `effort_shape(model).levels()`, the current value and source from
-      `effective_effort`, and — when the list is empty — the single line
-      `this model takes no reasoning effort parameter`. With `level: Some(l)`,
-      dial `effort/set`; on `narrowed: true`, print both the requested and the
-      applied level. With `save: true`, additionally call
-      `mur_core::cmd::agent::cmd_effort(name, Some(l), false)`.
-- [ ] Run `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist
-      cargo test -p mur-core --lib cmd::agent::cli` and watch the CLI suite pass.
-- [ ] Run `cargo fmt -p mur-core` and
-      `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo clippy -p mur-core --all-targets -- -D warnings`.
-- [ ] Commit: `feat(murmur): /effort sets reasoning effort for this session`
-
----
+- [x] `SlashCmd::Effort { level: Option<String>, save: bool }` + parse arm +
+      completion-table entry.
+- [x] Parse test covers bare, level, `--save`, either order, and `--save`
+      alone (a listing, not a write). 1 passed.
+- [x] `App.session_effort` holds the session override apart from the profile
+      value, so `effective_effort` can report WHICH is in force — the user
+      needs to know whether their change outlives the session.
+- [x] `model_cmd::current_effort()` reads the profile value from the same file
+      `current_model_ref` reads.
+- [x] The offered levels are resolved from the agent's model
+      (`current_model_ref` → registry → `ModelEntry.model`, the raw id — never
+      `provider:`, which is the wire protocol). A model with no reasoning
+      control says so instead of listing a scale it ignores.
+- [x] A level the model lacks is reported, not swallowed: `/effort medium` on
+      `deepseek-v4-pro` says `(this model has no medium; using low)`. The
+      runtime still stores what was asked for.
 
 ## Task 7 — Hub backend: effort on `AgentDetail`, re-narrow on model change
 

--- a/mur-agent-runtime/src/protocol/methods/effort_set.rs
+++ b/mur-agent-runtime/src/protocol/methods/effort_set.rs
@@ -1,0 +1,110 @@
+//! A2A method: `effort/set` — change the running agent's reasoning effort for
+//! this session, without a restart.
+//!
+//! Effort is a per-call parameter (`task_runner.rs`), so unlike `model/set`
+//! this needs no client reconstruction: store the level and the next turn
+//! carries it.
+//!
+//! Two things this handler deliberately does NOT do.
+//!
+//! It does not narrow the level to what the model accepts. Narrowing already
+//! happens at the wire in each client — `mur_common::llm::supported_effort`'s
+//! own doc records the split ("requests state the effort they want and this
+//! narrows it"). A second narrowing here would be a second derivation of one
+//! rule, which is the duplication this whole design exists to prevent.
+//!
+//! It does not write `profile.yaml`. The persistent form is
+//! `mur agent effort`, and murmur's `/effort --save` calls that. A session
+//! override that silently persisted would make the two surfaces mean the same
+//! thing, and then neither would mean anything.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
+use crate::task_runner::TaskRunner;
+
+pub struct EffortSetHandler {
+    runner: Arc<TaskRunner>,
+}
+
+impl EffortSetHandler {
+    pub fn new(runner: Arc<TaskRunner>) -> Self {
+        Self { runner }
+    }
+}
+
+/// Pull the level out of the params, or `None` to clear back to the profile
+/// value. Split out from [`MethodHandler::handle`] so the argument handling is
+/// testable without standing up a runner.
+fn parse_level(params: Option<Value>) -> Result<Option<mur_common::llm::Effort>, HandlerError> {
+    let params = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
+    match params.get("level") {
+        // Explicit null clears the override.
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(raw)) => raw
+            .parse::<mur_common::llm::Effort>()
+            .map(Some)
+            .map_err(HandlerError::InvalidParams),
+        Some(other) => Err(HandlerError::InvalidParams(format!(
+            "'level' must be a string, got {other}"
+        ))),
+    }
+}
+
+#[async_trait]
+impl MethodHandler for EffortSetHandler {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
+        let level = parse_level(params)?;
+        self.runner.set_effort(level);
+        tracing::info!(
+            level = level.map(|e| e.as_str()).unwrap_or("<cleared>"),
+            "effort/set: session effort changed"
+        );
+        Ok(json!({
+            "level": level.map(|e| e.as_str()),
+            "effective": "next-turn",
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::llm::Effort;
+
+    #[test]
+    fn a_level_string_parses() {
+        let p = Some(json!({"level": "xhigh"}));
+        assert_eq!(parse_level(p).unwrap(), Some(Effort::Xhigh));
+    }
+
+    #[test]
+    fn an_explicit_null_clears_the_override() {
+        assert_eq!(parse_level(Some(json!({"level": null}))).unwrap(), None);
+        assert_eq!(parse_level(Some(json!({}))).unwrap(), None);
+    }
+
+    #[test]
+    fn a_typo_is_reported_with_the_valid_set_rather_than_ignored() {
+        let err = parse_level(Some(json!({"level": "hgih"}))).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("valid:"), "{msg}");
+    }
+
+    #[test]
+    fn a_non_string_level_is_rejected_not_coerced() {
+        assert!(parse_level(Some(json!({"level": 3}))).is_err());
+    }
+
+    #[test]
+    fn missing_params_entirely_is_an_error() {
+        assert!(parse_level(None).is_err());
+    }
+}

--- a/mur-agent-runtime/src/protocol/methods/mod.rs
+++ b/mur-agent-runtime/src/protocol/methods/mod.rs
@@ -1,6 +1,7 @@
 //! A2A method handlers.
 pub mod card;
 pub mod channel_delegate;
+pub mod effort_set;
 pub mod memory_reload;
 pub mod message_send;
 pub mod model_set;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -1070,6 +1070,15 @@ fn build_dispatcher(
             )),
         );
     }
+    // murmur /effort. Unlike model/set this is registered unconditionally:
+    // effort is a per-call parameter, so there is no client to rebuild and no
+    // agent shape that cannot accept one.
+    d.register(
+        "effort/set",
+        Box::new(crate::protocol::methods::effort_set::EffortSetHandler::new(
+            runner.clone(),
+        )),
+    );
     // murmur `/remember` and `/forget` run in the CLI process; this is how they
     // tell the running agent its memory set changed.
     d.register(

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -222,7 +222,17 @@ pub struct TaskRunner {
     /// Per-agent effort for this agent's own turns. `None` = the API default.
     /// Mechanical internal calls override it downward regardless (see
     /// `graceful_exit`).
-    effort: Option<mur_common::llm::Effort>,
+    ///
+    /// Interior-mutable because murmur's `/effort` changes it on a RUNNING
+    /// agent through the `effort/set` A2A method, and the runner is shared as
+    /// `Arc<TaskRunner>`. Unlike a model swap this needs no reconstruction:
+    /// effort is a per-call parameter, so the next request picks it up.
+    ///
+    /// Deliberately stores what was ASKED FOR, not a narrowed value. Narrowing
+    /// to what a model accepts happens at the wire, in each client — see
+    /// `mur_common::llm::supported_effort`, whose doc records that split. A
+    /// second narrowing here would be a second derivation of one rule.
+    effort: std::sync::RwLock<Option<mur_common::llm::Effort>>,
     /// Multi-turn chat memory keyed by `context.task_id` (see `ConversationStore`).
     conversations: Mutex<ConversationStore>,
     /// Set by `begin_drain()` during graceful shutdown. When true, `run_sync_inner`
@@ -336,7 +346,7 @@ impl TaskRunner {
             max_token_budget: DEFAULT_MAX_TOKEN_BUDGET,
             tools: vec![],
             tools_policy: vec![],
-            effort: None,
+            effort: std::sync::RwLock::new(None),
             conversations: Mutex::new(ConversationStore::default()),
             draining: Arc::new(AtomicBool::new(false)),
         }
@@ -430,10 +440,27 @@ impl TaskRunner {
         self
     }
 
-    /// Set the agent's per-turn effort (from its profile).
+    /// Set the agent's per-turn effort (from its profile) at construction.
     pub fn with_effort(mut self, effort: Option<mur_common::llm::Effort>) -> Self {
-        self.effort = effort;
+        self.effort = std::sync::RwLock::new(effort);
         self
+    }
+
+    /// The effort this agent's own turns currently request.
+    ///
+    /// A poisoned lock reports `None` rather than panicking: losing the
+    /// session's effort override costs a slightly different reasoning budget,
+    /// while panicking here would take down a running agent mid-turn.
+    pub fn effort(&self) -> Option<mur_common::llm::Effort> {
+        self.effort.read().map(|g| *g).unwrap_or(None)
+    }
+
+    /// Change the effort on a running agent (murmur `/effort`, via the
+    /// `effort/set` A2A method). Takes effect on the next request.
+    pub fn set_effort(&self, effort: Option<mur_common::llm::Effort>) {
+        if let Ok(mut g) = self.effort.write() {
+            *g = effort;
+        }
     }
 
     pub fn with_telemetry(mut self, tx: mpsc::Sender<Event>) -> Self {
@@ -1161,7 +1188,7 @@ impl TaskRunner {
             temperature: None,
             max_tokens: None,
             tools: vec![],
-            effort: self.effort,
+            effort: self.effort(),
             intent,
             task_id: Some(task_id.to_string()),
             ..Default::default()
@@ -1664,7 +1691,7 @@ impl TaskRunner {
                 messages: history.clone(),
                 temperature: None,
                 max_tokens: None,
-                effort: self.effort,
+                effort: self.effort(),
                 tools: tool_defs.clone(),
                 intent,
                 task_id: Some(task_id.to_string()),

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -188,6 +188,12 @@ pub enum SlashCmd {
     Open,
     /// `/model [N|name]` — list registry models, or hot-switch to one.
     Model(Option<String>),
+    /// `/effort [level] [--save]` — list the levels this model accepts, or set
+    /// one. Session-scoped unless `--save` also writes the profile.
+    Effort {
+        level: Option<String>,
+        save: bool,
+    },
     /// `/login [anthropic|chatgpt]` — show OAuth health, or repair one provider.
     /// Unrelated to `mur auth login`, which signs in to mur.run.
     Login(Option<String>),
@@ -214,6 +220,16 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
             }
         }
         "model" => SlashCmd::Model(words.next().map(str::to_string)),
+        "effort" => {
+            let args: Vec<&str> = words.collect();
+            SlashCmd::Effort {
+                level: args
+                    .iter()
+                    .find(|s| !s.starts_with("--"))
+                    .map(|s| (*s).to_string()),
+                save: args.contains(&"--save"),
+            }
+        }
         "login" => SlashCmd::Login(words.next().map(str::to_string)),
         "auto" => SlashCmd::Auto(match words.next() {
             Some("on") => Some(true),
@@ -483,6 +499,10 @@ pub struct App {
     pub turn_in: u64,
     pub turn_out: u64,
     /// Last-known context fill from the runtime's `Task.usage.context_tokens`.
+    /// Effort set with `/effort` this session, if any. Kept apart from the
+    /// profile value so `effective_effort` can report WHICH one is in force —
+    /// the user needs to know whether their change outlives the session.
+    pub session_effort: Option<mur_common::llm::Effort>,
     pub ctx_tokens: u64,
     /// Pricing for the model that answered the LAST turn — not necessarily the
     /// one this agent is configured with, because the runtime's fallback chain
@@ -628,6 +648,7 @@ impl App {
             session_out: 0,
             turn_in: 0,
             turn_out: 0,
+            session_effort: None,
             ctx_tokens: 0,
             pricing: super::footer::Pricing::default(),
             pricing_book: None,
@@ -1823,6 +1844,46 @@ mod tests {
         a.start_new_session(s);
         assert!(a.context_task_id.is_none());
         assert_eq!(a.messages.last().unwrap().role, Role::System);
+    }
+
+    #[test]
+    fn effort_parses_bare_level_and_save() {
+        assert_eq!(
+            parse_slash("/effort"),
+            Some(SlashCmd::Effort {
+                level: None,
+                save: false
+            })
+        );
+        assert_eq!(
+            parse_slash("/effort high"),
+            Some(SlashCmd::Effort {
+                level: Some("high".into()),
+                save: false
+            })
+        );
+        assert_eq!(
+            parse_slash("/effort high --save"),
+            Some(SlashCmd::Effort {
+                level: Some("high".into()),
+                save: true
+            })
+        );
+        // Order must not matter, and `--save` alone is a listing, not a write.
+        assert_eq!(
+            parse_slash("/effort --save xhigh"),
+            Some(SlashCmd::Effort {
+                level: Some("xhigh".into()),
+                save: true
+            })
+        );
+        assert_eq!(
+            parse_slash("/effort --save"),
+            Some(SlashCmd::Effort {
+                level: None,
+                save: true
+            })
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -2002,6 +2002,110 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                 }
             }
         }
+        SlashCmd::Effort { level, save } => {
+            // The levels on offer are a property of the model this agent is
+            // configured with, so resolve it rather than listing the whole
+            // scale. `provider:` is the wire protocol, never the vendor — the
+            // raw id in `ModelEntry.model` is what the table keys on.
+            let model_id = model_cmd::current_model_ref(&app.home, &app.agent)
+                .and_then(|r| {
+                    mur_common::model::ModelRegistry::default_path()
+                        .and_then(|p| mur_common::model::ModelRegistry::load_from(&p))
+                        .ok()
+                        .and_then(|reg| reg.models.get(&r).map(|e| e.model.clone()))
+                })
+                .unwrap_or_default();
+            let levels = mur_common::llm::effort_shape(&model_id).levels();
+
+            if levels.is_empty() {
+                app.push_system(format!(
+                    "{model_id} takes no reasoning effort parameter — nothing to set"
+                ));
+                return;
+            }
+
+            let profile_effort = model_cmd::current_effort(&app.home, &app.agent);
+            let Some(raw) = level else {
+                let (eff, src) = mur_common::llm::effective_effort(
+                    app.session_effort,
+                    profile_effort,
+                    &model_id,
+                );
+                let offered: Vec<&str> = levels.iter().map(|e| e.as_str()).collect();
+                let now = match (eff, src) {
+                    (Some(e), mur_common::llm::EffortSource::SessionOverride) => {
+                        format!("{} (this session)", e.as_str())
+                    }
+                    (Some(e), _) => format!("{} (profile)", e.as_str()),
+                    (None, _) => "unset — the API default is high".to_string(),
+                };
+                app.push_system(format!(
+                    "{model_id} accepts: {}\ncurrent: {now}\n/effort <level> for this session, --save to persist",
+                    offered.join(" · ")
+                ));
+                return;
+            };
+
+            let want: mur_common::llm::Effort = match raw.parse() {
+                Ok(e) => e,
+                Err(e) => {
+                    app.push_system(e.to_string());
+                    return;
+                }
+            };
+            // Report what the model will ACTUALLY use. The runtime stores what
+            // was asked for and each client narrows at the wire, so a level
+            // this model lacks is not an error — but saying nothing about it
+            // would leave the user believing a setting that never applied.
+            let (applied, _) = mur_common::llm::effective_effort(Some(want), None, &model_id);
+
+            let (h, ag) = (app.home.clone(), app.agent.clone());
+            let lvl = want.as_str();
+            let res = tokio::task::spawn_blocking(move || {
+                dial_method(
+                    &h,
+                    &ag,
+                    "effort/set",
+                    serde_json::json!({ "level": lvl }),
+                    DialMode::Auto,
+                )
+            })
+            .await;
+
+            let narrowed = applied.filter(|a| *a != want);
+            let suffix = match narrowed {
+                Some(a) => format!(
+                    " (this model has no {}; using {})",
+                    want.as_str(),
+                    a.as_str()
+                ),
+                None => String::new(),
+            };
+            match res {
+                Ok(Ok(_)) => {
+                    app.session_effort = Some(want);
+                    app.push_system(format!(
+                        "effort → {}{suffix} (this session, effective next turn)",
+                        want.as_str()
+                    ));
+                }
+                Ok(Err(e)) => app.push_system(format!(
+                    "couldn't set effort on the running agent ({e:#}){suffix}"
+                )),
+                Err(e) => app.push_system(format!("effort task failed: {e}")),
+            }
+
+            if save {
+                match crate::cmd::agent::cmd_effort(
+                    &app.agent,
+                    Some(want.as_str().to_string()),
+                    false,
+                ) {
+                    Ok(()) => app.push_system(format!("saved {} to profile", want.as_str())),
+                    Err(e) => app.push_system(format!("profile write failed: {e:#}")),
+                }
+            }
+        }
         SlashCmd::Login(arg) => match arg {
             None => run_manage(app, move |agent| Ok(login::render_status_all(&agent))).await,
             Some(word) => match login::Provider::parse(&word) {
@@ -2889,6 +2993,7 @@ mod help_coverage_tests {
             SlashCmd::Panel(_) => Some("panel"),
             SlashCmd::Open => Some("open"),
             SlashCmd::Model(_) => Some("model"),
+            SlashCmd::Effort { .. } => Some("effort"),
             SlashCmd::Login(_) => Some("login"),
             SlashCmd::Quit => Some("exit"),
             SlashCmd::Unknown(_) => None,

--- a/mur-core/src/cmd/agent/cli/model_cmd.rs
+++ b/mur-core/src/cmd/agent/cli/model_cmd.rs
@@ -88,6 +88,16 @@ pub(crate) fn current_model_ref(home: &Path, agent: &str) -> Option<String> {
         .model_ref
 }
 
+/// The effort stored on the agent's profile, if any.
+///
+/// Read from the same file `current_model_ref` reads, so `/effort` reports the
+/// value the runtime will actually load at its next start rather than a copy
+/// held somewhere else.
+pub(crate) fn current_effort(home: &Path, agent: &str) -> Option<mur_common::llm::Effort> {
+    let yaml = std::fs::read_to_string(profile_path(home, agent)).ok()?;
+    serde_yaml_ng::from_str::<AgentProfile>(&yaml).ok()?.effort
+}
+
 /// Fallback persistence when the dial can't reach a `model/set`-capable
 /// runtime: typed round-trip + temp/rename, mirroring the runtime handler.
 pub(crate) fn write_model_ref(home: &Path, agent: &str, model_ref: &str) -> Result<()> {


### PR DESCRIPTION
Phase 2a of the plan merged in #1129 — the runtime half and the TUI, on top of the table from #1133. The Hub control is Phase 2b and stays unspecified until its insertion points are read.

```
/effort                  the levels THIS model accepts, the current value,
                         and which of the two sources it came from
/effort <level>          this session, effective next turn
/effort <level> --save   this session and the profile
```

## Reading the tree made the design smaller than the plan predicted

This is the whole reason the plan refused to specify Phase 2 in advance, and all three predictions were wrong:

| Plan predicted | Tree |
|---|---|
| thread a `SessionEffort` cell from the supervisor | `build_dispatcher` already has `runner: &Arc<TaskRunner>`; every other handler takes `runner.clone()` |
| `model_name` in scope at the `model/set` registration | not in scope — the model lives inside `backend: RunnerBackend` |
| the handler narrows the level to what the model accepts | **the handler must not narrow at all** |

That last row is the find. `supported_effort`'s own doc states the architecture — *"requests state the effort they want and this narrows it"* — so narrowing already happens at the wire, in each client. A second narrowing in the handler would be a second derivation of one rule, which is the duplication this whole design exists to prevent.

So `effort/set` needs **no knowledge of the model at all**. It stores what was asked for.

## Two deliberate refusals

**It does not write `profile.yaml`.** The persistent form is `mur agent effort`, which `--save` calls. A session override that silently persisted would collapse the two surfaces into one meaning, and then neither would mean anything.

**It does not panic on a poisoned lock.** `TaskRunner.effort` is interior-mutable (`RwLock`) because the runner is shared as `Arc<TaskRunner>` and this changes it on a *running* agent. A poisoned lock reports `None`: losing a session override costs a different reasoning budget, panicking takes down a running agent mid-turn.

Unlike `model/set` there is no client to rebuild — effort is a per-call parameter, so the next request carries it. That is also why `effort/set` is registered unconditionally, where `model/set` is not.

## What the TUI shows, and why it is not the whole scale

Offered levels are resolved from the agent's own model: `current_model_ref` → registry → `ModelEntry.model`, the **raw id** — never `provider:`, which is the wire protocol and reads `openai` for every OpenAI-compatible third party.

- A model with no reasoning control says so instead of listing a scale it ignores.
- A level the model lacks is reported, not swallowed: `/effort medium` on `deepseek-v4-pro` answers *"this model has no medium; using low"*. The runtime still stores what was asked for; only the display resolves it.
- `App.session_effort` is kept apart from the profile value so `effective_effort` can report **which** is in force — the user needs to know whether their change outlives the session. This is the first consumer of the single derivation #1133 shipped.

## Verification

- `cargo nextest run --workspace` — **8061 passed, 0 failed**, 30 skipped
- `cargo clippy -p mur-agent-runtime -p mur-core --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `effort_set` — 5 tests on argument handling, split into a free function so it is testable without standing up a runner
- `/effort` parsing — bare, level, `--save`, either order, and `--save` alone (a listing, not a write)

The workspace suite was re-run **after** two clippy fixes, not before. The fixes were provably equivalent (`iter().any` → `contains`, `format!` → `to_string`), but "provably" was my inference, and inference has been overturned by execution twice in this line of work already.

## Not covered by tests

The `/effort` handler itself is TUI glue — dial, match, render — with no seam that a unit test would exercise honestly. Its two branches that carry real logic (level resolution and the narrowing message) both call `mur-common` functions that #1133 tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
