### PR TITLE
fix(companion): review findings on the reminder delivery chain

### DIFF
--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -83,8 +83,13 @@ pub fn parse_bound(not_after: Option<&str>) -> Option<DateTime<Local>> {
 ///
 /// Before #1125 a completed scheduled turn was discarded: the scheduler warned
 /// on failure and did nothing at all with success, so a reminder fired on the
-/// second and reached nobody. The reply is now appended to a channel, which the
-/// Hub, the Panel and `mur channel` already read — one write, every surface.
+/// second and reached nobody.
+///
+/// The reply now goes two places. The channel is the record — signed, and read
+/// by the Hub, the Panel and `mur channel` alike. The companion inbox is where
+/// a person is already looking, and is what the Hub raises a system
+/// notification from. Neither replaces the other, and neither is conditional on
+/// the other succeeding.
 pub struct ScheduleSink {
     pub mur_home: PathBuf,
     pub agent: String,
@@ -127,7 +132,11 @@ async fn notify_inbox(sink: &ScheduleSink, task_id: &str, body: &str, now: DateT
         generated_at: now,
     };
     if let Err(e) = StdoutNotifier::new(inbox).send(&msg).await {
-        warn!(error = %e, task_id = %task_id, "scheduled reply reached the channel but not the inbox");
+        // Deliberately says only what this call knows. The earlier phrasing
+        // claimed the channel write had succeeded, which this function never
+        // checked — the same shape of unchecked assertion the whole batch is
+        // about, reintroduced inside its own fix.
+        warn!(error = %e, task_id = %task_id, "scheduled reply could not be written to the inbox");
     }
 }
 
@@ -192,7 +201,8 @@ async fn record_reply(sink: &ScheduleSink, task: &mur_common::a2a::Task, cron: &
     }
 
     // The channel makes the reply findable; the inbox is where a person is
-    // already looking. Both, because neither replaces the other.
+    // already looking. Both, because neither replaces the other — and the
+    // inbox attempt does not depend on the channel write having succeeded.
     notify_inbox(sink, &task.id, &text, chrono::Utc::now()).await;
 }
 

--- a/mur-hub-gui/src-tauri/src/companion_notify.rs
+++ b/mur-hub-gui/src-tauri/src/companion_notify.rs
@@ -59,9 +59,27 @@ fn mark_seen(mur_home: &Path, id: &str) -> Result<()> {
 /// One inbox entry, reduced to what a notification needs.
 pub struct InboxEntry {
     pub id: String,
+    /// The on-disk agent name — a path component, never shown to anyone.
     pub agent: String,
-    pub situation: String,
     pub body: String,
+}
+
+/// What to call the agent in a notification.
+///
+/// `agent` is the directory name and is lowercase by construction (the runtime
+/// spoof check matches it exactly against the on-disk name). The label a person
+/// should see is `display_name` — for the concierge that is the difference
+/// between a notification titled "mur" and one titled "MUR". Falls back to the
+/// directory name only when the profile cannot be read, which is better than no
+/// notification at all.
+fn display_name(mur_home: &Path, agent: &str) -> String {
+    let p = mur_home.join("agents").join(agent).join("profile.yaml");
+    std::fs::read_to_string(p)
+        .ok()
+        .and_then(|s| serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&s).ok())
+        .and_then(|v| v.get("display_name")?.as_str().map(str::to_string))
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| agent.to_string())
 }
 
 /// Parse the front matter `inbox::render` writes. Returns `None` for a file
@@ -79,7 +97,6 @@ fn parse_entry(agent: &str, path: &Path) -> Option<InboxEntry> {
     Some(InboxEntry {
         id: field("id")?,
         agent: agent.to_string(),
-        situation: field("situation").unwrap_or_default(),
         body: body
             .trim()
             .trim_end_matches(">>> response: <unset>")
@@ -109,10 +126,11 @@ fn inbox_dirs(mur_home: &Path) -> Vec<(String, PathBuf)> {
 /// and must not mark itself seen — otherwise a transient failure would silently
 /// consume the message.
 fn raise(app: &AppHandle, mur_home: &Path, e: &InboxEntry, missed: bool) {
+    let who = display_name(mur_home, &e.agent);
     let title = if missed {
-        format!("{} — while MUR Hub was closed", e.agent)
+        format!("{who} — while MUR Hub was closed")
     } else {
-        e.agent.clone()
+        who
     };
     match app
         .notification()
@@ -138,16 +156,18 @@ fn raise(app: &AppHandle, mur_home: &Path, e: &InboxEntry, missed: bool) {
 pub fn catch_up(app: &AppHandle, mur_home: &Path) -> usize {
     let seen = load_seen(mur_home);
     let mut n = 0;
+    let mut live: HashSet<String> = HashSet::new();
     for (agent, dir) in inbox_dirs(mur_home) {
         let Ok(rd) = std::fs::read_dir(&dir) else {
             continue;
         };
-        let mut entries: Vec<_> = rd
+        let all: Vec<_> = rd
             .flatten()
             .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
             .filter_map(|e| parse_entry(&agent, &e.path()))
-            .filter(|e| !seen.contains(&e.id))
             .collect();
+        live.extend(all.iter().map(|e| e.id.clone()));
+        let mut entries: Vec<_> = all.into_iter().filter(|e| !seen.contains(&e.id)).collect();
         // Oldest first, so a burst reads in the order it happened.
         entries.sort_by(|a, b| a.id.cmp(&b.id));
         for e in entries {
@@ -155,7 +175,25 @@ pub fn catch_up(app: &AppHandle, mur_home: &Path) -> usize {
             n += 1;
         }
     }
+    // An id whose entry no longer exists can never be offered again, so keeping
+    // it serves nothing while the marker grows for the life of the install.
+    // Pruning to what is on disk bounds it by the inbox rather than by time.
+    prune_seen(mur_home, &live);
     n
+}
+
+/// Drop recorded ids whose inbox entry is gone.
+fn prune_seen(mur_home: &Path, live: &HashSet<String>) {
+    let seen = load_seen(mur_home);
+    let kept: Vec<&String> = seen.iter().filter(|id| live.contains(*id)).collect();
+    if kept.len() == seen.len() {
+        return;
+    }
+    let body: String = kept.iter().map(|id| format!("{id}\n")).collect();
+    // Best-effort: a marker that fails to shrink is only ever too cautious.
+    if let Err(e) = std::fs::write(seen_path(mur_home), body) {
+        tracing::warn!("could not prune the notified-inbox marker: {e:#}");
+    }
 }
 
 /// Watch every agent's inbox and notify as entries appear.
@@ -173,12 +211,19 @@ pub fn watch_inboxes(app: AppHandle, mur_home: &Path) -> Result<Vec<notify::Reco
         let who = agent.clone();
         let mut w = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
             let Ok(ev) = res else { return };
-            let seen = load_seen(&home);
-            for p in ev
+            // Filter first. This tree is written to constantly and the seen set
+            // is a whole-file read; paying it for every unrelated event is the
+            // difference between a cheap watcher and a hot one.
+            let mds: Vec<_> = ev
                 .paths
                 .iter()
                 .filter(|p| p.extension().is_some_and(|x| x == "md"))
-            {
+                .collect();
+            if mds.is_empty() {
+                return;
+            }
+            let seen = load_seen(&home);
+            for p in mds {
                 if let Some(e) = parse_entry(&who, p)
                     && !seen.contains(&e.id)
                 {
@@ -224,11 +269,43 @@ mod tests {
         let e = parse_entry("mur", &p).expect("the real writer's output must parse");
         assert_eq!(e.id, "task-abc");
         assert_eq!(e.agent, "mur");
-        assert_eq!(e.situation, "scheduled");
+        assert_eq!(
+            display_name(tmp.path(), "mur"),
+            "mur",
+            "with no profile to read, the directory name is the only honest fallback"
+        );
         assert_eq!(
             e.body, "該吃早餐了 🥐",
             "the response placeholder must not reach the notification body"
         );
+    }
+
+    /// The notification title must be the label a person should see, not the
+    /// directory name. For the concierge that is the difference between a
+    /// notification titled "mur" and one titled "MUR" (CLAUDE.md rule 7).
+    #[test]
+    fn the_title_uses_display_name_not_the_directory_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents").join("mur");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("profile.yaml"), "name: mur\ndisplay_name: MUR\n").unwrap();
+        assert_eq!(display_name(tmp.path(), "mur"), "MUR");
+    }
+
+    /// An empty or absent `display_name` falls back to the directory name —
+    /// a badly-named notification beats no notification.
+    #[test]
+    fn a_missing_display_name_falls_back_to_the_directory_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("agents").join("solo");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("profile.yaml"),
+            "name: solo\ndisplay_name: \"  \"\n",
+        )
+        .unwrap();
+        assert_eq!(display_name(tmp.path(), "solo"), "solo");
+        assert_eq!(display_name(tmp.path(), "no-such-agent"), "no-such-agent");
     }
 
     /// A file that is not ours yields `None` rather than a notification built

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -598,16 +598,15 @@ pub fn run() {
                     Err(e) => tracing::warn!("install-inbox watcher failed to start: {e:#}"),
                 }
 
-                // Companion inbox → system notification. Catch up first, so a
-                // reminder that fired while the Hub was closed is reported as
-                // missed rather than absorbed into "unread" (#1125).
-                let missed = crate::companion_notify::catch_up(&app.handle().clone(), &home);
-                if missed > 0 {
-                    tracing::info!(
-                        missed,
-                        "companion inbox entries arrived while the Hub was closed"
-                    );
-                }
+                // Companion inbox → system notification (#1125).
+                //
+                // The watch is armed BEFORE the catch-up sweep. Sweeping first
+                // leaves a window: an entry written after the sweep read the
+                // directory but before the watch existed reached neither, and
+                // would surface only at the next Hub start. Arming first closes
+                // it — the seen marker already makes a double raise impossible,
+                // so the worst case is an entry labelled "new" that a stricter
+                // reading would have called "missed".
                 match crate::companion_notify::watch_inboxes(app.handle().clone(), &home) {
                     Ok(ws) => {
                         #[allow(dead_code)] // held only to keep the watchers alive
@@ -615,6 +614,13 @@ pub fn run() {
                         app.manage(std::sync::Mutex::new(Some(CompanionInboxWatchers(ws))));
                     }
                     Err(e) => tracing::warn!("companion inbox watchers failed to start: {e:#}"),
+                }
+                let missed = crate::companion_notify::catch_up(&app.handle().clone(), &home);
+                if missed > 0 {
+                    tracing::info!(
+                        missed,
+                        "companion inbox entries arrived while the Hub was closed"
+                    );
                 }
             }
 


### PR DESCRIPTION
Findings from a two-axis review of `v2.71.15...main` — the #1127 / #1130 / #1131 / #1132 delivery chain. Six fixed; three of them had an obvious wrong answer worth naming.

## Critical — the notification said "mur"

`raise()` titled the notification with `e.agent`, which is the **directory name**. It is lowercase by construction: the runtime's spoof check matches it exactly against the on-disk name. So the concierge's first-ever system notification would have arrived titled **"mur"**, against CLAUDE.md rule 7, which lists GUI strings explicitly.

It now reads `display_name` from the profile. The fallback direction matters and has its own test: an unreadable profile yields the directory name rather than **no notification**. "Skip it if we cannot name it properly" looks more rigorous and is worse.

## Important — a log line that asserted what it never checked

```rust
warn!(… "scheduled reply reached the channel but not the inbox");
```

`notify_inbox` does not check the channel write. When both failed, that line claimed the channel had succeeded.

Written by me, inside the fix for a batch of exactly this failure. The comment now on that line says so, because the next person's instinct will be to make the message *more* helpful — and more helpful phrasing is usually more unchecked assertion.

## Important — three shape problems

**The seen marker grew for the life of the install.** Not "keep the last N", not a timestamp: it is pruned to the ids whose inbox entry still exists. An id whose `.md` is gone can never be offered again, so keeping it serves nothing. Bounded by the inbox rather than by time.

**The watcher read that whole marker on every filesystem event** — `agents/` churns constantly with locks, logs and telemetry. It filters to `.md` first and returns early when nothing is left.

**An entry written between the catch-up sweep and the watch being armed reached neither.** Arming first closes it. The seen marker already makes a double raise impossible, so the worst case is an entry labelled "new" that a stricter reading would have called "missed" — better than one silently skipped.

## Minor

`InboxEntry.situation` was parsed and never read. The `ScheduleSink` doc still said "one write, every surface" after a second write was added.

## Verification

`test result: ok. 6 passed` (two runs, same result). Two new tests cover the title fix and its fallback direction. All three of CI's fmt invocations pass locally — including `cargo fmt --all -- --check`, which is the one CI actually uses for the workspace.