### PR TITLE
Smart routing: capability gate + inheritable policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,23 @@ Agent** wizard offers the same catalog as a source.
   prefix. The result ranks the list and says how much of it could be answered —
   `checked 1 of 4 reported items` — because a check that reports nothing about
   its own reach is indistinguishable from one that found nothing wrong.
+- **A router that can't hand your work to a model that can't do it** — Smart
+  background routing runs low-stakes turns on a cheaper model. It also, until
+  now, handed image recognition to a text-tier model: the picker ranked
+  candidates by price and never asked whether they could see. Nothing catches
+  that afterwards — the cascade escalates on a *malformed* reply, and a
+  confidently wrong recognition is perfectly well-formed — and the decision
+  caption only renders in Hub chat, which background turns never reach. So a
+  router may now only substitute a model that can serve the request: price
+  orders the eligible set, it doesn't decide who's in it. Silence about vision
+  counts as absence of it, because that failure is silent; silence about tools
+  doesn't, because a tool-incapable model is refused loudly and the chain simply
+  advances. Explicit choices are never filtered — your `model_ref`, your pinned
+  re-run — they're yours to get wrong. Smart is now **off by default**
+  (`mur model smart on`), and per agent it's genuinely three-state:
+  `mur agent smart <name> follow|on|off`, where `follow` means follow. The
+  toggle used to lie in the other direction too — an agent with no fallback
+  chain never ran Smart at all, whatever the setting said.
 
 ### 🔌 Power the tools you already pay for
 
@@ -633,7 +650,7 @@ mur
 ├── agent        create · start · stop · restart · remove · cli · send · card · dial · who ·
 │                export · install · install-service · addon · companion · voice · pair ·
 │                schedule (add · proposals · accept) · perm (incl. list-paths) · secret ·
-│                trash · rollback … (40+)
+│                fallback · smart · trash · rollback … (40+)
 ├── capability   install · list · show · remove   (MCP + skills + programs bundled → an agent)
 ├── fleet        create · list · show · status · run · set-loop · send · jobs   (squads of agents over a shared channel)
 ├── official     list · install   (official agents/fleets from the app.mur.run catalog)
@@ -648,7 +665,7 @@ mur
 ├── hook         unified hook entry for AI tools (prompt / tool / stop / session-start)
 ├── chat         conversations archive + ask
 ├── model        connect · import · add · list · show · remove · doctor · prices · role · route ·
-│                default · fallback · migrate   (connect = one key, many models)
+│                default · fallback · smart · migrate   (connect = one key, many models)
 ├── source       external knowledge — Obsidian · Notion · Joplin
 ├── project      index · search   (semantic code search)
 ├── daemon       start · stop · restart · status · serve · sleep

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -1,0 +1,1109 @@
+# Implementation Plan — Smart Routing Capability Gate + Inheritable Policy
+
+> **Execute with**: `mur-executing-plans` (in-context, task by task). Each task
+> ends green and committed; stop and report on any blocker rather than
+> improvising.
+> **Spec**: `docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md`
+
+**Goal**: automatic model substitution may never hand a request to a model that
+cannot serve it, and Smart background routing becomes opt-in with real
+three-state per-agent inheritance.
+
+**Architecture**: a pure capability predicate in `mur-common`
+(`Requirement`/`satisfies`) filters every *automatic* candidate inside
+`FallbackLlmClient::candidates_for`, leaving explicit user choices untouched.
+Separate `SmartOverride`/`RoutingOverride` partial types replace the
+whole-struct per-agent override, merged field-by-field onto the global config,
+with the effective values read through two `AgentProfile` helpers so every
+call site resolves inheritance identically.
+
+**Tech stack**: Rust 2024 (workspace crates `mur-common`, `mur-agent-runtime`,
+`mur-core`), Tauri 2 + React/TypeScript (`mur-hub-gui`, workspace-excluded),
+`cargo nextest` for tests, `vitest` for the Hub UI.
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes all of them.
+
+- **No hardcoded values.** Use constants, config, or env vars (CLAUDE.md rule 1).
+- **Single source file ≤ 800 lines** (CLAUDE.md rule 4). `mur-agent-runtime/src/supervisor_runner.rs` (954) and `mur-core/src/cmd/model.rs` (807) are ALREADY over budget: do not grow them beyond a few lines — new code goes into new sibling modules, and no code-movement refactor is in scope here.
+- **Explicit beats smart.** A user- or profile-pinned model is never overridden (spec §3.2).
+- **Fail-expensive, never fail-broken.** When unsure, keep the better model (spec §2).
+- **Above the chat baseline, capability is fail-closed: unstated is not permission** (spec §2).
+- **Do not touch `classify()` or the Phase-1 retryable/fatal boundary** (spec §3.2).
+- Hub i18n keys land in **both** `mur-hub-gui/ui/src/i18n/en.ts` and `zh-TW.ts`.
+- `cargo clippy --workspace --all-targets -- -D warnings` must pass (a `--lib`-only run hides broken test targets).
+- `cargo fmt` before every commit.
+
+## File structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `mur-common/src/model.rs` | modify | `Requirement`, `CAP_*` consts, `satisfies`, capability-aware `pick_cheap_model` |
+| `mur-common/src/config.rs` | modify | `SmartOverride`, `RoutingOverride`, `merged()` on both configs, `DEFAULT_SMART_ENABLED = false`, drop `RoutingConfig.smart` |
+| `mur-common/src/agent.rs` | modify | `AgentProfile.smart`, retype `routing`, `effective_smart()` / `effective_routing()` |
+| `mur-agent-runtime/src/llm/fallback/mod.rs` | modify | `requirements_of`, registry helpers, candidate filtering, read effective config via the helpers |
+| `mur-agent-runtime/src/llm/fallback/tests.rs` | modify | candidate-assembly tests incl. the incident regression |
+| `mur-agent-runtime/src/supervisor_runner.rs` | modify | `needs_routing_client` predicate + boot gate (few lines only) |
+| `mur-core/src/cmd/model_smart.rs` | **new** | `cmd_model_smart` — global Smart toggle |
+| `mur-core/src/cmd/model.rs` | modify | `ModelCmd::Smart` variant + dispatch arm; `ensure_ref_exists` → `pub(crate)` |
+| `mur-core/src/cmd/mod.rs` | modify | `pub mod model_smart;` |
+| `mur-core/src/cmd/agent/model_resolve.rs` | modify | `cmd_agent_set_smart` |
+| `mur-core/src/cli/agent.rs` | modify | `AgentAction::Smart` variant |
+| `mur-core/src/dispatch.rs` | modify | `AgentAction::Smart` arm |
+| `mur-core/src/cmd/agent/lifecycle.rs`, `mur-core/src/cmd/agent_companion/connector.rs` | modify | add `smart: None` to the two `AgentProfile` struct literals |
+| `mur-hub-gui/src-tauri/src/model_switch.rs` | modify | `agent_get_smart` / `agent_set_smart` commands |
+| `mur-hub-gui/src-tauri/src/lib.rs` | modify | register the two commands |
+| `mur-hub-gui/ui/src/components/settings/modelSwitch.ts` | modify | `normalizeMs` default flips to off |
+| `mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx` | modify | three-state per-agent Smart control |
+| `mur-hub-gui/ui/src/i18n/{en,zh-TW}.ts` | modify | 5 new keys each |
+
+---
+
+## Task 1 — Capability vocabulary and capability-aware auto-pick
+
+**Interfaces**
+
+*Consumes*: nothing.
+
+*Produces*:
+- `mur_common::model::Requirement` (`enum { Vision, Tools }`, `Copy`), `Requirement::capability(self) -> &'static str`
+- `mur_common::model::{CAP_CHAT, CAP_TOOLS, CAP_VISION}: &str`
+- `mur_common::model::satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool`
+- `mur_common::model::pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>, reqs: &[Requirement]) -> Option<String>` (**arity changed**)
+- `mur_agent_runtime::llm::fallback::requirements_of(req: &LlmRequest) -> Vec<Requirement>` (private to the module)
+
+**Steps**
+
+- [ ] Add both failing tests to the `mod tests` block in `mur-common/src/model.rs` (append after `pick_cheap_model_lowest_cost_chat_excluding_primary`):
+
+```rust
+    #[test]
+    fn satisfies_is_permissive_at_baseline_and_fail_closed_above_it() {
+        let mk = |caps: &[&str]| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        // Baseline: an entry written before the field existed is still chat.
+        assert!(satisfies(&mk(&[]), &[]));
+        assert!(satisfies(&mk(&["chat"]), &[]));
+        assert!(!satisfies(&mk(&["embedding"]), &[]));
+        // Above baseline: unstated is not permission.
+        assert!(!satisfies(&mk(&[]), &[Requirement::Vision]));
+        assert!(!satisfies(&mk(&["chat"]), &[Requirement::Vision]));
+        assert!(satisfies(&mk(&["chat", "vision"]), &[Requirement::Vision]));
+        assert!(!satisfies(&mk(&["chat", "vision"]), &[Requirement::Tools]));
+        assert!(satisfies(
+            &mk(&["chat", "vision", "tools"]),
+            &[Requirement::Vision, Requirement::Tools]
+        ));
+    }
+
+    /// The incident, as a regression test: an image request against a registry
+    /// where nothing declares vision must find no cheap candidate at all.
+    #[test]
+    fn pick_cheap_model_declines_when_no_entry_declares_the_requirement() {
+        let mk = |cost: f64, caps: &[&str]| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            cost_per_1k_tokens: Some(cost),
+            ..Default::default()
+        };
+        let mut reg = ModelRegistry::default();
+        reg.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        reg.models.insert("legacy".into(), mk(0.0002, &[]));
+        reg.models
+            .insert("frontier".into(), mk(0.01, &["chat", "vision"]));
+        // No requirement → cheapest wins (today's behaviour, unchanged).
+        assert_eq!(pick_cheap_model(&reg, None, &[]), Some("cheap_text".into()));
+        // Vision required → only the declaring entry qualifies, cost be damned.
+        assert_eq!(
+            pick_cheap_model(&reg, None, &[Requirement::Vision]),
+            Some("frontier".into())
+        );
+        // Nothing declares vision → None, so Smart goes inert.
+        let mut blind = ModelRegistry::default();
+        blind.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        blind.models.insert("legacy".into(), mk(0.0002, &[]));
+        assert_eq!(pick_cheap_model(&blind, None, &[Requirement::Vision]), None);
+    }
+```
+
+- [ ] Run `cargo nextest run -p mur-common model::tests` → both new tests fail to compile (`cannot find value Requirement`, `this function takes 2 arguments but 3 were supplied`). This is the expected red.
+- [ ] In `mur-common/src/model.rs`, insert immediately **above** `pub fn pick_cheap_model`:
+
+```rust
+/// Registry capability strings. The baseline (`chat`) is legacy-permissive —
+/// an entry with no `capabilities` at all predates the field and is assumed
+/// chat-capable. Everything above the baseline is fail-closed.
+pub const CAP_CHAT: &str = "chat";
+pub const CAP_TOOLS: &str = "tools";
+pub const CAP_VISION: &str = "vision";
+
+/// A capability the request needs from whatever model serves it. Derived from
+/// the request itself (an image in the messages, a tool list) and never from
+/// config: a router may only substitute a model that can do the job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Requirement {
+    /// The request carries an image; the model has to be able to see it.
+    Vision,
+    /// The request declares tools; the model has to be able to call them.
+    Tools,
+}
+
+impl Requirement {
+    /// The registry capability an entry must declare to satisfy this.
+    pub fn capability(self) -> &'static str {
+        match self {
+            Requirement::Vision => CAP_VISION,
+            Requirement::Tools => CAP_TOOLS,
+        }
+    }
+}
+
+/// Can this entry serve a request needing `reqs`?
+///
+/// No registry write path emits `vision` today, so a `Vision` requirement
+/// disqualifies every current entry — auto-substitution goes inert for image
+/// requests rather than answering them blind. The same code makes a finer
+/// distinction the day entries start declaring it; there is no second version
+/// of this function to write later.
+pub fn satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool {
+    let chat_capable = e.capabilities.is_empty() || e.capabilities.iter().any(|c| c == CAP_CHAT);
+    if !chat_capable {
+        return false;
+    }
+    reqs.iter()
+        .all(|r| e.capabilities.iter().any(|c| c == r.capability()))
+}
+```
+
+- [ ] Replace the body and signature of `pick_cheap_model` with:
+
+```rust
+/// Pick the cheapest registry entry that can serve a request needing `reqs`,
+/// excluding `exclude` (the agent's own primary). None when no qualifying
+/// entry exists → caller keeps normal candidates (fail-expensive).
+pub fn pick_cheap_model(
+    reg: &ModelRegistry,
+    exclude: Option<&str>,
+    reqs: &[Requirement],
+) -> Option<String> {
+    reg.models
+        .iter()
+        .filter(|(k, _)| exclude != Some(k.as_str()))
+        .filter(|(_, e)| satisfies(e, reqs))
+        .filter_map(|(k, e)| {
+            // Not the deprecated field directly: `mur model add --output-cost`
+            // deliberately leaves it unset, so reading it drops every entry
+            // added with the current flags instead of ranking it.
+            let (input, output) = e.effective_costs();
+            output.or(input).map(|c| (c, k.clone()))
+        })
+        .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(_, k)| k)
+}
+```
+
+- [ ] Update the three call sites inside the existing test `pick_cheap_model_lowest_cost_chat_excluding_primary` to pass `&[]` as the third argument: `pick_cheap_model(&reg, Some("cheap"), &[])`, `pick_cheap_model(&reg, None, &[])`, `pick_cheap_model(&empty, None, &[])`.
+- [ ] Run `cargo nextest run -p mur-common model::tests` → all green, including the two new tests.
+- [ ] In `mur-agent-runtime/src/llm/fallback/mod.rs`, change the import line `use mur_common::model::{choose_by_difficulty, resolve_model_refs};` to `use mur_common::model::{Requirement, choose_by_difficulty, resolve_model_refs};`
+- [ ] Replace `fn autopick_cheap` (currently at line 427) with:
+
+```rust
+/// The capabilities this request needs from whatever model serves it. Derived
+/// from the request, never from config: an image in the messages means the
+/// model has to be able to see it, a tool list means it has to be able to call.
+fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
+    let mut out = Vec::new();
+    if req
+        .messages
+        .iter()
+        .any(|m| matches!(m, RichMessage::ImageText { .. }))
+    {
+        out.push(Requirement::Vision);
+    }
+    if !req.tools.is_empty() {
+        out.push(Requirement::Tools);
+    }
+    out
+}
+
+fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String> {
+    let path = mur_common::model::ModelRegistry::default_path().ok()?;
+    let reg = mur_common::model::ModelRegistry::load_from(&path).ok()?;
+    mur_common::model::pick_cheap_model(&reg, primary, reqs)
+}
+```
+
+- [ ] In `candidates_for`, inside the `CandidateSource::PerRequest` arm, add `let reqs = requirements_of(req);` as the first line of the arm, and change the auto-pick call from `.or_else(|| autopick_cheap(primary.as_deref()))` to `.or_else(|| autopick_cheap(primary.as_deref(), &reqs))`.
+- [ ] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → green (existing tests unaffected; they pin `smart.cheap` and never reach auto-pick).
+- [ ] `cargo fmt && git commit -am "feat(model): capability requirements gate cheap-model auto-pick"`
+
+---
+
+## Task 2 — Filter every automatic substitution, not just auto-pick
+
+**Interfaces**
+
+*Consumes*: `Requirement`, `satisfies`, `pick_cheap_model`, `requirements_of` (Task 1).
+
+*Produces*: private to `mur-agent-runtime/src/llm/fallback/mod.rs`:
+- `load_registry() -> Option<ModelRegistry>`
+- `ref_ok(reg: Option<&ModelRegistry>, model_ref: &str, reqs: &[Requirement]) -> bool`
+- `filter_eligible(refs: Vec<String>, keep: Option<&str>, reqs: &[Requirement], reg: Option<&ModelRegistry>) -> Vec<String>`
+
+**Steps**
+
+- [ ] Add the failing test to `mur-agent-runtime/src/llm/fallback/tests.rs` (append at the end of the file):
+
+```rust
+/// The incident at the candidate-assembly layer: a background image turn must
+/// not be handed a cheap model that never declared it can see. Text work on the
+/// same config is untouched — this gate costs nothing when nothing is required.
+#[test]
+fn background_image_turn_drops_a_cheap_model_that_cannot_see() {
+    use mur_common::agent::AgentProfile;
+    use mur_common::config::{ModelSwitchConfig, SmartConfig};
+    use mur_common::model::{ModelEntry, ModelRegistry};
+
+    let mk = |cost: f64, caps: &[&str]| ModelEntry {
+        provider: "x".into(),
+        model: "m".into(),
+        capabilities: caps.iter().map(|s| s.to_string()).collect(),
+        cost_per_1k_tokens: Some(cost),
+        ..Default::default()
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let mut reg = ModelRegistry::default();
+    reg.models.insert("cheap".into(), mk(0.0001, &["chat"]));
+    reg.models.insert("primary".into(), mk(0.01, &["chat"]));
+    reg.save_to(&tmp.path().join("models.yaml")).unwrap();
+    // nextest runs one process per test, so this env write is not shared.
+    unsafe { std::env::set_var("MUR_HOME", tmp.path()) };
+
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
+    };
+    let fb = FallbackLlmClient::new_routed(
+        AgentProfile::default_for_tests(),
+        cfg,
+        factory_for(Default::default()),
+        retry0(),
+    );
+
+    let text_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&text_turn),
+        vec!["cheap".to_string(), "primary".into()],
+        "text background work still downgrades"
+    );
+
+    let image_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        messages: vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/png".into(),
+            data: "aGk=".into(),
+            text: "what is in this photo".into(),
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&image_turn),
+        vec!["primary".to_string()],
+        "nothing declares vision, so the explicit primary is all that is left"
+    );
+}
+```
+
+- [ ] Run `cargo nextest run -p mur-agent-runtime background_image_turn` → **fails**, asserting `["cheap", "primary"]` for the image turn. That failure is the bug, reproduced.
+- [ ] Add the three helpers to `mur-agent-runtime/src/llm/fallback/mod.rs`, immediately after `requirements_of`:
+
+```rust
+/// The registry, or `None` when it cannot be read. Eligibility treats `None`
+/// as "no opinion" and keeps every candidate: a routing heuristic must not turn
+/// registry I/O into a hard dependency on the request path.
+fn load_registry() -> Option<mur_common::model::ModelRegistry> {
+    let path = mur_common::model::ModelRegistry::default_path().ok()?;
+    mur_common::model::ModelRegistry::load_from(&path).ok()
+}
+
+/// Can `model_ref` serve a request needing `reqs`? A ref the registry does not
+/// know is kept, so the existing per-candidate factory-error reporting (#947)
+/// still names it instead of it vanishing from the failure list.
+fn ref_ok(
+    reg: Option<&mur_common::model::ModelRegistry>,
+    model_ref: &str,
+    reqs: &[Requirement],
+) -> bool {
+    match reg.and_then(|r| r.models.get(model_ref)) {
+        Some(e) => mur_common::model::satisfies(e, reqs),
+        None => true,
+    }
+}
+
+/// Drop automatic candidates that cannot serve the request. `keep` — the user's
+/// explicit primary — always survives: it is their choice and must fail loudly
+/// rather than be second-guessed. Empty `reqs` is the common case and is free.
+fn filter_eligible(
+    refs: Vec<String>,
+    keep: Option<&str>,
+    reqs: &[Requirement],
+    reg: Option<&mur_common::model::ModelRegistry>,
+) -> Vec<String> {
+    if reqs.is_empty() {
+        return refs;
+    }
+    refs.into_iter()
+        .filter(|r| Some(r.as_str()) == keep || ref_ok(reg, r, reqs))
+        .collect()
+}
+```
+
+- [ ] Replace the whole `CandidateSource::PerRequest { profile, cfg } => { … }` arm of `candidates_for` with:
+
+```rust
+            CandidateSource::PerRequest { profile, cfg } => {
+                let reqs = requirements_of(req);
+                let reg = if reqs.is_empty() {
+                    None
+                } else {
+                    load_registry()
+                };
+
+                // Per-agent routing overrides global; disabled → None → normal
+                // model_ref/default primary. A routed pick is an automatic
+                // substitution, so it has to clear the capability bar too;
+                // when it cannot, resolution falls through to the primary.
+                let routing = profile
+                    .routing
+                    .clone()
+                    .unwrap_or_else(|| cfg.routing.clone());
+                let routed = if routing.enabled {
+                    choose_by_difficulty(estimate_input_tokens(req), &routing)
+                        .filter(|r| ref_ok(reg.as_ref(), r, &reqs))
+                } else {
+                    None
+                };
+                let base = resolve_model_refs(profile, cfg, routed);
+                let keep = base.first().cloned();
+
+                // Smart background: cheap model first, base (primary + chain)
+                // behind it (cascade). Per-agent Smart config overrides global.
+                let smart = profile
+                    .routing
+                    .as_ref()
+                    .and_then(|r| r.smart.clone())
+                    .unwrap_or_else(|| cfg.smart.clone());
+                if matches!(req.intent, RequestIntent::Background(_)) && smart.enabled {
+                    let cheap = smart
+                        .cheap
+                        .clone()
+                        .filter(|c| ref_ok(reg.as_ref(), c, &reqs))
+                        .or_else(|| autopick_cheap(keep.as_deref(), &reqs));
+                    if let Some(c) = cheap {
+                        let mut out = vec![c];
+                        for r in base {
+                            if !out.contains(&r) {
+                                out.push(r);
+                            }
+                        }
+                        return filter_eligible(out, keep.as_deref(), &reqs, reg.as_ref());
+                    }
+                }
+                filter_eligible(base, keep.as_deref(), &reqs, reg.as_ref())
+            }
+```
+
+- [ ] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → all green, including the new test.
+- [ ] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → clean.
+- [ ] `cargo fmt && git commit -am "fix(routing): never substitute a model that cannot serve the request"`
+
+**Layer 1 is complete and shippable here.** Tasks 3-7 are the policy layer.
+
+---
+
+## Task 3 — Partial override types, per-field merge, and the opt-in default
+
+**Interfaces**
+
+*Consumes*: nothing from Tasks 1-2.
+
+*Produces*:
+- `mur_common::config::SmartOverride { enabled: Option<bool>, cheap: Option<String>, max_escalations: Option<u32> }` (`Default`, `PartialEq`)
+- `mur_common::config::RoutingOverride { enabled: Option<bool>, cheap: Option<String>, frontier: Option<String>, threshold_input_tokens: Option<u32>, smart: Option<SmartOverride> }` (`Default`, `PartialEq`)
+- `SmartConfig::merged(&self, ov: Option<&SmartOverride>) -> SmartConfig`
+- `RoutingConfig::merged(&self, ov: Option<&RoutingOverride>) -> RoutingConfig`
+- `mur_common::config::DEFAULT_SMART_ENABLED: bool` (= `false`)
+- `RoutingConfig.smart` is left in place here and removed in Task 4, where `AgentProfile.routing` is retyped — until then `fallback/mod.rs` still reads the legacy `profile.routing.smart` through it.
+
+**Steps**
+
+- [ ] Add the failing tests to the `mod tests` block at the bottom of `mur-common/src/config.rs`:
+
+```rust
+    #[test]
+    fn smart_override_inherits_field_by_field() {
+        let global = SmartConfig {
+            enabled: true,
+            cheap: Some("g".into()),
+            max_escalations: 3,
+        };
+        assert_eq!(global.merged(None), global);
+        assert_eq!(global.merged(Some(&SmartOverride::default())), global);
+        // Overriding one field must not reset the others — the whole point.
+        let only_cheap = SmartOverride {
+            cheap: Some("a".into()),
+            ..Default::default()
+        };
+        let m = global.merged(Some(&only_cheap));
+        assert!(m.enabled, "overriding cheap must not disable Smart");
+        assert_eq!(m.cheap.as_deref(), Some("a"));
+        assert_eq!(m.max_escalations, 3);
+        // An explicit false still beats a global true.
+        let off = SmartOverride {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        assert!(!global.merged(Some(&off)).enabled);
+    }
+
+    #[test]
+    fn routing_override_inherits_field_by_field() {
+        let global = RoutingConfig {
+            enabled: true,
+            cheap: Some("c".into()),
+            frontier: Some("f".into()),
+            threshold_input_tokens: Some(9),
+            smart: None, // removed in Task 4
+        };
+        let only_cheap = RoutingOverride {
+            cheap: Some("a".into()),
+            ..Default::default()
+        };
+        let m = global.merged(Some(&only_cheap));
+        assert!(m.enabled, "overriding cheap must not disable routing");
+        assert_eq!(m.cheap.as_deref(), Some("a"));
+        assert_eq!(m.frontier.as_deref(), Some("f"));
+        assert_eq!(m.threshold_input_tokens, Some(9));
+    }
+```
+
+- [ ] Run `cargo nextest run -p mur-common config::tests` → red (`SmartOverride` not found).
+- [ ] In `mur-common/src/config.rs`, add next to the other default constants (after `DEFAULT_SMART_MAX_ESCALATIONS`, line 16):
+
+```rust
+/// Smart background routing is opt-in. Its failure mode is silent and
+/// irreversible for the turn it degrades, which is the kind of automation that
+/// has to be asked for. See the capability-gate spec §2.
+pub const DEFAULT_SMART_ENABLED: bool = false;
+```
+
+and the serde helper next to `default_smart_max_escalations`:
+
+```rust
+fn default_smart_enabled() -> bool {
+    DEFAULT_SMART_ENABLED
+}
+```
+
+- [ ] In `SmartConfig`, change `#[serde(default = "default_true")]` on `enabled` to `#[serde(default = "default_smart_enabled")]`, and in `impl Default for SmartConfig` change `enabled: true` to `enabled: DEFAULT_SMART_ENABLED`. Update the doc comment above `SmartConfig` — replace "Defaults ON with `cheap: None`" with "Defaults OFF; enable per-agent or globally (`mur model smart on`). `cheap: None` auto-picks".
+- [ ] Add both override types and both `merged` impls immediately after `RoutingConfig`:
+
+```rust
+/// Partial view of [`SmartConfig`] for per-agent overrides: `None` on a field
+/// means "inherit the global value". A distinct type rather than reusing
+/// `SmartConfig`, because a full config standing in for a partial is exactly
+/// what made an omitted field silently mean `false` instead of "unset".
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct SmartOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_escalations: Option<u32>,
+}
+
+/// Partial view of [`RoutingConfig`]. Same inheritance rule as
+/// [`SmartOverride`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct RoutingOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold_input_tokens: Option<u32>,
+    /// Legacy nesting. Smart used to be overridden at `routing.smart`;
+    /// profiles written before the promotion to `AgentProfile.smart` — and
+    /// every exported `.muragent` bundle — still carry it, so it stays
+    /// readable forever. MUR never writes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smart: Option<SmartOverride>,
+}
+
+impl SmartConfig {
+    /// Global values with an agent's override layered on, field by field.
+    pub fn merged(&self, ov: Option<&SmartOverride>) -> SmartConfig {
+        let Some(o) = ov else { return self.clone() };
+        SmartConfig {
+            enabled: o.enabled.unwrap_or(self.enabled),
+            cheap: o.cheap.clone().or_else(|| self.cheap.clone()),
+            max_escalations: o.max_escalations.unwrap_or(self.max_escalations),
+        }
+    }
+}
+
+impl RoutingConfig {
+    /// Global values with an agent's override layered on, field by field.
+    pub fn merged(&self, ov: Option<&RoutingOverride>) -> RoutingConfig {
+        let Some(o) = ov else { return self.clone() };
+        RoutingConfig {
+            enabled: o.enabled.unwrap_or(self.enabled),
+            cheap: o.cheap.clone().or_else(|| self.cheap.clone()),
+            frontier: o.frontier.clone().or_else(|| self.frontier.clone()),
+            threshold_input_tokens: o.threshold_input_tokens.or(self.threshold_input_tokens),
+            // Carried through untouched; the field itself goes away in Task 4.
+            smart: self.smart.clone(),
+        }
+    }
+}
+```
+
+- [ ] Confirm `SmartConfig` still derives `PartialEq` (it does today) — the new tests compare whole structs.
+- [ ] Fix the existing default-value test around `mur-common/src/config.rs:2700`: change `assert!(cfg.models.smart.enabled); // default ON` to:
+
+```rust
+        assert!(
+            !cfg.models.smart.enabled,
+            "Smart background routing is opt-in (capability-gate spec §2)"
+        );
+```
+
+- [ ] Run `cargo nextest run -p mur-common config` → green.
+- [ ] `cargo fmt && git commit -am "feat(config): partial override types for smart/routing, Smart defaults off"`
+
+---
+
+## Task 4 — Promote the per-agent override onto the profile
+
+**Interfaces**
+
+*Consumes*: `SmartOverride`, `RoutingOverride`, `merged` (Task 3).
+
+*Produces*:
+- `AgentProfile.smart: Option<SmartOverride>` (new field, serde-default, skipped when `None`)
+- `AgentProfile.routing: Option<RoutingOverride>` (**retyped** from `Option<RoutingConfig>`)
+- `AgentProfile::effective_smart(&self, cfg: &ModelSwitchConfig) -> SmartConfig`
+- `AgentProfile::effective_routing(&self, cfg: &ModelSwitchConfig) -> RoutingConfig`
+- **Removed**: `RoutingConfig.smart` — the global type stops carrying a per-agent override; only `RoutingOverride` keeps one, for the legacy read
+
+**Steps**
+
+- [ ] Add the failing test to the `mod tests` block in `mur-common/src/agent.rs`:
+
+```rust
+    #[test]
+    fn effective_smart_prefers_the_promoted_field_then_the_legacy_nesting() {
+        use crate::config::{ModelSwitchConfig, SmartConfig, SmartOverride};
+        let cfg = ModelSwitchConfig {
+            smart: SmartConfig {
+                enabled: false,
+                cheap: Some("g".into()),
+                max_escalations: 2,
+            },
+            ..Default::default()
+        };
+        // No override at all → the global values, untouched.
+        let p = AgentProfile::default_for_tests();
+        assert_eq!(p.effective_smart(&cfg), cfg.smart);
+
+        // Legacy profiles carry the override nested under `routing`.
+        let mut legacy = AgentProfile::default_for_tests();
+        legacy.routing = Some(crate::config::RoutingOverride {
+            smart: Some(SmartOverride {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        assert!(legacy.effective_smart(&cfg).enabled, "legacy nesting is read");
+        assert_eq!(
+            legacy.effective_smart(&cfg).cheap.as_deref(),
+            Some("g"),
+            "unset fields still inherit"
+        );
+
+        // The promoted field wins when both are present.
+        let mut both = legacy.clone();
+        both.smart = Some(SmartOverride {
+            enabled: Some(false),
+            ..Default::default()
+        });
+        assert!(!both.effective_smart(&cfg).enabled);
+    }
+```
+
+- [ ] Run `cargo nextest run -p mur-common agent::tests` → red.
+- [ ] In `mur-common/src/agent.rs`, retype the `routing` field and add `smart` directly after it:
+
+```rust
+    /// Per-agent difficulty-routing override. Absent fields inherit the global
+    /// `models.routing`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing: Option<crate::config::RoutingOverride>,
+    /// Per-agent Smart background-routing override. Absent fields inherit the
+    /// global `models.smart`; `None` means "follow the global setting".
+    /// Promoted out of `routing` — nesting it there meant overriding Smart
+    /// silently rewrote this agent's difficulty routing as a side effect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smart: Option<crate::config::SmartOverride>,
+```
+
+- [ ] Add the two helpers inside `impl AgentProfile` (next to `default_for_tests`):
+
+```rust
+    /// This agent's effective Smart config: the global values with the agent's
+    /// override layered on. Reads the promoted `smart` field first and falls
+    /// back to the legacy `routing.smart` nesting that older profiles and
+    /// exported `.muragent` bundles still carry.
+    pub fn effective_smart(
+        &self,
+        cfg: &crate::config::ModelSwitchConfig,
+    ) -> crate::config::SmartConfig {
+        let ov = self
+            .smart
+            .as_ref()
+            .or_else(|| self.routing.as_ref().and_then(|r| r.smart.as_ref()));
+        cfg.smart.merged(ov)
+    }
+
+    /// This agent's effective difficulty-routing config.
+    pub fn effective_routing(
+        &self,
+        cfg: &crate::config::ModelSwitchConfig,
+    ) -> crate::config::RoutingConfig {
+        cfg.routing.merged(self.routing.as_ref())
+    }
+```
+
+- [ ] Fix the existing round-trip test at `mur-common/src/agent.rs:2055`: replace
+
+```rust
+        p.routing = Some(crate::config::RoutingConfig {
+            enabled: true,
+            ..Default::default()
+        });
+```
+
+with
+
+```rust
+        p.routing = Some(crate::config::RoutingOverride {
+            enabled: Some(true),
+            ..Default::default()
+        });
+```
+
+- [ ] Add `smart: None,` to the two `AgentProfile` struct literals — `mur-core/src/cmd/agent/lifecycle.rs:134` (next to `routing: None,`) and `mur-core/src/cmd/agent_companion/connector.rs:548`. `AgentProfile` has no `derive(Default)`, so a literal that omits the new field will not compile.
+- [ ] Replace the four inheritance read sites in `mur-agent-runtime/src/llm/fallback/mod.rs` with the helpers:
+  - in `selection_reason`: `let smart = profile.effective_smart(cfg);`
+  - in `candidates_for`: `let routing = profile.effective_routing(cfg);` and `let smart = profile.effective_smart(cfg);`
+  - in `generate_with_meta`'s `max_esc` match arm: `let smart = profile.effective_smart(cfg);`
+
+  Each replaces the corresponding `profile.routing…unwrap_or_else(|| cfg.…clone())` expression; nothing else in those blocks changes.
+- [ ] Now that the legacy read goes through `RoutingOverride.smart`, delete the `smart: Option<SmartConfig>` field (and its two serde attribute lines) from `RoutingConfig` in `mur-common/src/config.rs`, drop the `smart: self.smart.clone(),` line from `RoutingConfig::merged`, and drop the now-dangling `smart:` line from three literals: the `routing_override_inherits_field_by_field` test (Task 3), `mur-agent-runtime/src/llm/fallback/tests.rs` in `routed_generate_picks_frontier_for_large_request`, and `mur-hub-gui/src-tauri/src/model_switch.rs` around line 155.
+- [ ] Run `cargo nextest run -p mur-common && cargo nextest run -p mur-agent-runtime llm::fallback` → green.
+- [ ] `cargo check --workspace --all-targets` → clean (catches any remaining `AgentProfile` literal in a test target).
+- [ ] `cargo fmt && git commit -am "feat(agent): three-state smart override on the profile"`
+
+---
+
+## Task 5 — Stop the boot gate from silently disabling Smart
+
+**Interfaces**
+
+*Consumes*: `effective_smart`, `effective_routing` (Task 4).
+
+*Produces*: `mur_agent_runtime::supervisor_runner::needs_routing_client(refs: usize, routing_on: bool, smart_on: bool) -> bool` (crate-private).
+
+**Steps**
+
+- [ ] Add the failing test to the existing `#[cfg(test)] mod` at `mur-agent-runtime/src/supervisor_runner.rs:808`:
+
+```rust
+    /// An agent with one model ref and no chain still needs the routing-aware
+    /// client when Smart is on for it — the boot gate used to consult only the
+    /// chain length and difficulty routing, so Smart was dead for exactly the
+    /// agents that never configured anything else.
+    #[test]
+    fn single_ref_agent_with_smart_on_still_needs_the_routing_client() {
+        assert!(!super::needs_routing_client(1, false, false));
+        assert!(super::needs_routing_client(1, false, true));
+        assert!(super::needs_routing_client(1, true, false));
+        assert!(super::needs_routing_client(2, false, false));
+    }
+```
+
+- [ ] Run `cargo nextest run -p mur-agent-runtime needs_routing_client` → red (function does not exist).
+- [ ] Add the predicate just above the function containing the gate (search for `if refs.len() <= 1 && !routing.enabled {`):
+
+```rust
+/// Does this agent need the routing-aware client, or is a single plain client
+/// enough? Extracted so the decision is testable without building providers:
+/// when this is wrong, Smart is silently inert for every agent with no
+/// fallback chain and the toggle reports a state it does not have.
+pub(crate) fn needs_routing_client(refs: usize, routing_on: bool, smart_on: bool) -> bool {
+    refs > 1 || routing_on || smart_on
+}
+```
+
+- [ ] Replace the gate block:
+
+```rust
+    let routing = profile.inner.effective_routing(&switch_cfg);
+    let smart = profile.inner.effective_smart(&switch_cfg);
+    let refs = mur_common::model::resolve_model_refs(&profile.inner, &switch_cfg, None);
+
+    if !needs_routing_client(refs.len(), routing.enabled, smart.enabled) {
+```
+
+  (the old `let routing = profile.inner.routing.clone().unwrap_or_else(…);` goes away; the body of the `if` is unchanged.)
+- [ ] Update the comment block above it: the sentence "With no `models:` config and no per-agent chain/routing, `refs.len() <= 1 && !routing.enabled`" becomes "With no `models:` config, no per-agent chain/routing and Smart off (the default), `needs_routing_client` is false".
+- [ ] Run `cargo nextest run -p mur-agent-runtime` → green.
+- [ ] `cargo fmt && git commit -am "fix(runtime): boot gate consults the effective Smart setting"`
+
+---
+
+## Task 6 — CLI: `mur model smart` and `mur agent smart`
+
+**Interfaces**
+
+*Consumes*: `SmartOverride` (Task 3), `AgentProfile.smart` (Task 4).
+
+*Produces*:
+- `mur_core::cmd::model_smart::cmd_model_smart(home: &Path, on: bool, cheap: Option<&str>) -> anyhow::Result<()>`
+- `mur_core::cmd::agent::model_resolve::cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> anyhow::Result<()>`
+- `ModelCmd::Smart { state: String, cheap: Option<String> }`, `AgentAction::Smart { name: String, state: String }`
+- `mur_core::cmd::model::ensure_ref_exists` becomes `pub(crate)`
+
+**Steps**
+
+- [ ] Create `mur-core/src/cmd/model_smart.rs` with its test first:
+
+```rust
+//! `mur model smart <on|off>` — the global Smart background-routing toggle.
+//!
+//! Its own module rather than another arm in `cmd/model.rs`, which is already
+//! at the 800-line ceiling (CLAUDE.md rule 4), matching the `model_doctor` /
+//! `model_connect` siblings.
+use std::path::Path;
+
+use crate::cmd::model::ensure_ref_exists;
+
+/// Set `models.smart.enabled`, optionally pinning the model Smart downgrades
+/// to. The ref is validated against `models.yaml` fail-closed, like every other
+/// ref-taking setter.
+pub fn cmd_model_smart(home: &Path, on: bool, cheap: Option<&str>) -> anyhow::Result<()> {
+    if let Some(c) = cheap {
+        ensure_ref_exists(home, c)?;
+    }
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.smart.enabled = on;
+    if let Some(c) = cheap {
+        cfg.models.smart.cheap = Some(c.to_string());
+    }
+    crate::store::config::save_config_at(&home.join("config.yaml"), &cfg)?;
+    println!(
+        "smart background routing = {} (cheap = {})",
+        if on { "on" } else { "off" },
+        cfg.models.smart.cheap.as_deref().unwrap_or("auto")
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::model::{ModelEntry, ModelRegistry};
+
+    #[test]
+    fn toggles_and_validates_the_cheap_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "haiku".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-haiku-4-5".into(),
+                ..Default::default()
+            },
+        );
+        reg.save_to(&home.join("models.yaml")).unwrap();
+
+        cmd_model_smart(home, true, Some("haiku")).unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert!(cfg.models.smart.enabled);
+        assert_eq!(cfg.models.smart.cheap.as_deref(), Some("haiku"));
+
+        // Turning it off keeps the pinned ref — the user's choice survives.
+        cmd_model_smart(home, false, None).unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert!(!cfg.models.smart.enabled);
+        assert_eq!(cfg.models.smart.cheap.as_deref(), Some("haiku"));
+
+        // Unknown ref is refused before anything is written.
+        assert!(cmd_model_smart(home, true, Some("nope")).is_err());
+    }
+}
+```
+
+- [ ] Add `pub mod model_smart;` to `mur-core/src/cmd/mod.rs` after `pub mod model_doctor;` (line 53).
+- [ ] Change `fn ensure_ref_exists` in `mur-core/src/cmd/model.rs:704` to `pub(crate) fn ensure_ref_exists`.
+- [ ] Add the subcommand variant to `ModelCmd` in `mur-core/src/cmd/model.rs`, after `Fallback`:
+
+```rust
+    /// Turn Smart background routing on or off globally (config.yaml
+    /// `models.smart`). Off by default: background turns then run on the
+    /// agent's own model. `--cheap` pins the model Smart downgrades to;
+    /// omit it to auto-pick the cheapest capable chat model.
+    Smart {
+        /// `on` or `off`.
+        #[arg(value_parser = ["on", "off"])]
+        state: String,
+        /// Registry key Smart downgrades to. Omit for auto-pick.
+        #[arg(long)]
+        cheap: Option<String>,
+    },
+```
+
+- [ ] Add the dispatch arm next to `ModelCmd::Fallback` (around line 394):
+
+```rust
+        ModelCmd::Smart { state, cheap } => crate::cmd::model_smart::cmd_model_smart(
+            &crate::cmd::agent::resolve_mur_home()?,
+            state == "on",
+            cheap.as_deref(),
+        )?,
+```
+
+- [ ] Add `cmd_agent_set_smart` to `mur-core/src/cmd/agent/model_resolve.rs`, directly after `cmd_agent_set_fallback`:
+
+```rust
+/// Set (or clear) this agent's Smart background-routing override.
+/// `follow` removes the override so the agent inherits `models.smart`.
+pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
+    let profile_path = home.join("agents").join(name).join("profile.yaml");
+    if !profile_path.exists() {
+        bail!("agent '{name}' not installed at {}", profile_path.display());
+    }
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
+            .with_context(|| format!("parse {}", profile_path.display()))?;
+    // Preserve any other overridden field (e.g. a pinned cheap model): this
+    // sets one field, it does not replace the block.
+    let existing = profile.smart.take().unwrap_or_default();
+    profile.smart = match state {
+        "follow" => None,
+        "on" => Some(mur_common::config::SmartOverride {
+            enabled: Some(true),
+            ..existing
+        }),
+        "off" => Some(mur_common::config::SmartOverride {
+            enabled: Some(false),
+            ..existing
+        }),
+        other => bail!("unknown state '{other}' (expected on, off, or follow)"),
+    };
+    std::fs::write(&profile_path, serde_yaml_ng::to_string(&profile)?)
+        .with_context(|| format!("write {}", profile_path.display()))?;
+    println!("agent '{name}' smart routing = {state}");
+    Ok(())
+}
+```
+
+- [ ] Add the CLI variant to `AgentAction` in `mur-core/src/cli/agent.rs`, after `Fallback`:
+
+```rust
+    /// Turn Smart background routing on or off for this agent, or `follow` to
+    /// clear the override and inherit the global setting (`mur model smart`).
+    Smart {
+        /// Agent name.
+        name: String,
+        /// `on`, `off`, or `follow`.
+        #[arg(value_parser = ["on", "off", "follow"])]
+        state: String,
+    },
+```
+
+- [ ] Add the dispatch arm in `mur-core/src/dispatch.rs`, after the `AgentAction::Fallback` arm:
+
+```rust
+        AgentAction::Smart { name, state } => cmd::agent::model_resolve::cmd_agent_set_smart(
+            &cmd::agent::resolve_mur_home()?,
+            &name,
+            &state,
+        )?,
+```
+
+- [ ] Run `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo nextest run -p mur-core model_smart` → green. (`mur-core` needs both env vars to build; without `MUR_WEB_DIST` the dashboard embed fails.)
+- [ ] Verify the surface end to end:
+
+```bash
+export MUR_HOME=$(mktemp -d)
+cargo run -q -- model smart on --cheap nope   # expect: error, model_ref "nope" not in models.yaml
+cargo run -q -- model smart off               # expect: smart background routing = off (cheap = auto)
+```
+
+- [ ] `cargo fmt && git commit -am "feat(cli): mur model smart and mur agent smart"`
+
+---
+
+## Task 7 — Hub: three-state per-agent control and the flipped default
+
+**Interfaces**
+
+*Consumes*: `AgentProfile.smart`, `SmartOverride` (Tasks 3-4), `cmd_agent_set_smart` (Task 6).
+
+*Produces*:
+- Tauri commands `agent_get_smart(name) -> Option<bool>` and `agent_set_smart(name, state: String) -> Option<bool>`
+- i18n keys `detail.smartRouting`, `detail.smartFollow`, `detail.smartOn`, `detail.smartOff`, `detail.smartHint` in both locales
+
+**Steps**
+
+- [ ] Add the two command impls to `mur-hub-gui/src-tauri/src/model_switch.rs`, after `agent_set_fallback`:
+
+```rust
+/// Tri-state read: `None` = the agent follows the global setting.
+pub(crate) fn agent_get_smart_impl(home: &Path, name: &str) -> Result<Option<bool>, String> {
+    let path = home.join("agents").join(name).join("profile.yaml");
+    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(
+        &std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?,
+    )
+    .map_err(|e| format!("parse profile: {e}"))?;
+    Ok(profile.smart.and_then(|s| s.enabled))
+}
+
+pub(crate) fn agent_set_smart_impl(
+    home: &Path,
+    name: &str,
+    state: &str,
+) -> Result<Option<bool>, String> {
+    mur_core::cmd::agent::model_resolve::cmd_agent_set_smart(home, name, state)
+        .map_err(|e| format!("{e}"))?;
+    agent_get_smart_impl(home, name)
+}
+
+#[tauri::command]
+pub fn agent_get_smart(name: String) -> Result<Option<bool>, String> {
+    agent_get_smart_impl(&crate::mur_home_path(), &name)
+}
+
+#[tauri::command]
+pub fn agent_set_smart(name: String, state: String) -> Result<Option<bool>, String> {
+    agent_set_smart_impl(&crate::mur_home_path(), &name, &state)
+}
+```
+
+- [ ] Register both in the `tauri::generate_handler![...]` list in `mur-hub-gui/src-tauri/src/lib.rs`, next to `agent_get_fallback` / `agent_set_fallback`.
+- [ ] Flip the TS default in `mur-hub-gui/ui/src/components/settings/modelSwitch.ts` — inside `normalizeMs`, change `enabled: raw.smart?.enabled ?? true` to `enabled: raw.smart?.enabled ?? false`, and update the doc comment sentence about `smart` to say the fallback mirrors the Rust default, which is now off.
+- [ ] Add the vitest case to `mur-hub-gui/ui/src/components/settings/modelSwitch.test.ts`:
+
+```ts
+  it("defaults smart to off when the config predates the field", () => {
+    const raw = { retry: {}, routing: {} } as unknown as ModelSwitchView;
+    expect(normalizeMs(raw).smart.enabled).toBe(false);
+  });
+```
+
+- [ ] Add the five keys to `mur-hub-gui/ui/src/i18n/en.ts`:
+
+```ts
+  "detail.smartRouting": "Smart routing",
+  "detail.smartFollow": "Follow global setting",
+  "detail.smartOn": "On for this agent",
+  "detail.smartOff": "Off for this agent",
+  "detail.smartHint":
+    "Background tasks may run on a cost-saving model. Never applies to requests this agent's cheaper models cannot serve.",
+```
+
+and to `mur-hub-gui/ui/src/i18n/zh-TW.ts`:
+
+```ts
+  "detail.smartRouting": "智慧路由",
+  "detail.smartFollow": "跟隨全域設定",
+  "detail.smartOn": "此 agent 開啟",
+  "detail.smartOff": "此 agent 關閉",
+  "detail.smartHint":
+    "背景任務可能改用較省錢的模型。若該模型無法勝任這個請求，一律不會降級。",
+```
+
+- [ ] Wire the control in `mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx`. Add state and a loader next to the existing `agentChain` pair (around line 91):
+
+```tsx
+  // Per-agent Smart override. null = follow the global setting.
+  const [agentSmart, setAgentSmart] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    invoke<boolean | null>("agent_get_smart", { name: agentName })
+      .then(setAgentSmart)
+      .catch(() => setAgentSmart(null));
+  }, [agentName]);
+
+  function saveAgentSmart(state: string) {
+    invoke<boolean | null>("agent_set_smart", { name: agentName, state })
+      .then(setAgentSmart)
+      .catch((e) => setChainErr(String(e)));
+  }
+```
+
+  and render it directly below the `FallbackChainEditor` block (inside the same `div.tab-form`, after the `chainErr` paragraph):
+
+```tsx
+              <label className="field-label" htmlFor="agent-smart">
+                {t("detail.smartRouting")}
+              </label>
+              <select
+                id="agent-smart"
+                value={agentSmart === null ? "follow" : agentSmart ? "on" : "off"}
+                onChange={(e) => saveAgentSmart(e.target.value)}
+              >
+                <option value="follow">{t("detail.smartFollow")}</option>
+                <option value="on">{t("detail.smartOn")}</option>
+                <option value="off">{t("detail.smartOff")}</option>
+              </select>
+              <p className="settings-hint">{t("detail.smartHint")}</p>
+```
+
+- [ ] Run the UI gate: `cd mur-hub-gui/ui && npm run test && npm run build` → tests green, build succeeds (this also produces `ui/dist`, which the Rust side needs).
+- [ ] Run the Tauri gate: `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings` → clean. (Requires `ui/dist` from the previous step.)
+- [ ] `cargo fmt && git commit -am "feat(hub): three-state per-agent smart routing control"`
+
+---
+
+## Final verification
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo nextest run -p mur-common -p mur-agent-runtime`
+- [ ] `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core`
+- [ ] `cd mur-hub-gui/ui && npm run test && npm run build`
+- [ ] Spec coverage walk: §3.1 → T1; §3.2 → T2; §4.2 → T3; §4.3 → T4; §4.4 → T3 (default) + T5 (gate); §4.5 → T6 (CLI) + T7 (Hub); §4.6 → no task, by design; §7 (Layer 3) → deliberately out of scope.
+- [ ] Docs: this change adds two CLI commands and flips a user-visible default, so it triggers the documentation checklist (README, docs site, product page) via the `update-docs` skill. Not part of this plan — raise it as the follow-up when the branch is ready.

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -1103,10 +1103,10 @@ and to `mur-hub-gui/ui/src/i18n/zh-TW.ts`:
 
 ## Final verification
 
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
-- [ ] `cargo nextest run -p mur-common -p mur-agent-runtime`
-- [ ] `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core`
-- [ ] `cd mur-hub-gui/ui && npm run test && npm run build`
-- [ ] Spec coverage walk: §3.1 → T1; §3.2 → T2; §4.2 → T3; §4.3 → T4; §4.4 → T3 (default) + T5 (gate); §4.5 → T6 (CLI) + T7 (Hub); §4.6 → no task, by design; §7 (Layer 3) → deliberately out of scope.
-- [ ] Docs: this change adds two CLI commands and flips a user-visible default, so it triggers the documentation checklist (README, docs site, product page) via the `update-docs` skill. Not part of this plan — raise it as the follow-up when the branch is ready.
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` — caught two `needless_update` errors in pre-existing difficulty-routing tests, left dangling by removing `RoutingConfig.smart`. `cargo check --all-targets` compiles them fine; only clippy rejects them, so five literals needed the field dropped, not the three this plan listed
+- [x] `cargo nextest run -p mur-common -p mur-agent-runtime`
+- [x] `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432 cargo nextest run -p mur-core`
+- [x] `cd mur-hub-gui/ui && npm run test && npm run build`
+- [x] Spec coverage walk: §3.1 → T1; §3.2 → T2; §4.2 → T3; §4.3 → T4; §4.4 → T3 (default) + T5 (gate); §4.5 → T6 (CLI) + T7 (Hub); §4.6 → no task, by design; §7 (Layer 3) → deliberately out of scope.
+- [x] Docs: this change adds two CLI commands and flips a user-visible default, so it triggers the documentation checklist (README, docs site, product page) via the `update-docs` skill. Not part of this plan — raise it as the follow-up when the branch is ready.

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -989,7 +989,7 @@ cargo run -q --bin mur -- model smart off               # expect: smart backgrou
 
 **Steps**
 
-- [ ] Add the two command impls to `mur-hub-gui/src-tauri/src/model_switch.rs`, after `agent_set_fallback`:
+- [x] Add the two command impls to `mur-hub-gui/src-tauri/src/model_switch.rs`, after `agent_set_fallback`:
 
 ```rust
 /// Tri-state read: `None` = the agent follows the global setting.
@@ -1023,9 +1023,9 @@ pub fn agent_set_smart(name: String, state: String) -> Result<Option<bool>, Stri
 }
 ```
 
-- [ ] Register both in the `tauri::generate_handler![...]` list in `mur-hub-gui/src-tauri/src/lib.rs`, next to `agent_get_fallback` / `agent_set_fallback`.
-- [ ] Flip the TS default in `mur-hub-gui/ui/src/components/settings/modelSwitch.ts` — inside `normalizeMs`, change `enabled: raw.smart?.enabled ?? true` to `enabled: raw.smart?.enabled ?? false`, and update the doc comment sentence about `smart` to say the fallback mirrors the Rust default, which is now off.
-- [ ] Add the vitest case to `mur-hub-gui/ui/src/components/settings/modelSwitch.test.ts`:
+- [x] Register both in the `tauri::generate_handler![...]` list in `mur-hub-gui/src-tauri/src/lib.rs`, next to `agent_get_fallback` / `agent_set_fallback`.
+- [x] Flip the TS default in `mur-hub-gui/ui/src/components/settings/modelSwitch.ts` — inside `normalizeMs`, change `enabled: raw.smart?.enabled ?? true` to `enabled: raw.smart?.enabled ?? false`, and update the doc comment sentence about `smart` to say the fallback mirrors the Rust default, which is now off.
+- [x] Add the vitest case to `mur-hub-gui/ui/src/components/settings/modelSwitch.test.ts`:
 
 ```ts
   it("defaults smart to off when the config predates the field", () => {
@@ -1034,7 +1034,7 @@ pub fn agent_set_smart(name: String, state: String) -> Result<Option<bool>, Stri
   });
 ```
 
-- [ ] Add the five keys to `mur-hub-gui/ui/src/i18n/en.ts`:
+- [x] Add the five keys to `mur-hub-gui/ui/src/i18n/en.ts`:
 
 ```ts
   "detail.smartRouting": "Smart routing",
@@ -1056,7 +1056,7 @@ and to `mur-hub-gui/ui/src/i18n/zh-TW.ts`:
     "背景任務可能改用較省錢的模型。若該模型無法勝任這個請求，一律不會降級。",
 ```
 
-- [ ] Wire the control in `mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx`. Add state and a loader next to the existing `agentChain` pair (around line 91):
+- [x] Wire the control in `mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx`. Add state and a loader next to the existing `agentChain` pair (around line 91):
 
 ```tsx
   // Per-agent Smart override. null = follow the global setting.
@@ -1093,9 +1093,11 @@ and to `mur-hub-gui/ui/src/i18n/zh-TW.ts`:
               <p className="settings-hint">{t("detail.smartHint")}</p>
 ```
 
-- [ ] Run the UI gate: `cd mur-hub-gui/ui && npm run test && npm run build` → tests green, build succeeds (this also produces `ui/dist`, which the Rust side needs).
-- [ ] Run the Tauri gate: `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings` → clean. (Requires `ui/dist` from the previous step.)
-- [ ] `cargo fmt && git commit -am "feat(hub): three-state per-agent smart routing control"`
+- [x] `npm ci` first — a fresh worktree has no `node_modules`. Then the UI gate: `npm run test && npm run build`
+- [x] **Plan gap found during execution**: the existing case `normalizeMs fills fields the Rust config omits` asserted `smart.enabled === true`. Flipped to `false` alongside the default (same class as the Rust-side `smart_config_defaults_on_with_autopick`)
+- [x] ~~Run the UI gate~~ → tests green, build succeeds (this also produces `ui/dist`, which the Rust side needs).
+- [x] Run the Tauri gate: `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings` → clean. (Requires `ui/dist` from the previous step.) The log never prints `Checking mur-hub-gui` — a build-script package gets one `Compiling` line — so a negative control (a deliberate unused variable) was used to confirm the crate really is linted: exit 101, then 0 once removed.
+- [x] `cargo fmt && git commit -am "feat(hub): three-state per-agent smart routing control"`
 
 ---
 

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -806,7 +806,7 @@ pub(crate) fn needs_routing_client(refs: usize, routing_on: bool, smart_on: bool
 
 **Steps**
 
-- [ ] Create `mur-core/src/cmd/model_smart.rs` with its test first:
+- [x] Create `mur-core/src/cmd/model_smart.rs` with its test first:
 
 ```rust
 //! `mur model smart <on|off>` — the global Smart background-routing toggle.
@@ -876,9 +876,9 @@ mod tests {
 }
 ```
 
-- [ ] Add `pub mod model_smart;` to `mur-core/src/cmd/mod.rs` after `pub mod model_doctor;` (line 53).
-- [ ] Change `fn ensure_ref_exists` in `mur-core/src/cmd/model.rs:704` to `pub(crate) fn ensure_ref_exists`.
-- [ ] Add the subcommand variant to `ModelCmd` in `mur-core/src/cmd/model.rs`, after `Fallback`:
+- [x] Add `pub mod model_smart;` to `mur-core/src/cmd/mod.rs` after `pub mod model_doctor;` (line 53).
+- [x] Change `fn ensure_ref_exists` in `mur-core/src/cmd/model.rs:704` to `pub(crate) fn ensure_ref_exists`.
+- [x] Add the subcommand variant to `ModelCmd` in `mur-core/src/cmd/model.rs`, after `Fallback`:
 
 ```rust
     /// Turn Smart background routing on or off globally (config.yaml
@@ -895,7 +895,7 @@ mod tests {
     },
 ```
 
-- [ ] Add the dispatch arm next to `ModelCmd::Fallback` (around line 394):
+- [x] Add the dispatch arm next to `ModelCmd::Fallback` (around line 394):
 
 ```rust
         ModelCmd::Smart { state, cheap } => crate::cmd::model_smart::cmd_model_smart(
@@ -905,7 +905,7 @@ mod tests {
         )?,
 ```
 
-- [ ] Add `cmd_agent_set_smart` to `mur-core/src/cmd/agent/model_resolve.rs`, directly after `cmd_agent_set_fallback`:
+- [x] Add `cmd_agent_set_smart` to `mur-core/src/cmd/agent/model_resolve.rs`, directly after `cmd_agent_set_fallback`:
 
 ```rust
 /// Set (or clear) this agent's Smart background-routing override.
@@ -940,7 +940,7 @@ pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
 }
 ```
 
-- [ ] Add the CLI variant to `AgentAction` in `mur-core/src/cli/agent.rs`, after `Fallback`:
+- [x] Add the CLI variant to `AgentAction` in `mur-core/src/cli/agent.rs`, after `Fallback`:
 
 ```rust
     /// Turn Smart background routing on or off for this agent, or `follow` to
@@ -954,7 +954,7 @@ pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
     },
 ```
 
-- [ ] Add the dispatch arm in `mur-core/src/dispatch.rs`, after the `AgentAction::Fallback` arm:
+- [x] Add the dispatch arm in `mur-core/src/dispatch.rs`, after the `AgentAction::Fallback` arm:
 
 ```rust
         AgentAction::Smart { name, state } => cmd::agent::model_resolve::cmd_agent_set_smart(
@@ -964,16 +964,16 @@ pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
         )?,
 ```
 
-- [ ] Run `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo nextest run -p mur-core model_smart` → green. (`mur-core` needs both env vars to build; without `MUR_WEB_DIST` the dashboard embed fails.)
-- [ ] Verify the surface end to end:
+- [x] Run `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo nextest run -p mur-core model_smart` → green. (`mur-core` needs both env vars to build; without `MUR_WEB_DIST` the dashboard embed fails.)
+- [x] Verify the surface end to end:
 
 ```bash
 export MUR_HOME=$(mktemp -d)
-cargo run -q -- model smart on --cheap nope   # expect: error, model_ref "nope" not in models.yaml
-cargo run -q -- model smart off               # expect: smart background routing = off (cheap = auto)
+cargo run -q --bin mur -- model smart on --cheap nope   # --bin is required: the workspace has 10 binaries   # expect: error, model_ref "nope" not in models.yaml
+cargo run -q --bin mur -- model smart off               # expect: smart background routing = off (cheap = auto)
 ```
 
-- [ ] `cargo fmt && git commit -am "feat(cli): mur model smart and mur agent smart"`
+- [x] `cargo fmt && git commit -am "feat(cli): mur model smart and mur agent smart"`
 
 ---
 

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -616,7 +616,7 @@ impl RoutingConfig {
 
 **Steps**
 
-- [ ] Add the failing test to the `mod tests` block in `mur-common/src/agent.rs`:
+- [x] Add the failing test to the `mod tests` block in `mur-common/src/agent.rs`:
 
 ```rust
     #[test]
@@ -660,8 +660,8 @@ impl RoutingConfig {
     }
 ```
 
-- [ ] Run `cargo nextest run -p mur-common agent::tests` → red.
-- [ ] In `mur-common/src/agent.rs`, retype the `routing` field and add `smart` directly after it:
+- [x] Run `cargo nextest run -p mur-common agent::tests` → red.
+- [x] In `mur-common/src/agent.rs`, retype the `routing` field and add `smart` directly after it:
 
 ```rust
     /// Per-agent difficulty-routing override. Absent fields inherit the global
@@ -676,7 +676,7 @@ impl RoutingConfig {
     pub smart: Option<crate::config::SmartOverride>,
 ```
 
-- [ ] Add the two helpers inside `impl AgentProfile` (next to `default_for_tests`):
+- [x] Add the two helpers inside `impl AgentProfile` (next to `default_for_tests`):
 
 ```rust
     /// This agent's effective Smart config: the global values with the agent's
@@ -703,7 +703,7 @@ impl RoutingConfig {
     }
 ```
 
-- [ ] Fix the existing round-trip test at `mur-common/src/agent.rs:2055`: replace
+- [x] Fix the existing round-trip test at `mur-common/src/agent.rs:2055`: replace
 
 ```rust
         p.routing = Some(crate::config::RoutingConfig {
@@ -721,17 +721,18 @@ with
         });
 ```
 
-- [ ] Add `smart: None,` to the two `AgentProfile` struct literals — `mur-core/src/cmd/agent/lifecycle.rs:134` (next to `routing: None,`) and `mur-core/src/cmd/agent_companion/connector.rs:548`. `AgentProfile` has no `derive(Default)`, so a literal that omits the new field will not compile.
-- [ ] Replace the four inheritance read sites in `mur-agent-runtime/src/llm/fallback/mod.rs` with the helpers:
+- [x] Add `smart: None,` to the two `AgentProfile` struct literals — `mur-core/src/cmd/agent/lifecycle.rs:134` (next to `routing: None,`) and `mur-core/src/cmd/agent_companion/connector.rs:548`. `AgentProfile` has no `derive(Default)`, so a literal that omits the new field will not compile.
+- [x] Replace the four inheritance read sites in `mur-agent-runtime/src/llm/fallback/mod.rs` with the helpers:
   - in `selection_reason`: `let smart = profile.effective_smart(cfg);`
   - in `candidates_for`: `let routing = profile.effective_routing(cfg);` and `let smart = profile.effective_smart(cfg);`
   - in `generate_with_meta`'s `max_esc` match arm: `let smart = profile.effective_smart(cfg);`
 
   Each replaces the corresponding `profile.routing…unwrap_or_else(|| cfg.…clone())` expression; nothing else in those blocks changes.
-- [ ] Now that the legacy read goes through `RoutingOverride.smart`, delete the `smart: Option<SmartConfig>` field (and its two serde attribute lines) from `RoutingConfig` in `mur-common/src/config.rs`, drop the `smart: self.smart.clone(),` line from `RoutingConfig::merged`, and drop the now-dangling `smart:` line from three literals: the `routing_override_inherits_field_by_field` test (Task 3), `mur-agent-runtime/src/llm/fallback/tests.rs` in `routed_generate_picks_frontier_for_large_request`, and `mur-hub-gui/src-tauri/src/model_switch.rs` around line 155.
-- [ ] Run `cargo nextest run -p mur-common && cargo nextest run -p mur-agent-runtime llm::fallback` → green.
-- [ ] `cargo check --workspace --all-targets` → clean (catches any remaining `AgentProfile` literal in a test target).
-- [ ] `cargo fmt && git commit -am "feat(agent): three-state smart override on the profile"`
+- [x] Now that the legacy read goes through `RoutingOverride.smart`, delete the `smart: Option<SmartConfig>` field (and its two serde attribute lines) from `RoutingConfig` in `mur-common/src/config.rs`, drop the `smart: self.smart.clone(),` line from `RoutingConfig::merged`, and drop the now-dangling `smart:` line from three literals: the `routing_override_inherits_field_by_field` test (Task 3), `mur-agent-runtime/src/llm/fallback/tests.rs` in `routed_generate_picks_frontier_for_large_request`, and `mur-hub-gui/src-tauri/src/model_switch.rs` around line 155.
+- [x] Run `cargo nextest run -p mur-common && cargo nextest run -p mur-agent-runtime llm::fallback` → green.
+- [x] **Task-boundary gap found during execution**: retyping `profile.routing` breaks `supervisor_runner.rs` (`unwrap_or_else(|| switch_cfg.routing.clone())` type mismatch, `!routing.enabled` on an `Option<bool>`), so Task 4 cannot reach a clean workspace check on its own. Task 5's gate edit is the fix; the two tasks were executed and committed together.
+- [x] `cargo check --workspace --all-targets` → clean (catches any remaining `AgentProfile` literal in a test target).
+- [x] `cargo fmt && git commit -am "feat(agent): three-state smart override on the profile"`
 
 ---
 
@@ -745,7 +746,7 @@ with
 
 **Steps**
 
-- [ ] Add the failing test to the existing `#[cfg(test)] mod` at `mur-agent-runtime/src/supervisor_runner.rs:808`:
+- [x] Add the failing test to the existing `#[cfg(test)] mod` at `mur-agent-runtime/src/supervisor_runner.rs:808`:
 
 ```rust
     /// An agent with one model ref and no chain still needs the routing-aware
@@ -761,8 +762,8 @@ with
     }
 ```
 
-- [ ] Run `cargo nextest run -p mur-agent-runtime needs_routing_client` → red (function does not exist).
-- [ ] Add the predicate just above the function containing the gate (search for `if refs.len() <= 1 && !routing.enabled {`):
+- [x] Run `cargo nextest run -p mur-agent-runtime needs_routing_client` → red (function does not exist).
+- [x] Add the predicate just above the function containing the gate (search for `if refs.len() <= 1 && !routing.enabled {`):
 
 ```rust
 /// Does this agent need the routing-aware client, or is a single plain client
@@ -774,7 +775,7 @@ pub(crate) fn needs_routing_client(refs: usize, routing_on: bool, smart_on: bool
 }
 ```
 
-- [ ] Replace the gate block:
+- [x] Replace the gate block:
 
 ```rust
     let routing = profile.inner.effective_routing(&switch_cfg);
@@ -785,9 +786,9 @@ pub(crate) fn needs_routing_client(refs: usize, routing_on: bool, smart_on: bool
 ```
 
   (the old `let routing = profile.inner.routing.clone().unwrap_or_else(…);` goes away; the body of the `if` is unchanged.)
-- [ ] Update the comment block above it: the sentence "With no `models:` config and no per-agent chain/routing, `refs.len() <= 1 && !routing.enabled`" becomes "With no `models:` config, no per-agent chain/routing and Smart off (the default), `needs_routing_client` is false".
-- [ ] Run `cargo nextest run -p mur-agent-runtime` → green.
-- [ ] `cargo fmt && git commit -am "fix(runtime): boot gate consults the effective Smart setting"`
+- [x] Update the comment block above it: the sentence "With no `models:` config and no per-agent chain/routing, `refs.len() <= 1 && !routing.enabled`" becomes "With no `models:` config, no per-agent chain/routing and Smart off (the default), `needs_routing_client` is false".
+- [x] Run `cargo nextest run -p mur-agent-runtime` → green.
+- [x] `cargo fmt && git commit -am "fix(runtime): boot gate consults the effective Smart setting"`
 
 ---
 

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -452,7 +452,7 @@ fn filter_eligible(
 
 **Steps**
 
-- [ ] Add the failing tests to the `mod tests` block at the bottom of `mur-common/src/config.rs`:
+- [x] Add the failing tests to the `mod tests` block at the bottom of `mur-common/src/config.rs`:
 
 ```rust
     #[test]
@@ -502,8 +502,8 @@ fn filter_eligible(
     }
 ```
 
-- [ ] Run `cargo nextest run -p mur-common config::tests` → red (`SmartOverride` not found).
-- [ ] In `mur-common/src/config.rs`, add next to the other default constants (after `DEFAULT_SMART_MAX_ESCALATIONS`, line 16):
+- [x] Run `cargo nextest run -p mur-common config::tests` → red (`SmartOverride` not found).
+- [x] In `mur-common/src/config.rs`, add next to the other default constants (after `DEFAULT_SMART_MAX_ESCALATIONS`, line 16):
 
 ```rust
 /// Smart background routing is opt-in. Its failure mode is silent and
@@ -520,8 +520,8 @@ fn default_smart_enabled() -> bool {
 }
 ```
 
-- [ ] In `SmartConfig`, change `#[serde(default = "default_true")]` on `enabled` to `#[serde(default = "default_smart_enabled")]`, and in `impl Default for SmartConfig` change `enabled: true` to `enabled: DEFAULT_SMART_ENABLED`. Update the doc comment above `SmartConfig` — replace "Defaults ON with `cheap: None`" with "Defaults OFF; enable per-agent or globally (`mur model smart on`). `cheap: None` auto-picks".
-- [ ] Add both override types and both `merged` impls immediately after `RoutingConfig`:
+- [x] In `SmartConfig`, change `#[serde(default = "default_true")]` on `enabled` to `#[serde(default = "default_smart_enabled")]`, and in `impl Default for SmartConfig` change `enabled: true` to `enabled: DEFAULT_SMART_ENABLED`. Update the doc comment above `SmartConfig` — replace "Defaults ON with `cheap: None`" with "Defaults OFF; enable per-agent or globally (`mur model smart on`). `cheap: None` auto-picks".
+- [x] Add both override types and both `merged` impls immediately after `RoutingConfig`:
 
 ```rust
 /// Partial view of [`SmartConfig`] for per-agent overrides: `None` on a field
@@ -586,8 +586,8 @@ impl RoutingConfig {
 }
 ```
 
-- [ ] Confirm `SmartConfig` still derives `PartialEq` (it does today) — the new tests compare whole structs.
-- [ ] Fix the existing default-value test around `mur-common/src/config.rs:2700`: change `assert!(cfg.models.smart.enabled); // default ON` to:
+- [x] Confirm `SmartConfig` still derives `PartialEq` (it does today) — the new tests compare whole structs.
+- [x] Fix the existing default-value test around `mur-common/src/config.rs:2700`: change `assert!(cfg.models.smart.enabled); // default ON` to:
 
 ```rust
         assert!(
@@ -596,8 +596,8 @@ impl RoutingConfig {
         );
 ```
 
-- [ ] Run `cargo nextest run -p mur-common config` → green.
-- [ ] `cargo fmt && git commit -am "feat(config): partial override types for smart/routing, Smart defaults off"`
+- [x] Run `cargo nextest run -p mur-common config` → green.
+- [x] `cargo fmt && git commit -am "feat(config): partial override types for smart/routing, Smart defaults off"`
 
 ---
 

--- a/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
+++ b/docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md
@@ -75,7 +75,7 @@ Copied verbatim; every task implicitly includes all of them.
 
 **Steps**
 
-- [ ] Add both failing tests to the `mod tests` block in `mur-common/src/model.rs` (append after `pick_cheap_model_lowest_cost_chat_excluding_primary`):
+- [x] Add both failing tests to the `mod tests` block in `mur-common/src/model.rs` (append after `pick_cheap_model_lowest_cost_chat_excluding_primary`):
 
 ```rust
     #[test]
@@ -132,8 +132,8 @@ Copied verbatim; every task implicitly includes all of them.
     }
 ```
 
-- [ ] Run `cargo nextest run -p mur-common model::tests` → both new tests fail to compile (`cannot find value Requirement`, `this function takes 2 arguments but 3 were supplied`). This is the expected red.
-- [ ] In `mur-common/src/model.rs`, insert immediately **above** `pub fn pick_cheap_model`:
+- [x] Run `cargo nextest run -p mur-common model::tests` → both new tests fail to compile (`cannot find value Requirement`, `this function takes 2 arguments but 3 were supplied`). This is the expected red.
+- [x] In `mur-common/src/model.rs`, insert immediately **above** `pub fn pick_cheap_model`:
 
 ```rust
 /// Registry capability strings. The baseline (`chat`) is legacy-permissive —
@@ -181,7 +181,7 @@ pub fn satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool {
 }
 ```
 
-- [ ] Replace the body and signature of `pick_cheap_model` with:
+- [x] Replace the body and signature of `pick_cheap_model` with:
 
 ```rust
 /// Pick the cheapest registry entry that can serve a request needing `reqs`,
@@ -208,10 +208,10 @@ pub fn pick_cheap_model(
 }
 ```
 
-- [ ] Update the three call sites inside the existing test `pick_cheap_model_lowest_cost_chat_excluding_primary` to pass `&[]` as the third argument: `pick_cheap_model(&reg, Some("cheap"), &[])`, `pick_cheap_model(&reg, None, &[])`, `pick_cheap_model(&empty, None, &[])`.
-- [ ] Run `cargo nextest run -p mur-common model::tests` → all green, including the two new tests.
-- [ ] In `mur-agent-runtime/src/llm/fallback/mod.rs`, change the import line `use mur_common::model::{choose_by_difficulty, resolve_model_refs};` to `use mur_common::model::{Requirement, choose_by_difficulty, resolve_model_refs};`
-- [ ] Replace `fn autopick_cheap` (currently at line 427) with:
+- [x] Update the call sites to pass `&[]` as the third argument. **Plan said three; there are five** — two more live in the price/`effective_costs` tests (lines ~1020 and ~1034). Same mechanical fix: `pick_cheap_model(&reg, Some("cheap"), &[])`, `pick_cheap_model(&reg, None, &[])`, `pick_cheap_model(&empty, None, &[])`.
+- [x] Run `cargo nextest run -p mur-common model::tests` → all green, including the two new tests.
+- [x] In `mur-agent-runtime/src/llm/fallback/mod.rs`, change the import line `use mur_common::model::{choose_by_difficulty, resolve_model_refs};` to `use mur_common::model::{Requirement, choose_by_difficulty, resolve_model_refs};`
+- [x] Replace `fn autopick_cheap` (currently at line 427) with:
 
 ```rust
 /// The capabilities this request needs from whatever model serves it. Derived
@@ -239,9 +239,9 @@ fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String>
 }
 ```
 
-- [ ] In `candidates_for`, inside the `CandidateSource::PerRequest` arm, add `let reqs = requirements_of(req);` as the first line of the arm, and change the auto-pick call from `.or_else(|| autopick_cheap(primary.as_deref()))` to `.or_else(|| autopick_cheap(primary.as_deref(), &reqs))`.
-- [ ] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → green (existing tests unaffected; they pin `smart.cheap` and never reach auto-pick).
-- [ ] `cargo fmt && git commit -am "feat(model): capability requirements gate cheap-model auto-pick"`
+- [x] In `candidates_for`, inside the `CandidateSource::PerRequest` arm, add `let reqs = requirements_of(req);` as the first line of the arm, and change the auto-pick call from `.or_else(|| autopick_cheap(primary.as_deref()))` to `.or_else(|| autopick_cheap(primary.as_deref(), &reqs))`.
+- [x] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → green (existing tests unaffected; they pin `smart.cheap` and never reach auto-pick).
+- [x] `cargo fmt && git commit -am "feat(model): capability requirements gate cheap-model auto-pick"`
 
 ---
 
@@ -258,7 +258,7 @@ fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String>
 
 **Steps**
 
-- [ ] Add the failing test to `mur-agent-runtime/src/llm/fallback/tests.rs` (append at the end of the file):
+- [x] Add the failing test to `mur-agent-runtime/src/llm/fallback/tests.rs` (append at the end of the file):
 
 ```rust
 /// The incident at the candidate-assembly layer: a background image turn must
@@ -329,8 +329,8 @@ fn background_image_turn_drops_a_cheap_model_that_cannot_see() {
 }
 ```
 
-- [ ] Run `cargo nextest run -p mur-agent-runtime background_image_turn` → **fails**, asserting `["cheap", "primary"]` for the image turn. That failure is the bug, reproduced.
-- [ ] Add the three helpers to `mur-agent-runtime/src/llm/fallback/mod.rs`, immediately after `requirements_of`:
+- [x] Run `cargo nextest run -p mur-agent-runtime background_image_turn` → **fails**, asserting `["cheap", "primary"]` for the image turn. That failure is the bug, reproduced.
+- [x] Add the three helpers to `mur-agent-runtime/src/llm/fallback/mod.rs`, immediately after `requirements_of`:
 
 ```rust
 /// The registry, or `None` when it cannot be read. Eligibility treats `None`
@@ -373,7 +373,7 @@ fn filter_eligible(
 }
 ```
 
-- [ ] Replace the whole `CandidateSource::PerRequest { profile, cfg } => { … }` arm of `candidates_for` with:
+- [x] Replace the whole `CandidateSource::PerRequest { profile, cfg } => { … }` arm of `candidates_for` with:
 
 ```rust
             CandidateSource::PerRequest { profile, cfg } => {
@@ -428,9 +428,9 @@ fn filter_eligible(
             }
 ```
 
-- [ ] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → all green, including the new test.
-- [ ] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → clean.
-- [ ] `cargo fmt && git commit -am "fix(routing): never substitute a model that cannot serve the request"`
+- [x] Run `cargo nextest run -p mur-agent-runtime llm::fallback` → all green, including the new test.
+- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → clean.
+- [x] `cargo fmt && git commit -am "fix(routing): never substitute a model that cannot serve the request"`
 
 **Layer 1 is complete and shippable here.** Tasks 3-7 are the policy layer.
 

--- a/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
@@ -1,0 +1,305 @@
+# Smart Routing — Capability Gate + Inheritable Policy Design Spec
+
+> **Date**: 2026-09-01
+> **Status**: Ready for review
+> **Scope**: Make automatic model substitution capability-preserving (Layer 1), and make the Smart-routing policy opt-in with three-state per-agent inheritance (Layer 2). Builds on model-switching Phase 1 (#692), Phase 2 (#693) and Phase A+B (#697).
+> **Out of scope**: quality-based re-routing (still out of scope, see Phase A+B spec); learned/kNN routing (cost-router Phase 3); merging the Smart and difficulty-routing switches into one user-visible toggle (rejected, §9); routing-decision visibility for background turns (Layer 3 — deferred, but see §7).
+
+## 1. The incident this comes from
+
+An agent running scheduled image-recognition turns had its model silently
+substituted by Smart background routing. Recognition quality dropped hard and
+the user had no way to know. Three independent facts make that outcome
+inevitable rather than unlucky:
+
+1. **Auto-pick does not consider capability.** `pick_cheap_model`
+   (`mur-common/src/model.rs:293`) filters on exactly one predicate:
+   `capabilities` contains `chat` **or is empty**. No vision vocabulary exists
+   anywhere: no registry write path (`mur model add`, `mur model connect`)
+   emits one, and observed registries carry only `chat` and `tools`, with most
+   entries carrying no `capabilities` key at all. Every cheap text-tier model
+   is therefore an eligible candidate for an image request.
+2. **Cascade cannot catch a quality failure.** Escalation fires on
+   `LlmError::InvalidResponse` (malformed/empty output). A confidently wrong
+   recognition is well-formed, so the cascade never runs. Quality-based
+   re-routing is explicitly out of scope — meaning quality-sensitive work
+   currently has *no* backstop under Smart.
+3. **The transparency promise does not cover background turns.** The
+   Phase A+B caption (`⚡ model · Smart (background)`) renders in Hub chat.
+   Smart only acts on **background** turns — scheduled tasks and companion
+   outbox generation — which have no chat bubble to carry the caption.
+
+A fourth fact would reproduce the same failure through the other mechanism:
+the token estimator counts an `ImageText` message as `text.len()`
+(`mur-agent-runtime/src/llm/fallback/mod.rs:482`), so "image + short caption"
+estimates as trivially easy and difficulty routing also sends it to `cheap`.
+
+## 2. First principle
+
+> **A router may only substitute a model that can satisfy the request. Price
+> orders the eligible set; it does not define membership.**
+
+This is the load-balancer invariant. Today price *is* the only criterion —
+"can this model do this job" is absent from the decision. Every symptom above
+is that one omission.
+
+Two consequences shape the whole design:
+
+- **Fail-closed above the baseline.** An entry with no declared capabilities is
+  assumed chat-capable (the existing legacy clause, which must stay or every
+  pre-capability entry drops out). It is **not** assumed vision- or
+  tool-capable. Unstated is not permission.
+- **Automation appetite tracks failure mode, not preference.** The Phase A+B
+  spec turned Smart on by default because background failures were judged
+  loud (structural) and correctable (one-click re-run). The incident shows the
+  real failure is silent and irreversible for that turn. Silent + irreversible
+  ⇒ opt-in.
+
+## 3. Layer 1 — Capability gate (mechanism)
+
+### 3.1 Requirements derived from the request
+
+```rust
+// mur-common/src/model.rs — pure, testable, no LlmRequest dependency
+pub enum Requirement { Vision, Tools }
+
+/// Baseline (chat) stays legacy-permissive: empty capabilities = chat-capable.
+/// Everything above baseline is fail-closed: the entry must declare it.
+pub fn satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool;
+
+/// Cheapest chat-capable entry that ALSO satisfies `reqs`.
+pub fn pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>,
+                        reqs: &[Requirement]) -> Option<String>;
+```
+
+```rust
+// mur-agent-runtime — LlmRequest lives here
+fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
+    // messages contains RichMessage::ImageText  -> Vision
+    // !req.tools.is_empty()                     -> Tools
+}
+```
+
+The crate split follows the existing rule: the pure predicate lives in
+`mur-common` (below both `mur-core` and `mur-agent-runtime`); only the
+derivation from `LlmRequest` lives in the runtime.
+
+**Why this is simultaneously the minimal and the complete fix:** no registry
+entry declares `vision` today, so an image request finds no eligible cheap
+candidate and Smart goes inert — the exact behaviour a hardcoded "images are
+never downgraded" check would produce, with no migration. When vision
+declarations later arrive (models.dev carries modality data; `mur model
+connect` already reads that catalog), the same code starts making the finer
+distinction with no second change. There is no minimal-version/full-version
+fork to schedule.
+
+### 3.2 Where the filter applies
+
+Applied in `FallbackLlmClient::candidates_for`
+(`mur-agent-runtime/src/llm/fallback/mod.rs:143`), to **automatic
+substitutions only**:
+
+| Candidate source | Filtered | Why |
+|---|---|---|
+| `req.pin_model_ref` | No | User re-run. Explicit beats smart. |
+| Primary (`model_ref` / `models.default`) | No | The user configured it; it must fail loudly, not be second-guessed. |
+| Smart auto-pick `cheap` | **Yes** | Chosen by MUR for this request. |
+| Difficulty-routed `cheap`/`frontier` | **Yes** | Config declares a policy, not this request's model. Also closes the `text.len()` estimator hole (§1.4). |
+| `fallback_chain` members | **Yes** | Consumed automatically on failure. An ineligible member is skipped like any other unusable candidate. |
+
+If filtering empties the candidate list, the existing exhaustion path returns
+the last error. A loud failure is the correct outcome — never answer an image
+request with a blind model.
+
+`satisfies` never changes `classify()` or the Phase-1 retryable/fatal
+boundary; it only shortens the candidate list before the loop starts.
+
+## 4. Layer 2 — Policy (opt-in + three-state inheritance)
+
+### 4.1 The defect being fixed
+
+`profile.routing` is `Option<RoutingConfig>`
+(`mur-common/src/agent.rs:88`) and is consumed with
+`profile.routing.clone().unwrap_or_else(|| cfg.routing.clone())`
+(`fallback/mod.rs:146`). The full config struct is being used as a partial
+override, so it has only two states — all or nothing — and any field the agent
+omits silently takes the serde default instead of the global value.
+
+The compound trap: disabling Smart for one agent requires writing
+`routing: { smart: { enabled: false } }`, because the per-agent Smart override
+is nested inside `routing` (`config.rs:110`) — and that write simultaneously
+sets that agent's difficulty-routing `enabled` to `false`. Two mechanisms, one
+keystroke, no diagnostic.
+
+### 4.2 Types
+
+```rust
+// mur-common/src/config.rs — partials are their own type; None = inherit
+pub struct SmartOverride {
+    pub enabled: Option<bool>,
+    pub cheap: Option<String>,
+    pub max_escalations: Option<u32>,
+}
+pub struct RoutingOverride {
+    pub enabled: Option<bool>,
+    pub cheap: Option<String>,
+    pub frontier: Option<String>,
+    pub threshold_input_tokens: Option<u32>,
+}
+
+impl SmartConfig   { pub fn merged(&self, ov: Option<&SmartOverride>)   -> SmartConfig; }
+impl RoutingConfig { pub fn merged(&self, ov: Option<&RoutingOverride>) -> RoutingConfig; }
+```
+
+A distinct override type is load-bearing, not ceremony: the bug in §4.1 is
+caused by a full struct standing in for a partial one. The type must say
+"I am a partial" so a missing field cannot mean `Default::default()`.
+
+### 4.3 Profile shape
+
+`AgentProfile` gains `smart: Option<SmartOverride>` **promoted out of
+`routing`** — the nesting is what creates the compound trap. `routing` becomes
+`Option<RoutingOverride>`.
+
+Resolution order for the effective Smart config:
+
+1. `profile.smart` (new location)
+2. `profile.routing.smart` (legacy nested location — read-only compatibility)
+3. global `config.models.smart`
+
+### 4.4 Default and boot gate
+
+- `SmartConfig::default().enabled` flips **`true` → `false`** (`config.rs:51`).
+- `supervisor_runner.rs:474` currently short-circuits to a plain single client
+  on `refs.len() <= 1 && !routing.enabled`, **without consulting
+  `smart.enabled`**. Consequence today: an agent with no fallback chain and no
+  difficulty routing never runs Smart at all, regardless of the global toggle —
+  the switch says "on" and nothing happens. The gate gains the effective Smart
+  check so the toggle stops lying in both directions.
+
+### 4.5 Surfaces
+
+- CLI. Nothing today writes `models.smart` or `models.routing` from the command
+  line — `mur model default` / `fallback` and `mur agent fallback` cover only
+  the chain, and `mur model route` is the unrelated cost-router namespace
+  (role-based spawn routing, `route estimate`). This is the one gap in the
+  model/switch surface:
+  - `mur model smart <on|off> [--cheap <ref>]` — global
+  - `mur agent smart <name> <on|off|follow>` — per-agent, `follow` clears the
+    override
+  - Both validate refs against `models.yaml` fail-closed, matching
+    `mur model fallback` / `mur agent fallback`.
+- Hub: the Smart row in `ModelsSettings.tsx` stays a two-state toggle (global);
+  the per-agent control is **three-state** (`follow` / `on` / `off`) — inherit
+  is a first-class displayed state, not something inferred from a blank field.
+  `validate_refs` in `mur-hub-gui/src-tauri/src/model_switch.rs` extends to the
+  override's `cheap`. i18n keys land in **both** `en.ts` and `zh-TW.ts`.
+  Beware the known narrow-DTO hazard: `model_switch_set` is a full-object write,
+  so any new field must round-trip through the Hub DTO or it is erased on save.
+
+### 4.6 Migration
+
+Changing "omitted field" from *serde default* to *inherit global* is a
+behaviour change for any profile that already carries a `routing:` block, and
+it must be deliberate rather than smuggled in as a bug fix. A one-shot
+migration in the existing `mur-common/src/config_migrate.rs` writes an explicit
+`enabled: false` into any legacy per-agent `routing` block that omitted it,
+preserving today's effective behaviour exactly. Users opt into the new
+inheritance by clearing the field themselves (or via `mur agent smart <name>
+follow`).
+
+Exported `.muragent` bundles carry old profiles, so the legacy nested read
+(§4.3 step 2) is permanent, not transitional.
+
+## 5. Data flow
+
+```
+LlmRequest ──▶ requirements_of()  ──┐
+                                    ├─▶ candidates_for()
+profile.smart ─┐                    │     • pin?      -> [pinned]           (unfiltered)
+profile.routing├─ merged(global) ───┘     • primary   -> kept               (unfiltered)
+global models  ┘                          • cheap/chain -> satisfies(reqs)? (filtered)
+                                          └─▶ [eligible candidates]
+                                                └─▶ existing retry/cascade loop (unchanged)
+```
+
+## 6. Failure modes
+
+| Situation | Behaviour |
+|---|---|
+| Image request, no entry declares vision | Smart inert; primary used. Fail-expensive. |
+| Image request, primary itself cannot see | Primary is unfiltered → provider errors loudly. Not the router's call to silently fix. |
+| Tools requested, cheap entry declares no `tools` | Cheap skipped; next eligible candidate. |
+| All candidates filtered out | Exhaustion path returns the last error (loud). |
+| `smart.cheap` pinned by the user to an ineligible ref | Filtered like any substitution; a pinned *cheap* is a policy, not a per-request choice. Hub/CLI validate the ref exists but cannot validate per-request eligibility. |
+| Legacy profile with nested `routing.smart` | Read at §4.3 step 2; unchanged behaviour. |
+
+## 7. Layer 3 — Visibility (deferred, with a condition attached)
+
+Background routing decisions are recorded (`mur.routing` telemetry, Phase B)
+but have no read surface outside Hub chat captions, which background turns
+never reach. This spec does **not** implement one.
+
+It records the dependency instead: **restoring `smart.enabled` to a default of
+`true` requires a background-visible routing surface first.** Without it, a
+Layer 1 or Layer 2 regression is again invisible to the person paying for it.
+Candidate surfaces (not chosen here): `mur agent routing-log <name>`, a Hub
+notification on substitution, or a provenance line on companion/scheduled
+output.
+
+## 8. Testing
+
+Unit (`mur-common`):
+- `satisfies`: empty capabilities → chat yes, vision no, tools no; declared
+  vision → yes; declared `tools` only → tools yes, vision no.
+- `pick_cheap_model` with `[Vision]` against a registry where nothing declares
+  vision → `None` (the incident, as a regression test).
+- `merged`: `None` field inherits global; `Some` overrides; per-field
+  independence (overriding `cheap` does not disable `enabled`).
+
+Unit (`mur-agent-runtime`):
+- `requirements_of`: `ImageText` → `Vision`; non-empty `tools` → `Tools`;
+  plain text → empty.
+- `candidates_for`: pinned and primary survive filtering; Smart cheap and chain
+  members are filtered; empty result → exhaustion error, not a blind call.
+- Boot gate: agent with one ref and Smart effective-on builds the routed client
+  (regression for §4.4).
+
+Config/back-compat:
+- Legacy `models:` without `smart:` → `enabled: false` (new default).
+- Legacy profile with nested `routing.smart` still resolves.
+- Migration writes explicit `enabled: false` and changes nothing else.
+
+## 9. Rejected alternatives
+
+- **Only flip the default to off.** Leaves the mechanism defect intact: anyone
+  who later turns Smart on — including a future reader of this spec — hits the
+  identical failure, now with "you enabled it yourself" as the explanation. It
+  also converts a mechanism gap into a preference setting, which is how such
+  gaps stop getting fixed.
+- **Hardcode "never downgrade image requests".** Same immediate effect as §3.1
+  but does not generalise, and has to be torn out when capability data arrives.
+  The declared-capability rule costs the same and upgrades itself.
+- **Quality-based re-routing** (judge the output, re-run if poor). Cannot
+  determine quality without a second expensive call, doubles cost on exactly
+  the turns Smart exists to make cheaper, and remains out of scope per the
+  Phase A+B spec.
+- **A per-task "do not downgrade" flag.** A third knob for what per-agent
+  `off` already covers. YAGNI.
+- **One user-visible "smart routing" switch gating both mechanisms.** Their
+  blast radii differ by an order of magnitude — Smart touches background turns
+  only, difficulty routing swaps the model on *interactive* turns by token
+  count. One click producing two classes of behaviour change is the opposite of
+  the transparency principle. What they should share is the inheritance
+  semantics (§4.2), not the switch.
+
+## 10. Phasing
+
+| Phase | Content | Gate |
+|---|---|---|
+| L1 | `Requirement`/`satisfies`/`pick_cheap_model` + `requirements_of` + `candidates_for` filter + tests | Ships alone; fixes the incident without any config change |
+| L2 | Override types, profile promotion, default flip, boot gate, migration, CLI, Hub three-state | Depends on L1 (turning the switch on must already be safe) |
+| L3 | Background-visible routing surface | Precondition for ever defaulting Smart back on (§7) |
+
+L1 is deliberately shippable on its own: it makes the current default-on
+configuration safe for users who never read this spec.

--- a/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
@@ -45,10 +45,24 @@ is that one omission.
 
 Two consequences shape the whole design:
 
-- **Fail-closed above the baseline.** An entry with no declared capabilities is
-  assumed chat-capable (the existing legacy clause, which must stay or every
-  pre-capability entry drops out). It is **not** assumed vision- or
-  tool-capable. Unstated is not permission.
+- **Fail-closed above the baseline, per requirement.** An entry with no declared
+  capabilities is assumed chat-capable (the existing legacy clause, which must
+  stay or every pre-capability entry drops out). Above the baseline the rule
+  follows the *failure mode*, not a blanket policy:
+  - **Vision — silence disqualifies.** A model that cannot see answers with
+    confident nonsense: silent, and unrecoverable for that turn. Unstated is
+    not permission.
+  - **Tools — silence is permitted.** A tool-incapable model is rejected by the
+    provider, loudly, and the existing retry/advance path already handles it.
+    Treating silence as incapacity would drop every pre-`capabilities` entry —
+    most of a real registry — out of the fallback chain of every tool-carrying
+    turn, a large regression bought for very little. (Confirmed against a live
+    registry: the entries in an actual global chain carry no `capabilities` key
+    at all.)
+
+  An entry that *does* declare capabilities is taken at its word either way:
+  enumerating what you can do and leaving `tools` out is a statement, not
+  silence.
 - **Automation appetite tracks failure mode, not preference.** The Phase A+B
   spec turned Smart on by default because background failures were judged
   loud (structural) and correctable (one-click re-run). The incident shows the
@@ -79,6 +93,10 @@ fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
     // !req.tools.is_empty()                     -> Tools
 }
 ```
+
+`Requirement::permitted_when_undeclared` carries the per-requirement rule from
+§2, so `satisfies` enforces a declared capability list exactly and treats an
+absent one according to which failure the requirement guards against.
 
 The crate split follows the existing rule: the pure predicate lives in
 `mur-common` (below both `mur-core` and `mur-agent-runtime`); only the
@@ -240,7 +258,8 @@ global models  ┘                          • cheap/chain -> satisfies(reqs)? 
 |---|---|
 | Image request, no entry declares vision | Smart inert; primary used. Fail-expensive. |
 | Image request, primary itself cannot see | Primary is unfiltered → provider errors loudly. Not the router's call to silently fix. |
-| Tools requested, cheap entry declares no `tools` | Cheap skipped; next eligible candidate. |
+| Tools requested, cheap entry declares `capabilities` without `tools` | Cheap skipped; next eligible candidate. |
+| Tools requested, entry declares no `capabilities` at all | Kept. Silence is permitted for tools (§2); a genuinely tool-incapable model fails loudly and the chain advances. |
 | All candidates filtered out | Exhaustion path returns the last error (loud). |
 | `smart.cheap` pinned by the user to an ineligible ref | Filtered like any substitution; a pinned *cheap* is a policy, not a per-request choice. Hub/CLI validate the ref exists but cannot validate per-request eligibility. |
 | Legacy profile with nested `routing.smart` | Read at §4.3 step 2; unchanged behaviour. |

--- a/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
@@ -199,14 +199,25 @@ Resolution order for the effective Smart config:
 
 ### 4.6 Migration
 
-Changing "omitted field" from *serde default* to *inherit global* is a
-behaviour change for any profile that already carries a `routing:` block, and
-it must be deliberate rather than smuggled in as a bug fix. A one-shot
-migration in the existing `mur-common/src/config_migrate.rs` writes an explicit
-`enabled: false` into any legacy per-agent `routing` block that omitted it,
-preserving today's effective behaviour exactly. Users opt into the new
-inheritance by clearing the field themselves (or via `mur agent smart <name>
-follow`).
+None, deliberately.
+
+`RoutingOverride.enabled` is `Option<bool>`, so a legacy profile that wrote
+`enabled: false` explicitly still deserializes to `Some(false)` and keeps its
+behaviour exactly. Only a profile that *omitted* `enabled` changes meaning —
+from "disabled" (the serde default) to "inherit global".
+
+That difference is observable in exactly one configuration: global difficulty
+routing on **and** a hand-written per-agent `routing:` block that omits
+`enabled`. There, the old behaviour was itself the bug — omission was the only
+way to express a partial override, and it silently disabled the mechanism the
+user had just enabled globally. The new reading is what the author meant.
+
+A file-rewriting migration was considered and rejected. `config_migrate.rs`
+operates on the global `config.yaml` **text** and is wired into
+`Config::load_or_default` / `save_config_at`; it never sees
+`agents/*/profile.yaml`. Honouring the old reading would mean a new
+profile-rewriting pass over every agent on disk to defend a configuration that
+needs two uncommon conditions to coincide.
 
 Exported `.muragent` bundles carry old profiles, so the legacy nested read
 (§4.3 step 2) is permanent, not transitional.
@@ -268,7 +279,8 @@ Unit (`mur-agent-runtime`):
 Config/back-compat:
 - Legacy `models:` without `smart:` → `enabled: false` (new default).
 - Legacy profile with nested `routing.smart` still resolves.
-- Migration writes explicit `enabled: false` and changes nothing else.
+- Legacy profile with an explicit `routing.enabled: false` still resolves to
+  `Some(false)` — no silent re-enable (§4.6).
 
 ## 9. Rejected alternatives
 
@@ -298,7 +310,7 @@ Config/back-compat:
 | Phase | Content | Gate |
 |---|---|---|
 | L1 | `Requirement`/`satisfies`/`pick_cheap_model` + `requirements_of` + `candidates_for` filter + tests | Ships alone; fixes the incident without any config change |
-| L2 | Override types, profile promotion, default flip, boot gate, migration, CLI, Hub three-state | Depends on L1 (turning the switch on must already be safe) |
+| L2 | Override types, profile promotion, default flip, boot gate, CLI, Hub three-state | Depends on L1 (turning the switch on must already be safe) |
 | L3 | Background-visible routing surface | Precondition for ever defaulting Smart back on (§7) |
 
 L1 is deliberately shippable on its own: it makes the current default-on

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -416,10 +416,6 @@ fn truncate_chars(s: &str, max: usize) -> String {
     }
 }
 
-/// Auto-pick a cheap model from the on-disk registry, excluding `primary`.
-/// Any failure (no registry path, load error, empty registry) yields `None`
-/// so the caller falls through to Phase-1 `base` candidates (fail-expensive,
-/// never fail-hard).
 /// The capabilities this request needs from whatever model serves it. Derived
 /// from the request, never from config: an image in the messages means the
 /// model has to be able to see it, a tool list means it has to be able to call.
@@ -438,6 +434,10 @@ fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
     out
 }
 
+/// Auto-pick a cheap model from the on-disk registry that can serve `reqs`,
+/// excluding `primary`. Any failure (no registry path, load error, empty
+/// registry, nothing capable enough) yields `None` so the caller falls through
+/// to the `base` candidates (fail-expensive, never fail-hard).
 fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String> {
     let path = mur_common::model::ModelRegistry::default_path().ok()?;
     let reg = mur_common::model::ModelRegistry::load_from(&path).ok()?;

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -142,18 +142,28 @@ impl FallbackLlmClient {
             CandidateSource::Static(v) => v.clone(),
             CandidateSource::PerRequest { profile, cfg } => {
                 let reqs = requirements_of(req);
+                let reg = if reqs.is_empty() {
+                    None
+                } else {
+                    load_registry()
+                };
+
                 // Per-agent routing overrides global; disabled → None → normal
-                // model_ref/default primary.
+                // model_ref/default primary. A routed pick is an automatic
+                // substitution, so it has to clear the capability bar too;
+                // when it cannot, resolution falls through to the primary.
                 let routing = profile
                     .routing
                     .clone()
                     .unwrap_or_else(|| cfg.routing.clone());
                 let routed = if routing.enabled {
                     choose_by_difficulty(estimate_input_tokens(req), &routing)
+                        .filter(|r| ref_ok(reg.as_ref(), r, &reqs))
                 } else {
                     None
                 };
                 let base = resolve_model_refs(profile, cfg, routed);
+                let keep = base.first().cloned();
 
                 // Smart background: cheap model first, base (primary + chain)
                 // behind it (cascade). Per-agent Smart config overrides global.
@@ -163,11 +173,11 @@ impl FallbackLlmClient {
                     .and_then(|r| r.smart.clone())
                     .unwrap_or_else(|| cfg.smart.clone());
                 if matches!(req.intent, RequestIntent::Background(_)) && smart.enabled {
-                    let primary = base.first().cloned();
                     let cheap = smart
                         .cheap
                         .clone()
-                        .or_else(|| autopick_cheap(primary.as_deref(), &reqs));
+                        .filter(|c| ref_ok(reg.as_ref(), c, &reqs))
+                        .or_else(|| autopick_cheap(keep.as_deref(), &reqs));
                     if let Some(c) = cheap {
                         let mut out = vec![c];
                         for r in base {
@@ -175,10 +185,10 @@ impl FallbackLlmClient {
                                 out.push(r);
                             }
                         }
-                        return out;
+                        return filter_eligible(out, keep.as_deref(), &reqs, reg.as_ref());
                     }
                 }
-                base
+                filter_eligible(base, keep.as_deref(), &reqs, reg.as_ref())
             }
         }
     }
@@ -447,6 +457,45 @@ fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String>
     let path = mur_common::model::ModelRegistry::default_path().ok()?;
     let reg = mur_common::model::ModelRegistry::load_from(&path).ok()?;
     mur_common::model::pick_cheap_model(&reg, primary, reqs)
+}
+
+/// The registry, or `None` when it cannot be read. Eligibility treats `None`
+/// as "no opinion" and keeps every candidate: a routing heuristic must not turn
+/// registry I/O into a hard dependency on the request path.
+fn load_registry() -> Option<mur_common::model::ModelRegistry> {
+    let path = mur_common::model::ModelRegistry::default_path().ok()?;
+    mur_common::model::ModelRegistry::load_from(&path).ok()
+}
+
+/// Can `model_ref` serve a request needing `reqs`? A ref the registry does not
+/// know is kept, so the existing per-candidate factory-error reporting (#947)
+/// still names it instead of it vanishing from the failure list.
+fn ref_ok(
+    reg: Option<&mur_common::model::ModelRegistry>,
+    model_ref: &str,
+    reqs: &[Requirement],
+) -> bool {
+    match reg.and_then(|r| r.models.get(model_ref)) {
+        Some(e) => mur_common::model::satisfies(e, reqs),
+        None => true,
+    }
+}
+
+/// Drop automatic candidates that cannot serve the request. `keep` — the user's
+/// explicit primary — always survives: it is their choice and must fail loudly
+/// rather than be second-guessed. Empty `reqs` is the common case and is free.
+fn filter_eligible(
+    refs: Vec<String>,
+    keep: Option<&str>,
+    reqs: &[Requirement],
+    reg: Option<&mur_common::model::ModelRegistry>,
+) -> Vec<String> {
+    if reqs.is_empty() {
+        return refs;
+    }
+    refs.into_iter()
+        .filter(|r| Some(r.as_str()) == keep || ref_ok(reg, r, reqs))
+        .collect()
 }
 
 /// In-memory per-model cooldown (circuit-breaker). Process-local; a restart

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -119,11 +119,7 @@ impl FallbackLlmClient {
             return "explicit".to_string();
         }
         if let CandidateSource::PerRequest { profile, cfg } = &self.source {
-            let smart = profile
-                .routing
-                .as_ref()
-                .and_then(|r| r.smart.clone())
-                .unwrap_or_else(|| cfg.smart.clone());
+            let smart = profile.effective_smart(cfg);
             if matches!(req.intent, RequestIntent::Background(_)) && smart.enabled {
                 return "smart-background".to_string();
             }
@@ -152,10 +148,7 @@ impl FallbackLlmClient {
                 // model_ref/default primary. A routed pick is an automatic
                 // substitution, so it has to clear the capability bar too;
                 // when it cannot, resolution falls through to the primary.
-                let routing = profile
-                    .routing
-                    .clone()
-                    .unwrap_or_else(|| cfg.routing.clone());
+                let routing = profile.effective_routing(cfg);
                 let routed = if routing.enabled {
                     choose_by_difficulty(estimate_input_tokens(req), &routing)
                         .filter(|r| ref_ok(reg.as_ref(), r, &reqs))
@@ -167,11 +160,7 @@ impl FallbackLlmClient {
 
                 // Smart background: cheap model first, base (primary + chain)
                 // behind it (cascade). Per-agent Smart config overrides global.
-                let smart = profile
-                    .routing
-                    .as_ref()
-                    .and_then(|r| r.smart.clone())
-                    .unwrap_or_else(|| cfg.smart.clone());
+                let smart = profile.effective_smart(cfg);
                 if matches!(req.intent, RequestIntent::Background(_)) && smart.enabled {
                     let cheap = smart
                         .cheap
@@ -230,11 +219,7 @@ impl FallbackLlmClient {
             CandidateSource::PerRequest { profile, cfg }
                 if matches!(req.intent, RequestIntent::Background(_)) =>
             {
-                let smart = profile
-                    .routing
-                    .as_ref()
-                    .and_then(|r| r.smart.clone())
-                    .unwrap_or_else(|| cfg.smart.clone());
+                let smart = profile.effective_smart(cfg);
                 if smart.enabled {
                     smart.max_escalations
                 } else {

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use mur_common::agent::AgentProfile;
 use mur_common::config::{ModelSwitchConfig, RetryConfig};
-use mur_common::model::{choose_by_difficulty, resolve_model_refs};
+use mur_common::model::{Requirement, choose_by_difficulty, resolve_model_refs};
 
 use super::{
     BackgroundKind, Disposition, LlmClient, LlmError, LlmRequest, LlmResponse, RequestIntent,
@@ -141,6 +141,7 @@ impl FallbackLlmClient {
         match &self.source {
             CandidateSource::Static(v) => v.clone(),
             CandidateSource::PerRequest { profile, cfg } => {
+                let reqs = requirements_of(req);
                 // Per-agent routing overrides global; disabled → None → normal
                 // model_ref/default primary.
                 let routing = profile
@@ -166,7 +167,7 @@ impl FallbackLlmClient {
                     let cheap = smart
                         .cheap
                         .clone()
-                        .or_else(|| autopick_cheap(primary.as_deref()));
+                        .or_else(|| autopick_cheap(primary.as_deref(), &reqs));
                     if let Some(c) = cheap {
                         let mut out = vec![c];
                         for r in base {
@@ -424,10 +425,28 @@ fn truncate_chars(s: &str, max: usize) -> String {
 /// Any failure (no registry path, load error, empty registry) yields `None`
 /// so the caller falls through to Phase-1 `base` candidates (fail-expensive,
 /// never fail-hard).
-fn autopick_cheap(primary: Option<&str>) -> Option<String> {
+/// The capabilities this request needs from whatever model serves it. Derived
+/// from the request, never from config: an image in the messages means the
+/// model has to be able to see it, a tool list means it has to be able to call.
+fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
+    let mut out = Vec::new();
+    if req
+        .messages
+        .iter()
+        .any(|m| matches!(m, RichMessage::ImageText { .. }))
+    {
+        out.push(Requirement::Vision);
+    }
+    if !req.tools.is_empty() {
+        out.push(Requirement::Tools);
+    }
+    out
+}
+
+fn autopick_cheap(primary: Option<&str>, reqs: &[Requirement]) -> Option<String> {
     let path = mur_common::model::ModelRegistry::default_path().ok()?;
     let reg = mur_common::model::ModelRegistry::load_from(&path).ok()?;
-    mur_common::model::pick_cheap_model(&reg, primary)
+    mur_common::model::pick_cheap_model(&reg, primary, reqs)
 }
 
 /// In-memory per-model cooldown (circuit-breaker). Process-local; a restart

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -541,3 +541,70 @@ async fn routed_generate_emits_routing_event_on_escalation() {
         other => panic!("expected Event::Routing, got {other:?}"),
     }
 }
+
+/// The incident at the candidate-assembly layer: a background image turn must
+/// not be handed a cheap model that never declared it can see. Text work on the
+/// same config is untouched — this gate costs nothing when nothing is required.
+#[test]
+fn background_image_turn_drops_a_cheap_model_that_cannot_see() {
+    use mur_common::agent::AgentProfile;
+    use mur_common::config::{ModelSwitchConfig, SmartConfig};
+    use mur_common::model::{ModelEntry, ModelRegistry};
+
+    let mk = |cost: f64, caps: &[&str]| ModelEntry {
+        provider: "x".into(),
+        model: "m".into(),
+        capabilities: caps.iter().map(|s| s.to_string()).collect(),
+        cost_per_1k_tokens: Some(cost),
+        ..Default::default()
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let mut reg = ModelRegistry::default();
+    reg.models.insert("cheap".into(), mk(0.0001, &["chat"]));
+    reg.models.insert("primary".into(), mk(0.01, &["chat"]));
+    reg.save_to(&tmp.path().join("models.yaml")).unwrap();
+    // nextest runs one process per test, so this env write is not shared.
+    unsafe { std::env::set_var("MUR_HOME", tmp.path()) };
+
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
+    };
+    let fb = FallbackLlmClient::new_routed(
+        AgentProfile::default_for_tests(),
+        cfg,
+        factory_for(Default::default()),
+        retry0(),
+    );
+
+    let text_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&text_turn),
+        vec!["cheap".to_string(), "primary".into()],
+        "text background work still downgrades"
+    );
+
+    let image_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        messages: vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/png".into(),
+            data: "aGk=".into(),
+            text: "what is in this photo".into(),
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&image_turn),
+        vec!["primary".to_string()],
+        "nothing declares vision, so the explicit primary is all that is left"
+    );
+}

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -332,7 +332,6 @@ async fn routed_generate_picks_frontier_for_large_request() {
             cheap: Some("cheap".into()),
             frontier: Some("frontier".into()),
             threshold_input_tokens: Some(5),
-            smart: None,
         },
         ..Default::default()
     };

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -192,6 +192,14 @@ pub fn build_runner(
     Arc::new(runner)
 }
 
+/// Does this agent need the routing-aware client, or is a single plain client
+/// enough? Extracted so the decision is testable without building providers:
+/// when this is wrong, Smart is silently inert for every agent with no
+/// fallback chain and the toggle reports a state it does not have.
+pub(crate) fn needs_routing_client(refs: usize, routing_on: bool, smart_on: bool) -> bool {
+    refs > 1 || routing_on || smart_on
+}
+
 /// Build the LLM-backed TaskRunner for a resolved model entry.
 /// Returns (runner, optional LLM client for companion sharing, optional McpPool for shutdown).
 #[allow(clippy::too_many_arguments)]
@@ -459,19 +467,17 @@ pub async fn build_provider_runner(
 
     // Model-switch: load the global config, resolve the ordered candidate refs
     // (per-agent overrides global) and decide single-client vs routing-aware
-    // fallback chain. With no `models:` config and no per-agent chain/routing,
-    // `refs.len() <= 1 && !routing.enabled` — the exact single-model path below
-    // runs unchanged (byte-for-byte with the pre-Task-7 behaviour).
+    // fallback chain. With no `models:` config, no per-agent chain/routing and
+    // Smart off (the default), `needs_routing_client` is false — the exact
+    // single-model path below runs unchanged (byte-for-byte with the
+    // pre-Task-7 behaviour).
     let switch_cfg =
         mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).models;
-    let routing = profile
-        .inner
-        .routing
-        .clone()
-        .unwrap_or_else(|| switch_cfg.routing.clone());
+    let routing = profile.inner.effective_routing(&switch_cfg);
+    let smart = profile.inner.effective_smart(&switch_cfg);
     let refs = mur_common::model::resolve_model_refs(&profile.inner, &switch_cfg, None);
 
-    if refs.len() <= 1 && !routing.enabled {
+    if !needs_routing_client(refs.len(), routing.enabled, smart.enabled) {
         // Nothing configured (no chain, no routing) → today's exact single-model
         // path on the SAME `entry` resolved above via `resolve_model_entry`, no
         // FallbackLlmClient wrapper.
@@ -808,6 +814,18 @@ pub(crate) async fn prepare_runtime(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An agent with one model ref and no chain still needs the routing-aware
+    /// client when Smart is on for it — the boot gate used to consult only the
+    /// chain length and difficulty routing, so Smart was dead for exactly the
+    /// agents that never configured anything else.
+    #[test]
+    fn single_ref_agent_with_smart_on_still_needs_the_routing_client() {
+        assert!(!needs_routing_client(1, false, false));
+        assert!(needs_routing_client(1, false, true));
+        assert!(needs_routing_client(1, true, false));
+        assert!(needs_routing_client(2, false, false));
+    }
 
     #[test]
     fn provider_host_extracts_external_host_only() {

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -82,10 +82,16 @@ pub struct AgentProfile {
     /// `models.fallback_chain` when non-empty. See the model-switch spec.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fallback_chain: Vec<String>,
-    /// Per-agent difficulty-routing override. Inherits the global
-    /// `models.routing` when `None`.
+    /// Per-agent difficulty-routing override. Absent fields inherit the global
+    /// `models.routing`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub routing: Option<crate::config::RoutingConfig>,
+    pub routing: Option<crate::config::RoutingOverride>,
+    /// Per-agent Smart background-routing override. Absent fields inherit the
+    /// global `models.smart`; `None` means "follow the global setting".
+    /// Promoted out of `routing` — nesting it there meant overriding Smart
+    /// silently rewrote this agent's difficulty routing as a side effect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smart: Option<crate::config::SmartOverride>,
     #[serde(default)]
     pub mcp_servers: Vec<McpServerEntry>,
     #[serde(default)]
@@ -1754,6 +1760,29 @@ impl AgentProfile {
             .expect("minimal profile fixture")
     }
 
+    /// This agent's effective Smart config: the global values with the agent's
+    /// override layered on. Reads the promoted `smart` field first and falls
+    /// back to the legacy `routing.smart` nesting that older profiles and
+    /// exported `.muragent` bundles still carry.
+    pub fn effective_smart(
+        &self,
+        cfg: &crate::config::ModelSwitchConfig,
+    ) -> crate::config::SmartConfig {
+        let ov = self
+            .smart
+            .as_ref()
+            .or_else(|| self.routing.as_ref().and_then(|r| r.smart.as_ref()));
+        cfg.smart.merged(ov)
+    }
+
+    /// This agent's effective difficulty-routing config.
+    pub fn effective_routing(
+        &self,
+        cfg: &crate::config::ModelSwitchConfig,
+    ) -> crate::config::RoutingConfig {
+        cfg.routing.merged(self.routing.as_ref())
+    }
+
     /// Load an agent's profile from `<mur_home>/agents/<name>/profile.yaml`.
     ///
     /// Canonical read-path counterpart to the atomic-write path used by
@@ -2052,8 +2081,8 @@ mod model_ref_tests {
         // Round-trip with fallback_chain and routing.
         let mut p = p.clone();
         p.fallback_chain = vec!["claude_opus".into(), "claude_sonnet".into()];
-        p.routing = Some(crate::config::RoutingConfig {
-            enabled: true,
+        p.routing = Some(crate::config::RoutingOverride {
+            enabled: Some(true),
             ..Default::default()
         });
         let s = serde_yaml_ng::to_string(&p).unwrap();
@@ -2068,10 +2097,54 @@ mod model_ref_tests {
             vec!["claude_opus", "claude_sonnet"],
             "fallback_chain must round-trip"
         );
-        assert!(
+        assert_eq!(
             p2.routing.as_ref().unwrap().enabled,
+            Some(true),
             "routing.enabled must round-trip"
         );
+    }
+
+    #[test]
+    fn effective_smart_prefers_the_promoted_field_then_the_legacy_nesting() {
+        use crate::config::{ModelSwitchConfig, SmartConfig, SmartOverride};
+        let cfg = ModelSwitchConfig {
+            smart: SmartConfig {
+                enabled: false,
+                cheap: Some("g".into()),
+                max_escalations: 2,
+            },
+            ..Default::default()
+        };
+        // No override at all → the global values, untouched.
+        let p = AgentProfile::default_for_tests();
+        assert_eq!(p.effective_smart(&cfg), cfg.smart);
+
+        // Legacy profiles carry the override nested under `routing`.
+        let mut legacy = AgentProfile::default_for_tests();
+        legacy.routing = Some(crate::config::RoutingOverride {
+            smart: Some(SmartOverride {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        assert!(
+            legacy.effective_smart(&cfg).enabled,
+            "legacy nesting is read"
+        );
+        assert_eq!(
+            legacy.effective_smart(&cfg).cheap.as_deref(),
+            Some("g"),
+            "unset fields still inherit"
+        );
+
+        // The promoted field wins when both are present.
+        let mut both = legacy.clone();
+        both.smart = Some(SmartOverride {
+            enabled: Some(false),
+            ..Default::default()
+        });
+        assert!(!both.effective_smart(&cfg).enabled);
     }
 }
 

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1760,19 +1760,27 @@ impl AgentProfile {
             .expect("minimal profile fixture")
     }
 
+    /// This agent's Smart override, wherever it lives: the promoted `smart`
+    /// field, else the legacy `routing.smart` nesting that older profiles and
+    /// exported `.muragent` bundles still carry. `None` = follow the global
+    /// setting.
+    ///
+    /// Every reader goes through here. A surface that checked only the
+    /// promoted field would report "follows global" for an agent whose legacy
+    /// override is actually in force — one fact, two answers.
+    pub fn smart_override(&self) -> Option<&crate::config::SmartOverride> {
+        self.smart
+            .as_ref()
+            .or_else(|| self.routing.as_ref().and_then(|r| r.smart.as_ref()))
+    }
+
     /// This agent's effective Smart config: the global values with the agent's
-    /// override layered on. Reads the promoted `smart` field first and falls
-    /// back to the legacy `routing.smart` nesting that older profiles and
-    /// exported `.muragent` bundles still carry.
+    /// override layered on.
     pub fn effective_smart(
         &self,
         cfg: &crate::config::ModelSwitchConfig,
     ) -> crate::config::SmartConfig {
-        let ov = self
-            .smart
-            .as_ref()
-            .or_else(|| self.routing.as_ref().and_then(|r| r.smart.as_ref()));
-        cfg.smart.merged(ov)
+        cfg.smart.merged(self.smart_override())
     }
 
     /// This agent's effective difficulty-routing config.

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -15,6 +15,11 @@ pub const DEFAULT_COOLDOWN_SECS: u64 = 60;
 pub const DEFAULT_ROUTING_THRESHOLD: u32 = 2000;
 pub const DEFAULT_SMART_MAX_ESCALATIONS: u32 = 1;
 
+/// Smart background routing is opt-in. Its failure mode is silent and
+/// irreversible for the turn it degrades, which is the kind of automation that
+/// has to be asked for. See the capability-gate spec §2.
+pub const DEFAULT_SMART_ENABLED: bool = false;
+
 /// The Ollama provider default endpoint. Single definition — `BackendConfig`
 /// resolution (`default_ollama_endpoint`), `config_migrate`, and the
 /// conversations `doctor`/`preflight` probes all read this constant instead of
@@ -33,14 +38,18 @@ fn default_cooldown_secs() -> u64 {
 fn default_smart_max_escalations() -> u32 {
     DEFAULT_SMART_MAX_ESCALATIONS
 }
+fn default_smart_enabled() -> bool {
+    DEFAULT_SMART_ENABLED
+}
 
 /// Smart background routing: auto-pick a cheap model for low-stakes/background
 /// requests instead of always dialing the agent's primary model_ref. Defaults
-/// ON with `cheap: None` (auto-pick the cheapest chat-capable registry entry
-/// via `mur_common::model::pick_cheap_model`).
+/// OFF — enable it globally (`mur model smart on`) or per agent. `cheap: None`
+/// auto-picks the cheapest registry entry that can serve the request
+/// (`mur_common::model::pick_cheap_model`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SmartConfig {
-    #[serde(default = "default_true")]
+    #[serde(default = "default_smart_enabled")]
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cheap: Option<String>,
@@ -51,7 +60,7 @@ pub struct SmartConfig {
 impl Default for SmartConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: DEFAULT_SMART_ENABLED,
             cheap: None,
             max_escalations: DEFAULT_SMART_MAX_ESCALATIONS,
         }
@@ -108,6 +117,67 @@ pub struct RoutingConfig {
     pub threshold_input_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smart: Option<SmartConfig>,
+}
+
+/// Partial view of [`SmartConfig`] for per-agent overrides: `None` on a field
+/// means "inherit the global value". A distinct type rather than reusing
+/// `SmartConfig`, because a full config standing in for a partial is exactly
+/// what made an omitted field silently mean `false` instead of "unset".
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct SmartOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_escalations: Option<u32>,
+}
+
+/// Partial view of [`RoutingConfig`]. Same inheritance rule as
+/// [`SmartOverride`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct RoutingOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold_input_tokens: Option<u32>,
+    /// Legacy nesting. Smart used to be overridden at `routing.smart`;
+    /// profiles written before the promotion to `AgentProfile.smart` — and
+    /// every exported `.muragent` bundle — still carry it, so it stays
+    /// readable forever. MUR never writes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smart: Option<SmartOverride>,
+}
+
+impl SmartConfig {
+    /// Global values with an agent's override layered on, field by field.
+    pub fn merged(&self, ov: Option<&SmartOverride>) -> SmartConfig {
+        let Some(o) = ov else { return self.clone() };
+        SmartConfig {
+            enabled: o.enabled.unwrap_or(self.enabled),
+            cheap: o.cheap.clone().or_else(|| self.cheap.clone()),
+            max_escalations: o.max_escalations.unwrap_or(self.max_escalations),
+        }
+    }
+}
+
+impl RoutingConfig {
+    /// Global values with an agent's override layered on, field by field.
+    pub fn merged(&self, ov: Option<&RoutingOverride>) -> RoutingConfig {
+        let Some(o) = ov else { return self.clone() };
+        RoutingConfig {
+            enabled: o.enabled.unwrap_or(self.enabled),
+            cheap: o.cheap.clone().or_else(|| self.cheap.clone()),
+            frontier: o.frontier.clone().or_else(|| self.frontier.clone()),
+            threshold_input_tokens: o.threshold_input_tokens.or(self.threshold_input_tokens),
+            // Carried through untouched; the field itself goes away in Task 4.
+            smart: self.smart.clone(),
+        }
+    }
 }
 
 /// Global MUR configuration (~/.mur/config.yaml)
@@ -2695,13 +2765,62 @@ mod model_switch_config_tests {
     }
 
     #[test]
-    fn smart_config_defaults_on_with_autopick() {
+    fn smart_config_defaults_off_with_autopick() {
         let cfg: Config = serde_yaml::from_str("{}").unwrap();
-        assert!(cfg.models.smart.enabled); // default ON
+        assert!(
+            !cfg.models.smart.enabled,
+            "Smart background routing is opt-in (capability-gate spec §2)"
+        );
         assert_eq!(cfg.models.smart.cheap, None); // auto-pick
         assert_eq!(
             cfg.models.smart.max_escalations,
             DEFAULT_SMART_MAX_ESCALATIONS
         );
+    }
+
+    #[test]
+    fn smart_override_inherits_field_by_field() {
+        let global = SmartConfig {
+            enabled: true,
+            cheap: Some("g".into()),
+            max_escalations: 3,
+        };
+        assert_eq!(global.merged(None), global);
+        assert_eq!(global.merged(Some(&SmartOverride::default())), global);
+        // Overriding one field must not reset the others — the whole point.
+        let only_cheap = SmartOverride {
+            cheap: Some("a".into()),
+            ..Default::default()
+        };
+        let m = global.merged(Some(&only_cheap));
+        assert!(m.enabled, "overriding cheap must not disable Smart");
+        assert_eq!(m.cheap.as_deref(), Some("a"));
+        assert_eq!(m.max_escalations, 3);
+        // An explicit false still beats a global true.
+        let off = SmartOverride {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        assert!(!global.merged(Some(&off)).enabled);
+    }
+
+    #[test]
+    fn routing_override_inherits_field_by_field() {
+        let global = RoutingConfig {
+            enabled: true,
+            cheap: Some("c".into()),
+            frontier: Some("f".into()),
+            threshold_input_tokens: Some(9),
+            smart: None, // removed in Task 4
+        };
+        let only_cheap = RoutingOverride {
+            cheap: Some("a".into()),
+            ..Default::default()
+        };
+        let m = global.merged(Some(&only_cheap));
+        assert!(m.enabled, "overriding cheap must not disable routing");
+        assert_eq!(m.cheap.as_deref(), Some("a"));
+        assert_eq!(m.frontier.as_deref(), Some("f"));
+        assert_eq!(m.threshold_input_tokens, Some(9));
     }
 }

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -115,8 +115,6 @@ pub struct RoutingConfig {
     pub frontier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub threshold_input_tokens: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub smart: Option<SmartConfig>,
 }
 
 /// Partial view of [`SmartConfig`] for per-agent overrides: `None` on a field
@@ -174,8 +172,6 @@ impl RoutingConfig {
             cheap: o.cheap.clone().or_else(|| self.cheap.clone()),
             frontier: o.frontier.clone().or_else(|| self.frontier.clone()),
             threshold_input_tokens: o.threshold_input_tokens.or(self.threshold_input_tokens),
-            // Carried through untouched; the field itself goes away in Task 4.
-            smart: self.smart.clone(),
         }
     }
 }
@@ -2811,7 +2807,6 @@ mod model_switch_config_tests {
             cheap: Some("c".into()),
             frontier: Some("f".into()),
             threshold_input_tokens: Some(9),
-            smart: None, // removed in Task 4
         };
         let only_cheap = RoutingOverride {
             cheap: Some("a".into()),

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -925,7 +925,8 @@ mod switch_tests {
             ..Default::default()
         };
         let mut reg = ModelRegistry::default();
-        reg.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        reg.models
+            .insert("cheap_text".into(), mk(0.0001, &["chat"]));
         reg.models.insert("legacy".into(), mk(0.0002, &[]));
         reg.models
             .insert("frontier".into(), mk(0.01, &["chat", "vision"]));
@@ -938,7 +939,9 @@ mod switch_tests {
         );
         // Nothing declares vision -> None, so Smart goes inert.
         let mut blind = ModelRegistry::default();
-        blind.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        blind
+            .models
+            .insert("cheap_text".into(), mk(0.0001, &["chat"]));
         blind.models.insert("legacy".into(), mk(0.0002, &[]));
         assert_eq!(pick_cheap_model(&blind, None, &[Requirement::Vision]), None);
     }

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -290,15 +290,62 @@ pub fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<
     }
 }
 
-/// Pick the cheapest chat-capable model_ref for Smart background routing,
-/// excluding `exclude` (the agent's own primary). Chat-capable = capabilities
-/// contains "chat" OR is empty (legacy entries assumed chat). None when no
-/// qualifying entry exists → caller keeps normal candidates (fail-expensive).
-pub fn pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>) -> Option<String> {
+/// Registry capability strings. The baseline (`chat`) is legacy-permissive —
+/// an entry with no `capabilities` at all predates the field and is assumed
+/// chat-capable. Everything above the baseline is fail-closed.
+pub const CAP_CHAT: &str = "chat";
+pub const CAP_TOOLS: &str = "tools";
+pub const CAP_VISION: &str = "vision";
+
+/// A capability the request needs from whatever model serves it. Derived from
+/// the request itself (an image in the messages, a tool list) and never from
+/// config: a router may only substitute a model that can do the job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Requirement {
+    /// The request carries an image; the model has to be able to see it.
+    Vision,
+    /// The request declares tools; the model has to be able to call them.
+    Tools,
+}
+
+impl Requirement {
+    /// The registry capability an entry must declare to satisfy this.
+    pub fn capability(self) -> &'static str {
+        match self {
+            Requirement::Vision => CAP_VISION,
+            Requirement::Tools => CAP_TOOLS,
+        }
+    }
+}
+
+/// Can this entry serve a request needing `reqs`?
+///
+/// No registry write path emits `vision` today, so a `Vision` requirement
+/// disqualifies every current entry — auto-substitution goes inert for image
+/// requests rather than answering them blind. The same code makes a finer
+/// distinction the day entries start declaring it; there is no second version
+/// of this function to write later.
+pub fn satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool {
+    let chat_capable = e.capabilities.is_empty() || e.capabilities.iter().any(|c| c == CAP_CHAT);
+    if !chat_capable {
+        return false;
+    }
+    reqs.iter()
+        .all(|r| e.capabilities.iter().any(|c| c == r.capability()))
+}
+
+/// Pick the cheapest registry entry that can serve a request needing `reqs`,
+/// excluding `exclude` (the agent's own primary). None when no qualifying
+/// entry exists → caller keeps normal candidates (fail-expensive).
+pub fn pick_cheap_model(
+    reg: &ModelRegistry,
+    exclude: Option<&str>,
+    reqs: &[Requirement],
+) -> Option<String> {
     reg.models
         .iter()
         .filter(|(k, _)| exclude != Some(k.as_str()))
-        .filter(|(_, e)| e.capabilities.is_empty() || e.capabilities.iter().any(|c| c == "chat"))
+        .filter(|(_, e)| satisfies(e, reqs))
         .filter_map(|(k, e)| {
             // Not the deprecated field directly: `mur model add --output-cost`
             // deliberately leaves it unset, so reading it drops every entry
@@ -833,14 +880,67 @@ mod switch_tests {
             .insert("embed".into(), mk(0.00001, &["embedding"])); // not chat → skip
         // cheapest chat-capable, excluding the agent's own primary:
         assert_eq!(
-            pick_cheap_model(&reg, Some("cheap")),
+            pick_cheap_model(&reg, Some("cheap"), &[]),
             Some("frontier".into())
         ); // cheap excluded
-        assert_eq!(pick_cheap_model(&reg, None), Some("cheap".into()));
+        assert_eq!(pick_cheap_model(&reg, None, &[]), Some("cheap".into()));
         // no chat entries → None (Smart inert)
         let mut empty = ModelRegistry::default();
         empty.models.insert("e".into(), mk(0.0, &["embedding"]));
-        assert_eq!(pick_cheap_model(&empty, None), None);
+        assert_eq!(pick_cheap_model(&empty, None, &[]), None);
+    }
+
+    #[test]
+    fn satisfies_is_permissive_at_baseline_and_fail_closed_above_it() {
+        let mk = |caps: &[&str]| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        // Baseline: an entry written before the field existed is still chat.
+        assert!(satisfies(&mk(&[]), &[]));
+        assert!(satisfies(&mk(&["chat"]), &[]));
+        assert!(!satisfies(&mk(&["embedding"]), &[]));
+        // Above baseline: unstated is not permission.
+        assert!(!satisfies(&mk(&[]), &[Requirement::Vision]));
+        assert!(!satisfies(&mk(&["chat"]), &[Requirement::Vision]));
+        assert!(satisfies(&mk(&["chat", "vision"]), &[Requirement::Vision]));
+        assert!(!satisfies(&mk(&["chat", "vision"]), &[Requirement::Tools]));
+        assert!(satisfies(
+            &mk(&["chat", "vision", "tools"]),
+            &[Requirement::Vision, Requirement::Tools]
+        ));
+    }
+
+    /// The incident, as a regression test: an image request against a registry
+    /// where nothing declares vision must find no cheap candidate at all.
+    #[test]
+    fn pick_cheap_model_declines_when_no_entry_declares_the_requirement() {
+        let mk = |cost: f64, caps: &[&str]| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            cost_per_1k_tokens: Some(cost),
+            ..Default::default()
+        };
+        let mut reg = ModelRegistry::default();
+        reg.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        reg.models.insert("legacy".into(), mk(0.0002, &[]));
+        reg.models
+            .insert("frontier".into(), mk(0.01, &["chat", "vision"]));
+        // No requirement -> cheapest wins (today's behaviour, unchanged).
+        assert_eq!(pick_cheap_model(&reg, None, &[]), Some("cheap_text".into()));
+        // Vision required -> only the declaring entry qualifies, cost be damned.
+        assert_eq!(
+            pick_cheap_model(&reg, None, &[Requirement::Vision]),
+            Some("frontier".into())
+        );
+        // Nothing declares vision -> None, so Smart goes inert.
+        let mut blind = ModelRegistry::default();
+        blind.models.insert("cheap_text".into(), mk(0.0001, &["chat"]));
+        blind.models.insert("legacy".into(), mk(0.0002, &[]));
+        assert_eq!(pick_cheap_model(&blind, None, &[Requirement::Vision]), None);
     }
 
     /// A price with no date is a guess wearing the costume of a fact. But a
@@ -917,7 +1017,7 @@ models:
         };
         reg.models.insert("dear".into(), split(0.005, 0.025));
         reg.models.insert("cheap".into(), split(0.0001, 0.0004));
-        assert_eq!(pick_cheap_model(&reg, None), Some("cheap".into()));
+        assert_eq!(pick_cheap_model(&reg, None, &[]), Some("cheap".into()));
 
         // Input-only entries are priced too, rather than silently skipped.
         let mut input_only = ModelRegistry::default();
@@ -931,6 +1031,6 @@ models:
                 ..Default::default()
             },
         );
-        assert_eq!(pick_cheap_model(&input_only, None), Some("in".into()));
+        assert_eq!(pick_cheap_model(&input_only, None, &[]), Some("in".into()));
     }
 }

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -316,6 +316,32 @@ impl Requirement {
             Requirement::Tools => CAP_TOOLS,
         }
     }
+
+    /// Does an entry that declares NO capabilities at all satisfy this?
+    ///
+    /// The two requirements differ in how they fail, and the answer follows
+    /// the failure mode rather than a blanket rule:
+    ///
+    /// - `Vision`: **no**. A model that cannot see answers an image request
+    ///   with confident nonsense — silent, and unrecoverable for that turn.
+    ///   That is the failure this gate exists to prevent, so silence about
+    ///   vision is treated as absence of it.
+    /// - `Tools`: **yes**. A model that cannot call tools fails loudly (the
+    ///   provider rejects the request) and the existing retry/advance path
+    ///   already handles it. Treating undeclared as incapable would drop every
+    ///   entry written before `capabilities` existed — in practice most of a
+    ///   real registry — out of the fallback chain of every tool-carrying turn,
+    ///   which is a large regression bought for very little.
+    ///
+    /// An entry that DOES declare capabilities is taken at its word either
+    /// way: if it enumerated what it can do and left `tools` out, that is a
+    /// statement, not silence.
+    fn permitted_when_undeclared(self) -> bool {
+        match self {
+            Requirement::Vision => false,
+            Requirement::Tools => true,
+        }
+    }
 }
 
 /// Can this entry serve a request needing `reqs`?
@@ -330,8 +356,13 @@ pub fn satisfies(e: &ModelEntry, reqs: &[Requirement]) -> bool {
     if !chat_capable {
         return false;
     }
-    reqs.iter()
-        .all(|r| e.capabilities.iter().any(|c| c == r.capability()))
+    reqs.iter().all(|r| {
+        if e.capabilities.is_empty() {
+            r.permitted_when_undeclared()
+        } else {
+            e.capabilities.iter().any(|c| c == r.capability())
+        }
+    })
 }
 
 /// Pick the cheapest registry entry that can serve a request needing `reqs`,
@@ -909,6 +940,32 @@ mod switch_tests {
             &mk(&["chat", "vision", "tools"]),
             &[Requirement::Vision, Requirement::Tools]
         ));
+    }
+
+    /// Tools and Vision disagree about silence on purpose. A tool-incapable
+    /// model fails loudly and the chain advances; a blind one answers with
+    /// confident nonsense. So an entry that declares nothing keeps its place in
+    /// the chain for a tool turn — otherwise every pre-`capabilities` entry
+    /// (most of a real registry) would drop out of every tool-carrying request
+    /// — while the same silence disqualifies it for an image.
+    #[test]
+    fn undeclared_capabilities_pass_tools_but_never_vision() {
+        let mk = |caps: &[&str]| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: caps.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        // Silence: permitted for tools, never for vision.
+        assert!(satisfies(&mk(&[]), &[Requirement::Tools]));
+        assert!(!satisfies(&mk(&[]), &[Requirement::Vision]));
+        assert!(!satisfies(
+            &mk(&[]),
+            &[Requirement::Vision, Requirement::Tools]
+        ));
+        // A declaration is taken at its word in both directions.
+        assert!(!satisfies(&mk(&["chat"]), &[Requirement::Tools]));
+        assert!(satisfies(&mk(&["chat", "tools"]), &[Requirement::Tools]));
     }
 
     /// The incident, as a regression test: an image request against a registry

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -849,7 +849,6 @@ mod switch_tests {
             cheap: Some("cheap".into()),
             frontier: Some("frontier".into()),
             threshold_input_tokens: Some(1000),
-            ..Default::default()
         };
         assert_eq!(choose_by_difficulty(1500, &r), Some("frontier".into()));
         assert_eq!(choose_by_difficulty(500, &r), Some("cheap".into()));
@@ -859,7 +858,6 @@ mod switch_tests {
             cheap: Some("c".into()),
             frontier: None,
             threshold_input_tokens: None,
-            ..Default::default()
         };
         assert_eq!(choose_by_difficulty(9999, &bad), None);
     }

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -99,6 +99,15 @@ pub enum AgentAction {
         #[arg(num_args = 0..)]
         model_refs: Vec<String>,
     },
+    /// Turn Smart background routing on or off for this agent, or `follow` to
+    /// clear the override and inherit the global setting (`mur model smart`).
+    Smart {
+        /// Agent name
+        name: String,
+        /// `on`, `off`, or `follow`.
+        #[arg(value_parser = ["on", "off", "follow"])]
+        state: String,
+    },
     /// Dial an agent's Unix socket and issue A2A `message/send`
     Send {
         /// Agent name

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -132,6 +132,7 @@ pub fn cmd_create(
         model_ref: resolved_model_ref,
         fallback_chain: Vec::new(),
         routing: None,
+        smart: None,
         mcp_servers: vec![],
         skills: vec![],
         transport: TransportConfig {

--- a/mur-core/src/cmd/agent/model_resolve.rs
+++ b/mur-core/src/cmd/agent/model_resolve.rs
@@ -157,9 +157,18 @@ pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
     let mut profile: mur_common::AgentProfile =
         serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
             .with_context(|| format!("parse {}", profile_path.display()))?;
-    // Preserve any other overridden field (e.g. a pinned cheap model): this
-    // sets one field, it does not replace the block.
-    let existing = profile.smart.take().unwrap_or_default();
+    // Migrate any legacy `routing.smart` override forward and clear it, so the
+    // setting ends up living in exactly one place. Leaving both would mean
+    // `follow` did not actually follow: the legacy nesting still outranks the
+    // global config on the read path.
+    let existing = profile
+        .smart
+        .take()
+        .or_else(|| profile.routing.as_mut().and_then(|r| r.smart.take()))
+        .unwrap_or_default();
+    if let Some(r) = profile.routing.as_mut() {
+        r.smart = None;
+    }
     profile.smart = match state {
         "follow" => None,
         "on" => Some(mur_common::config::SmartOverride {

--- a/mur-core/src/cmd/agent/model_resolve.rs
+++ b/mur-core/src/cmd/agent/model_resolve.rs
@@ -147,6 +147,37 @@ pub fn cmd_agent_set_fallback(home: &Path, name: &str, refs: &[String]) -> Resul
     Ok(())
 }
 
+/// Set (or clear) this agent's Smart background-routing override.
+/// `follow` removes the override so the agent inherits `models.smart`.
+pub fn cmd_agent_set_smart(home: &Path, name: &str, state: &str) -> Result<()> {
+    let profile_path = home.join("agents").join(name).join("profile.yaml");
+    if !profile_path.exists() {
+        bail!("agent '{name}' not installed at {}", profile_path.display());
+    }
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
+            .with_context(|| format!("parse {}", profile_path.display()))?;
+    // Preserve any other overridden field (e.g. a pinned cheap model): this
+    // sets one field, it does not replace the block.
+    let existing = profile.smart.take().unwrap_or_default();
+    profile.smart = match state {
+        "follow" => None,
+        "on" => Some(mur_common::config::SmartOverride {
+            enabled: Some(true),
+            ..existing
+        }),
+        "off" => Some(mur_common::config::SmartOverride {
+            enabled: Some(false),
+            ..existing
+        }),
+        other => bail!("unknown state '{other}' (expected on, off, or follow)"),
+    };
+    std::fs::write(&profile_path, serde_yaml_ng::to_string(&profile)?)
+        .with_context(|| format!("write {}", profile_path.display()))?;
+    println!("agent '{name}' smart routing = {state}");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -546,6 +546,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
         model_ref: None,
         fallback_chain: Vec::new(),
         routing: None,
+        smart: None,
         mcp_servers: vec![],
         skills: vec![],
         transport: TransportConfig {

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod misc;
 pub mod model;
 pub mod model_connect;
 pub mod model_doctor;
+pub mod model_smart;
 pub(crate) mod murmurd;
 pub mod notes_cmd;
 pub(crate) mod official;

--- a/mur-core/src/cmd/model.rs
+++ b/mur-core/src/cmd/model.rs
@@ -139,6 +139,18 @@ pub enum ModelCmd {
         #[arg(num_args = 0..)]
         model_refs: Vec<String>,
     },
+    /// Turn Smart background routing on or off globally (config.yaml
+    /// `models.smart`). Off by default: background turns then run on the
+    /// agent's own model. `--cheap` pins the model Smart downgrades to;
+    /// omit it to auto-pick the cheapest capable chat model.
+    Smart {
+        /// `on` or `off`.
+        #[arg(value_parser = ["on", "off"])]
+        state: String,
+        /// Registry key Smart downgrades to. Omit for auto-pick.
+        #[arg(long)]
+        cheap: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -394,6 +406,11 @@ pub async fn run(args: ModelArgs) -> anyhow::Result<()> {
         ModelCmd::Fallback { model_refs } => {
             cmd_model_fallback(&crate::cmd::agent::resolve_mur_home()?, &model_refs)?
         }
+        ModelCmd::Smart { state, cheap } => crate::cmd::model_smart::cmd_model_smart(
+            &crate::cmd::agent::resolve_mur_home()?,
+            state == "on",
+            cheap.as_deref(),
+        )?,
     }
     Ok(())
 }
@@ -701,7 +718,7 @@ fn parse_route_policy(raw: &str) -> anyhow::Result<RoutePolicy> {
 /// `<home>/models.yaml`. Used by both the global (`mur model default` /
 /// `fallback`) and per-agent (`mur agent fallback`) setters so a typo'd ref
 /// can never be silently persisted.
-fn ensure_ref_exists(home: &Path, r: &str) -> anyhow::Result<()> {
+pub(crate) fn ensure_ref_exists(home: &Path, r: &str) -> anyhow::Result<()> {
     let reg = ModelRegistry::load_from(&home.join("models.yaml"))?;
     anyhow::ensure!(
         reg.models.contains_key(r),

--- a/mur-core/src/cmd/model_smart.rs
+++ b/mur-core/src/cmd/model_smart.rs
@@ -1,0 +1,65 @@
+//! `mur model smart <on|off>` — the global Smart background-routing toggle.
+//!
+//! Its own module rather than another arm in `cmd/model.rs`, which is already
+//! at the 800-line ceiling (CLAUDE.md rule 4), matching the `model_doctor` /
+//! `model_connect` siblings.
+use std::path::Path;
+
+use crate::cmd::model::ensure_ref_exists;
+
+/// Set `models.smart.enabled`, optionally pinning the model Smart downgrades
+/// to. The ref is validated against `models.yaml` fail-closed, like every other
+/// ref-taking setter.
+pub fn cmd_model_smart(home: &Path, on: bool, cheap: Option<&str>) -> anyhow::Result<()> {
+    if let Some(c) = cheap {
+        ensure_ref_exists(home, c)?;
+    }
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.smart.enabled = on;
+    if let Some(c) = cheap {
+        cfg.models.smart.cheap = Some(c.to_string());
+    }
+    crate::store::config::save_config_at(&home.join("config.yaml"), &cfg)?;
+    println!(
+        "smart background routing = {} (cheap = {})",
+        if on { "on" } else { "off" },
+        cfg.models.smart.cheap.as_deref().unwrap_or("auto")
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::model::{ModelEntry, ModelRegistry};
+
+    #[test]
+    fn toggles_and_validates_the_cheap_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "haiku".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-haiku-4-5".into(),
+                ..Default::default()
+            },
+        );
+        reg.save_to(&home.join("models.yaml")).unwrap();
+
+        cmd_model_smart(home, true, Some("haiku")).unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert!(cfg.models.smart.enabled);
+        assert_eq!(cfg.models.smart.cheap.as_deref(), Some("haiku"));
+
+        // Turning it off keeps the pinned ref — the user's choice survives.
+        cmd_model_smart(home, false, None).unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert!(!cfg.models.smart.enabled);
+        assert_eq!(cfg.models.smart.cheap.as_deref(), Some("haiku"));
+
+        // Unknown ref is refused before anything is written.
+        assert!(cmd_model_smart(home, true, Some("nope")).is_err());
+    }
+}

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1577,6 +1577,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 &model_refs,
             )?
         }
+        AgentAction::Smart { name, state } => cmd::agent::model_resolve::cmd_agent_set_smart(
+            &cmd::agent::resolve_mur_home()?,
+            &name,
+            &state,
+        )?,
         AgentAction::Send {
             name,
             message,

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -640,6 +640,8 @@ pub fn run() {
             model_switch::model_switch_set,
             model_switch::agent_get_fallback,
             model_switch::agent_set_fallback,
+            model_switch::agent_get_smart,
+            model_switch::agent_set_smart,
             pet::pet_spawn_at,
             pet::pet_close,
             pet::pet_return_to_hub,

--- a/mur-hub-gui/src-tauri/src/model_switch.rs
+++ b/mur-hub-gui/src-tauri/src/model_switch.rs
@@ -157,7 +157,6 @@ mod tests {
                 cheap: Some("claude_sonnet".into()),
                 frontier: Some("nope".into()), // unknown → reject
                 threshold_input_tokens: Some(1000),
-                smart: None,
             },
             ..Default::default()
         };

--- a/mur-hub-gui/src-tauri/src/model_switch.rs
+++ b/mur-hub-gui/src-tauri/src/model_switch.rs
@@ -94,7 +94,7 @@ pub(crate) fn agent_get_smart_impl(home: &Path, name: &str) -> Result<Option<boo
         &std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?,
     )
     .map_err(|e| format!("parse profile: {e}"))?;
-    Ok(profile.smart.and_then(|s| s.enabled))
+    Ok(profile.smart_override().and_then(|s| s.enabled))
 }
 
 pub(crate) fn agent_set_smart_impl(

--- a/mur-hub-gui/src-tauri/src/model_switch.rs
+++ b/mur-hub-gui/src-tauri/src/model_switch.rs
@@ -87,6 +87,36 @@ pub fn agent_set_fallback(name: String, refs: Vec<String>) -> Result<Vec<String>
     agent_set_fallback_impl(&crate::mur_home_path(), &name, &refs)
 }
 
+/// Tri-state read: `None` = the agent follows the global setting.
+pub(crate) fn agent_get_smart_impl(home: &Path, name: &str) -> Result<Option<bool>, String> {
+    let path = home.join("agents").join(name).join("profile.yaml");
+    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(
+        &std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?,
+    )
+    .map_err(|e| format!("parse profile: {e}"))?;
+    Ok(profile.smart.and_then(|s| s.enabled))
+}
+
+pub(crate) fn agent_set_smart_impl(
+    home: &Path,
+    name: &str,
+    state: &str,
+) -> Result<Option<bool>, String> {
+    mur_core::cmd::agent::model_resolve::cmd_agent_set_smart(home, name, state)
+        .map_err(|e| format!("{e}"))?;
+    agent_get_smart_impl(home, name)
+}
+
+#[tauri::command]
+pub fn agent_get_smart(name: String) -> Result<Option<bool>, String> {
+    agent_get_smart_impl(&crate::mur_home_path(), &name)
+}
+
+#[tauri::command]
+pub fn agent_set_smart(name: String, state: String) -> Result<Option<bool>, String> {
+    agent_set_smart_impl(&crate::mur_home_path(), &name, &state)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
@@ -79,6 +79,8 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [agentChain, setAgentChain] = useState<string[]>([]);
   const [chainErr, setChainErr] = useState<string | null>(null);
+  // Per-agent Smart override. null = follow the global setting.
+  const [agentSmart, setAgentSmart] = useState<boolean | null>(null);
 
   useEffect(() => {
     setError(null);
@@ -98,6 +100,12 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
   }, [agentName]);
 
   useEffect(() => {
+    invoke<boolean | null>("agent_get_smart", { name: agentName })
+      .then(setAgentSmart)
+      .catch(() => setAgentSmart(null));
+  }, [agentName]);
+
+  useEffect(() => {
     invoke<ModelOption[]>("list_models")
       .then(setModelOptions)
       .catch(() => setModelOptions([]));
@@ -110,6 +118,12 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
         setAgentChain(saved);
         setChainErr(null);
       })
+      .catch((e) => setChainErr(String(e)));
+  }
+
+  function saveAgentSmart(state: string) {
+    invoke<boolean | null>("agent_set_smart", { name: agentName, state })
+      .then(setAgentSmart)
       .catch((e) => setChainErr(String(e)));
   }
 
@@ -282,6 +296,19 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
                   {t("detail.fallbackChainError", { error: chainErr })}
                 </p>
               )}
+              <label className="field-label" htmlFor="agent-smart">
+                {t("detail.smartRouting")}
+              </label>
+              <select
+                id="agent-smart"
+                value={agentSmart === null ? "follow" : agentSmart ? "on" : "off"}
+                onChange={(e) => saveAgentSmart(e.target.value)}
+              >
+                <option value="follow">{t("detail.smartFollow")}</option>
+                <option value="on">{t("detail.smartOn")}</option>
+                <option value="off">{t("detail.smartOff")}</option>
+              </select>
+              <p className="settings-hint">{t("detail.smartHint")}</p>
             </div>
             <ModelLibrary open={libraryOpen} onClose={() => setLibraryOpen(false)} />
             <PersonaTab detail={detail} onSaved={handleSaved} />

--- a/mur-hub-gui/ui/src/components/settings/modelSwitch.test.ts
+++ b/mur-hub-gui/ui/src/components/settings/modelSwitch.test.ts
@@ -23,8 +23,8 @@ describe("modelSwitch helpers", () => {
     expect(ms.routing.threshold_input_tokens).toBeNull();
     expect(ms.routing.enabled).toBe(false);
     expect(ms.retry.cooldown_secs).toBe(60); // passthrough preserved
-    // smart defaults on and auto-picks when the Rust payload omits it entirely.
-    expect(ms.smart.enabled).toBe(true);
+    // smart is opt-in and auto-picks when the Rust payload omits it entirely.
+    expect(ms.smart.enabled).toBe(false);
     expect(ms.smart.cheap).toBeNull();
     expect(ms.smart.max_escalations).toBe(1);
   });
@@ -38,6 +38,11 @@ describe("modelSwitch helpers", () => {
     expect(ms.smart.enabled).toBe(false); // passthrough preserved
     expect(ms.smart.cheap).toBeNull();
     expect(ms.smart.max_escalations).toBe(3); // passthrough preserved
+  });
+
+  it("defaults smart to off when the config predates the field", () => {
+    const raw = { retry: {}, routing: {} } as unknown as ModelSwitchView;
+    expect(normalizeMs(raw).smart.enabled).toBe(false);
   });
 });
 

--- a/mur-hub-gui/ui/src/components/settings/modelSwitch.ts
+++ b/mur-hub-gui/ui/src/components/settings/modelSwitch.ts
@@ -49,7 +49,8 @@ export function isChainValid(chain: string[], known: Set<string>): boolean {
  * serialized, so they pass through untouched. `smart.cheap` is likewise
  * omitted when unset; `smart.enabled`/`smart.max_escalations` are always
  * serialized by the Rust side, but the whole `smart` object is guarded too
- * in case an older config predates the field entirely.
+ * in case an older config predates the field entirely. The `enabled` fallback
+ * mirrors the Rust default, which is off — Smart background routing is opt-in.
  */
 export function normalizeMs(raw: ModelSwitchView): ModelSwitchView {
   return {
@@ -64,7 +65,7 @@ export function normalizeMs(raw: ModelSwitchView): ModelSwitchView {
     },
     smart: {
       ...raw.smart,
-      enabled: raw.smart?.enabled ?? true,
+      enabled: raw.smart?.enabled ?? false,
       cheap: raw.smart?.cheap ?? null,
       max_escalations: raw.smart?.max_escalations ?? 1,
     },

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -95,6 +95,12 @@ export const en = {
   "detail.fallbackChain": "Fallback chain (overrides global)",
   "detail.fallbackChainInherits": "Inherits global fallback chain.",
   "detail.fallbackChainError": "Couldn't save fallback chain: {error}",
+  "detail.smartRouting": "Smart routing",
+  "detail.smartFollow": "Follow global setting",
+  "detail.smartOn": "On for this agent",
+  "detail.smartOff": "Off for this agent",
+  "detail.smartHint":
+    "Background tasks may run on a cost-saving model. Never applies to requests this agent's cheaper models cannot serve.",
   "conv.ask": "Ask model",
   "conv.compact": "Compact model",
   "conv.rollup": "Rollup model",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -97,6 +97,12 @@ export const zhTW: Table = {
   "detail.fallbackChain": "備援鏈（覆寫全域設定）",
   "detail.fallbackChainInherits": "繼承全域備援鏈。",
   "detail.fallbackChainError": "無法儲存備援鏈：{error}",
+  "detail.smartRouting": "智慧路由",
+  "detail.smartFollow": "跟隨全域設定",
+  "detail.smartOn": "此 agent 開啟",
+  "detail.smartOff": "此 agent 關閉",
+  "detail.smartHint":
+    "背景任務可能改用較省錢的模型。若該模型無法勝任這個請求，一律不會降級。",
   "conv.ask": "對話 Ask 模型",
   "conv.compact": "Compact 摘要模型",
   "conv.rollup": "Rollup 彙整模型",


### PR DESCRIPTION
A scheduled image-recognition turn was silently downgraded to a cheap
text-tier model. Recognition quality dropped and the user had no way to know.

Three facts made that inevitable rather than unlucky:

1. **Auto-pick ignored capability.** `pick_cheap_model` filtered on exactly one
   predicate — `capabilities` contains `chat` **or is empty**. No write path
   emits a `vision` capability, so every cheap text model was an eligible
   candidate for an image request.
2. **Cascade cannot catch a quality failure.** Escalation fires on
   `InvalidResponse`; a confidently wrong recognition is well-formed, so it
   never runs. Quality-based re-routing is out of scope by design — meaning
   quality-sensitive work had no backstop at all under Smart.
3. **Transparency did not reach background turns.** The `⚡ model · Smart` caption
   renders in Hub chat. Smart only acts on *background* turns — scheduled tasks,
   companion outbox — which have no chat bubble to carry it.

A fourth would reproduce it through the other mechanism: the token estimator
counts an image as its caption length, so difficulty routing scored
"image + short caption" as trivially easy and sent it to the cheap model too.

## The rule

> A router may only substitute a model that can serve the request. Price orders
> the eligible set; it does not define membership.

The chat baseline stays legacy-permissive (no `capabilities` at all still means
chat, or every pre-capability entry drops out). Above the baseline it is
fail-closed: the entry has to name the capability. Nothing declares `vision`
today, so image requests find no cheap candidate and auto-substitution goes
inert — and the same code starts making a finer distinction the day entries
declare it. There is no second version of this to write later.

## What changed

**Layer 1 — mechanism** (ships on its own; makes today's default-on config safe)
- `Requirement` / `satisfies` / capability-aware `pick_cheap_model` in `mur-common`
- `requirements_of(&LlmRequest)` in the runtime: `ImageText` → Vision, non-empty `tools` → Tools
- `candidates_for` filters **automatic substitutions only** — Smart's cheap model,
  a difficulty-routed pick, chain members. The user's explicit primary and an
  explicit pin are never filtered: they must fail loudly, not be second-guessed.
  An unknown ref is kept so per-candidate failure reporting (#947) still names it.

**Layer 2 — policy**
- `SmartOverride` / `RoutingOverride` are partials merged field by field. The old
  per-agent override reused the full config struct, so an omitted field meant
  `false` rather than "unset" — overriding one field silently disabled the feature.
- `AgentProfile.smart` promoted out of `routing`; nesting it there meant turning
  Smart off for an agent also rewrote its difficulty routing. The legacy
  `routing.smart` location is still read, permanently — exported `.muragent`
  bundles carry it.
- Smart defaults **off**. Its failure mode is silent and irreversible for the turn
  it degrades, and automation shaped like that has to be asked for.
- The boot gate consulted only chain length and difficulty routing, never Smart, so
  an agent with no fallback chain got a plain client and Smart was inert for it no
  matter what the toggle said. Now a testable predicate.
- CLI: `mur model smart <on|off> [--cheap ref]`, `mur agent smart <name> <on|off|follow>`
- Hub: three-state per-agent control (follow / on / off), i18n in `en` + `zh-TW`

**No migration.** `Option<bool>` preserves an explicitly written `enabled: false`.
The only configuration that changes meaning is global routing on **plus** a
hand-written per-agent block that omits `enabled` — where the old reading was
itself the bug. Details and the rejected file-rewriting alternative: spec §4.6.

**Deferred with a condition attached (spec §7).** Background routing decisions
still have no read surface outside Hub chat captions. Restoring the default to
`true` requires building one first — otherwise a regression here is again
invisible to the person paying for it.

## Test plan

- `cargo nextest run --workspace` — 8058 tests
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml --all-targets -- -D warnings` — clean.
  The log never prints `Checking mur-hub-gui` (a build-script package gets one
  `Compiling` line), so a negative control — a deliberate unused variable —
  confirmed the crate really is linted: exit 101, then 0 once removed.
- `mur-hub-gui/ui`: 196 vitest tests, `npm run build` clean
- CLI exercised end to end: `mur model smart on --cheap nope` rejects the unknown
  ref; `mur model smart off` reports `off (cheap = auto)`

The incident is a regression test: with a registry where nothing declares vision,
`pick_cheap_model(&reg, None, &[Requirement::Vision])` returns `None`, and a
background image turn's candidate list is the primary alone.

**One known flake**: `supervisor_shutdown::sigterm_removes_running_lock_and_flushes_telemetry`
failed once in a full-workspace run — a 10s `agent/card` boot timeout, while a second
full suite was running on the same machine. It passes in isolation (2.65s, 2.70s) and in
two per-crate runs; the test touches no config this PR changes, and under the default
config the new gate is value-identical to the old condition.

Spec: `docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md`
Plan: `docs/superpowers/plans/2026-09-01-smart-routing-capability-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
