### PR TITLE
feat(agent): mur agent routing — see the decisions nothing else renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ mur
 ├── agent        create · start · stop · restart · remove · cli · send · card · dial · who ·
 │                export · install · install-service · addon · companion · voice · pair ·
 │                schedule (add · proposals · accept) · perm (incl. list-paths) · secret ·
-│                fallback · smart · trash · rollback … (40+)
+│                fallback · smart · routing · trash · rollback … (40+)
 ├── capability   install · list · show · remove   (MCP + skills + programs bundled → an agent)
 ├── fleet        create · list · show · status · run · set-loop · send · jobs   (squads of agents over a shared channel)
 ├── official     list · install   (official agents/fleets from the app.mur.run catalog)

--- a/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
@@ -264,18 +264,28 @@ global models  ┘                          • cheap/chain -> satisfies(reqs)? 
 | `smart.cheap` pinned by the user to an ineligible ref | Filtered like any substitution; a pinned *cheap* is a policy, not a per-request choice. Hub/CLI validate the ref exists but cannot validate per-request eligibility. |
 | Legacy profile with nested `routing.smart` | Read at §4.3 step 2; unchanged behaviour. |
 
-## 7. Layer 3 — Visibility (deferred, with a condition attached)
+## 7. Layer 3 — Visibility (shipped as `mur agent routing`)
 
 Background routing decisions are recorded (`mur.routing` telemetry, Phase B)
-but have no read surface outside Hub chat captions, which background turns
-never reach. This spec does **not** implement one.
+but had no read surface outside Hub chat captions, which background turns never
+reach — so the least visible decisions were the ones nothing rendered.
 
-It records the dependency instead: **restoring `smart.enabled` to a default of
-`true` requires a background-visible routing surface first.** Without it, a
-Layer 1 or Layer 2 regression is again invisible to the person paying for it.
-Candidate surfaces (not chosen here): `mur agent routing-log <name>`, a Hub
-notification on substitution, or a provenance line on companion/scheduled
-output.
+`mur agent routing <name> [--limit N] [--downgrades-only]` is that surface. It
+reads `<agent_home>/telemetry/*.jsonl`, prints decisions newest first, and marks
+with `↓` the turns where `reason == smart-background` — the ones MUR chose for
+you rather than ones you configured. The summary line counts every decision on
+disk rather than the rows printed, because a "no downgrades" line speaking only
+for the last 20 turns would be the same half-truth the command exists to remove.
+
+The dependency this section originally recorded is therefore satisfied:
+**restoring `smart.enabled` to a default of `true` required a
+background-visible routing surface first.** That is not itself an argument for
+flipping it back — the default remains off on the reasoning in §2 — only a
+statement that the blocker is gone.
+
+Surfaces deliberately not built: a Hub notification on substitution, and a
+provenance line on companion/scheduled output. Both need UI work; the CLI reader
+answers the question with the telemetry that already exists.
 
 ## 8. Testing
 
@@ -330,7 +340,7 @@ Config/back-compat:
 |---|---|---|
 | L1 | `Requirement`/`satisfies`/`pick_cheap_model` + `requirements_of` + `candidates_for` filter + tests | Ships alone; fixes the incident without any config change |
 | L2 | Override types, profile promotion, default flip, boot gate, CLI, Hub three-state | Depends on L1 (turning the switch on must already be safe) |
-| L3 | Background-visible routing surface | Precondition for ever defaulting Smart back on (§7) |
+| L3 | `mur agent routing` — background-visible routing surface | **Shipped.** Was the precondition for ever defaulting Smart back on (§7) |
 
 L1 is deliberately shippable on its own: it makes the current default-on
 configuration safe for users who never read this spec.

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -152,6 +152,19 @@ pub enum AgentAction {
         #[arg(long)]
         clear: bool,
     },
+    /// What the router actually did, per turn — including the background turns
+    /// that never render a decision anywhere else. `↓` marks a model Smart
+    /// chose for you rather than one you configured.
+    Routing {
+        /// Agent name
+        name: String,
+        /// Rows to print (newest first). Default 20.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Only turns where Smart picked the model.
+        #[arg(long = "downgrades-only")]
+        downgrades_only: bool,
+    },
     /// Who can do what — the dispatch index, derived from what the sandbox
     /// actually enforces. With no filter, prints the whole roster.
     Who {

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -53,6 +53,7 @@ mod prompt;
 mod reconnect;
 mod restart;
 mod restart_confirm;
+mod routing;
 mod secret;
 mod service;
 pub mod skill;
@@ -109,6 +110,7 @@ pub use prompt::{cmd_prompt_edit, cmd_prompt_set, cmd_prompt_show};
 pub use reconnect::cmd_agent_reconnect;
 #[allow(unused_imports)]
 pub use restart::{cmd_restart, restart_stale_excluding};
+pub use routing::cmd_routing;
 #[allow(unused_imports)]
 pub use secret::{cmd_secret_delete, cmd_secret_list, cmd_secret_set};
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent/routing.rs
+++ b/mur-core/src/cmd/agent/routing.rs
@@ -1,0 +1,272 @@
+//! `mur agent routing` — what the router actually did, per turn.
+//!
+//! Smart background routing substitutes a cheaper model on turns nobody is
+//! watching. Every decision is already recorded (`mur.routing` telemetry), but
+//! until now the only place that rendered one was the Hub chat caption — and a
+//! scheduled task or companion-outbox turn has no chat bubble to carry it. So
+//! the decisions that are least visible were the ones with no read surface at
+//! all.
+//!
+//! This is that surface. It answers one question the raw JSONL does not: how
+//! many of these turns were chosen *for* you, and which model got them.
+
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+/// One `mur.routing` record, narrowed to the fields worth showing.
+struct Decision {
+    ts: String,
+    intent: String,
+    model_ref: String,
+    reason: String,
+    outcome: String,
+    attempts: u64,
+    escalations: u64,
+    summary: String,
+}
+
+impl Decision {
+    /// MUR picked this model rather than being told to. The one class of turn
+    /// this command exists for.
+    fn is_downgrade(&self) -> bool {
+        self.reason == REASON_SMART
+    }
+}
+
+/// `reason` value the runtime writes when Smart chose the candidate list.
+const REASON_SMART: &str = "smart-background";
+/// Telemetry envelope discriminator for a routing decision.
+const EVENT_TYPE: &str = "mur.routing";
+/// Task summaries are stored truncated already; keep the table readable.
+const SUMMARY_WIDTH: usize = 48;
+/// Default rows shown when `--limit` is not given.
+const DEFAULT_LIMIT: usize = 20;
+
+fn parse_line(v: &serde_json::Value) -> Option<Decision> {
+    if v.get("mur.event.type")?.as_str()? != EVENT_TYPE {
+        return None;
+    }
+    Some(Decision {
+        ts: v
+            .get("ts")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+        intent: v
+            .get("intent")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+        model_ref: v
+            .get("model_ref")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+        reason: v
+            .get("reason")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+        outcome: v
+            .get("outcome")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+        attempts: v.get("attempts").and_then(|t| t.as_u64()).unwrap_or(0),
+        escalations: v.get("escalations").and_then(|t| t.as_u64()).unwrap_or(0),
+        summary: v
+            .get("task_summary")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
+    })
+}
+
+/// Every routing decision in `<agent_home>/telemetry/*.jsonl`, oldest first.
+///
+/// A malformed line is skipped rather than fatal: this is a log reader, and a
+/// half-written trailing line is a normal thing to find in an append-only file
+/// that a live process is still writing.
+fn read_decisions(telemetry_dir: &Path) -> Result<Vec<Decision>> {
+    let mut files: Vec<_> = std::fs::read_dir(telemetry_dir)
+        .map_err(|e| anyhow::anyhow!("read {}: {e}", telemetry_dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "jsonl"))
+        .collect();
+    // Filenames are YYYY-MM-DD, so lexical order is chronological.
+    files.sort();
+
+    let mut out = Vec::new();
+    for f in files {
+        let Ok(text) = std::fs::read_to_string(&f) else {
+            continue;
+        };
+        for line in text.lines() {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(line)
+                && let Some(d) = parse_line(&v)
+            {
+                out.push(d);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let one_line: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    if one_line.chars().count() <= max {
+        return one_line;
+    }
+    let kept: String = one_line.chars().take(max.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+/// `mur agent routing <name> [--limit N] [--downgrades-only]`
+pub fn cmd_routing(name: &str, limit: Option<usize>, downgrades_only: bool) -> Result<()> {
+    let home = super::resolve_mur_home()?;
+    let agent_dir = home.join("agents").join(name);
+    if !agent_dir.exists() {
+        bail!("agent '{name}' not installed at {}", agent_dir.display());
+    }
+    let telemetry_dir = agent_dir.join("telemetry");
+    if !telemetry_dir.exists() {
+        println!(
+            "agent '{name}' has no telemetry yet ({})",
+            telemetry_dir.display()
+        );
+        return Ok(());
+    }
+
+    let all = read_decisions(&telemetry_dir)?;
+    // The summary counts EVERY decision on disk, not just the rows printed —
+    // a "0 downgrades" line that only spoke for the last 20 turns would be the
+    // same kind of half-truth this command exists to remove.
+    let total = all.len();
+    let downgrades = all.iter().filter(|d| d.is_downgrade()).count();
+
+    let mut rows: Vec<&Decision> = if downgrades_only {
+        all.iter().filter(|d| d.is_downgrade()).collect()
+    } else {
+        all.iter().collect()
+    };
+    rows.reverse(); // newest first
+    let shown = limit.unwrap_or(DEFAULT_LIMIT).min(rows.len());
+
+    if rows.is_empty() {
+        println!("agent '{name}': no routing decisions recorded");
+    } else {
+        println!(
+            "{:<20}  {:<22}  {:<24}  {:<17}  {:<15}  TASK",
+            "TIME", "INTENT", "MODEL", "REASON", "OUTCOME"
+        );
+        for d in rows.iter().take(shown) {
+            let mark = if d.is_downgrade() { "↓" } else { " " };
+            let tries = if d.attempts > 1 || d.escalations > 0 {
+                format!("{} ({}a/{}e)", d.outcome, d.attempts, d.escalations)
+            } else {
+                d.outcome.clone()
+            };
+            println!(
+                "{:<20}  {:<22}  {}{:<23}  {:<17}  {:<15}  {}",
+                truncate(&d.ts, 19),
+                truncate(&d.intent, 22),
+                mark,
+                truncate(&d.model_ref, 23),
+                truncate(&d.reason, 17),
+                truncate(&tries, 15),
+                truncate(&d.summary, SUMMARY_WIDTH)
+            );
+        }
+    }
+
+    println!();
+    if downgrades == 0 {
+        println!("{total} routing decisions · none were downgrades");
+    } else {
+        let models: std::collections::BTreeSet<&str> = all
+            .iter()
+            .filter(|d| d.is_downgrade())
+            .map(|d| d.model_ref.as_str())
+            .collect();
+        println!(
+            "{total} routing decisions · ↓ {downgrades} chosen for you by Smart, on {}",
+            models.into_iter().collect::<Vec<_>>().join(", ")
+        );
+    }
+    if !downgrades_only && rows.len() > shown {
+        println!(
+            "showing {shown} of {} — pass --limit to see more",
+            rows.len()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_jsonl(dir: &Path, day: &str, lines: &[&str]) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{day}.jsonl")), lines.join("\n")).unwrap();
+    }
+
+    #[test]
+    fn reads_routing_events_skips_everything_else_and_survives_a_torn_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("telemetry");
+        write_jsonl(
+            &dir,
+            "2026-09-01",
+            &[
+                r#"{"mur.event.type":"mur.routing","ts":"2026-09-01T10:00:00Z","intent":"background/scheduled","model_ref":"cheap","reason":"smart-background","outcome":"ok","attempts":1,"escalations":0,"task_summary":"describe this photo"}"#,
+                r#"{"mur.event.type":"mur.tool","ts":"2026-09-01T10:01:00Z"}"#,
+                r#"{"mur.event.type":"mur.routing","ts":"2026-09-01T10:02:00Z","intent":"interactive","model_ref":"primary","reason":"fallback-advance","outcome":"ok","attempts":1,"escalations":0,"task_summary":"hello"}"#,
+                // A live writer can leave a half-written trailing line.
+                r#"{"mur.event.type":"mur.rou"#,
+            ],
+        );
+        let got = read_decisions(&dir).unwrap();
+        assert_eq!(got.len(), 2, "non-routing and torn lines are skipped");
+        assert_eq!(got[0].reason, "smart-background");
+        assert!(got[0].is_downgrade());
+        assert!(
+            !got[1].is_downgrade(),
+            "fallback-advance is not a downgrade"
+        );
+    }
+
+    #[test]
+    fn days_are_read_in_chronological_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("telemetry");
+        let line = |ts: &str| {
+            format!(
+                r#"{{"mur.event.type":"mur.routing","ts":"{ts}","intent":"interactive","model_ref":"m","reason":"explicit","outcome":"ok","attempts":1,"escalations":0,"task_summary":"x"}}"#
+            )
+        };
+        write_jsonl(&dir, "2026-09-02", &[&line("2026-09-02T00:00:00Z")]);
+        write_jsonl(&dir, "2026-08-31", &[&line("2026-08-31T00:00:00Z")]);
+        let got = read_decisions(&dir).unwrap();
+        assert_eq!(got.len(), 2);
+        assert!(
+            got[0].ts.starts_with("2026-08-31"),
+            "oldest first, got {}",
+            got[0].ts
+        );
+    }
+
+    #[test]
+    fn truncate_counts_characters_not_bytes() {
+        // A CJK summary must not be cut mid-character.
+        assert_eq!(truncate("辨識這張照片", 4), "辨識這…");
+        assert_eq!(truncate("short", 40), "short");
+        assert_eq!(
+            truncate("a\nb", 40),
+            "a b",
+            "newlines would break the table"
+        );
+    }
+}

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1594,6 +1594,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             params,
         } => cmd::agent::cmd_dial(&name, &method, params.as_deref())?,
         AgentAction::Effort { name, level, clear } => cmd::agent::cmd_effort(&name, level, clear)?,
+        AgentAction::Routing {
+            name,
+            limit,
+            downgrades_only,
+        } => cmd::agent::cmd_routing(&name, limit, downgrades_only)?,
         AgentAction::Who {
             can,
             skill,


### PR DESCRIPTION
Closes the Layer 3 gap left open by [#1138](https://github.com/mur-run/mur/pull/1138) (capability-gate spec §7).

Smart background routing swaps the model on turns nobody is watching. Every decision was already recorded as `mur.routing` telemetry, but the only surface that rendered one was the Hub chat caption — and a scheduled task or companion-outbox turn has no chat bubble to carry it. **The least visible decisions were the ones with no read surface at all.**

```
$ mur agent routing mur --downgrades-only --limit 4
TIME                  INTENT                  MODEL                     REASON             OUTCOME          TASK
2026-09-01T13:55:0…   background/scheduled    ↓deepseek-v4-flash        smart-background   ok               LAYER-2-PROBE 請只回覆這一行:第二層已送達
2026-09-01T06:14:0…   background/scheduled    ↓deepseek-v4-flash        smart-background   ok               DELIVERY-PROBE-1127 請只回覆這一行:探針已送達
2026-09-01T02:00:0…   background/scheduled    ↓deepseek-v4-flash        smart-background   ok               該吃早餐了 🥐
2026-09-01T01:05:0…   background/scheduled    ↓deepseek-v4-flash        smart-background   ok               DELIVERY-PROBE-1119 — 這是一則測試提醒

1850 routing decisions · ↓ 4 chosen for you by Smart, on deepseek-v4-flash
```

`↓` marks `reason == smart-background` — a model MUR chose for you. `fallback-advance` and `explicit` are not downgrades: those are your own configuration taking effect.

**The summary line counts every decision on disk, not the rows printed.** A "no downgrades" line that only spoke for the last 20 turns would be the same half-truth this command exists to remove.

Three decisions worth stating:

- **A malformed line is skipped, not fatal.** A half-written trailing line is normal in an append-only file a live process is still writing; a log reader that refuses to work because of one is useless exactly when you need it.
- **Truncation counts characters, not bytes** — task summaries here are routinely CJK, and cutting mid-character corrupts the table.
- **It lives under `mur agent`, not `mur model`** — telemetry is per-agent, alongside `agent doctor` / `agent status`.

## Test plan

- 3 unit tests: non-routing events and torn lines are skipped; multi-day files read in chronological order (filenames are `YYYY-MM-DD`, so lexical order is chronological); truncation is character-based and flattens newlines.
- `cargo nextest run -p mur-core -E 'test(agent::routing)'` — 6 passed (lib + bin targets)
- `cargo clippy -p mur-core --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- **Run against real production telemetry**, not just fixtures: 1113 decisions on one agent (none downgraded), 1850 on another with the 4 shown above. Synthetic data passing proves the parser; this proves it reads the shape the runtime actually writes.

Spec §7 and the phasing table are updated to say L3 shipped. That records the precondition as satisfied — it is not an argument to flip the default back on, which still rests on §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
