### PR TITLE
chore(release): bump workspace version to 2.71.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.18"
+version = "2.71.19"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.18"
+version = "2.71.19"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.71.19 — #1141: an inbox entry stops claiming a blank locale.

Found by probing a real agent after 2.71.17 deployed, not by a test: every profile on disk carries `companion.locale: ""`, and a serde default only fires for an *absent* key, so the empty string was carried faithfully into the front matter.

Merging this IS the release.