### PR TITLE
fix(gateway): tell Brave's two 429s apart, and stop misadvising the operator

### DIFF
--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -204,9 +204,7 @@ fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
         .map_err(|e| FetchError::Http(e.to_string()))
 }
 
-/// Brave Search API web-search endpoint. First-class (real index, JSON, no
-/// scraping) — used when a subscription token is configured.
-const BRAVE_ENDPOINT: &str = "https://api.search.brave.com/res/v1/web/search";
+mod brave;
 
 /// Pluggable web search: `brave_key.is_some()` → Brave's first-class API;
 /// `None` → scrape DuckDuckGo's HTML endpoint (keyless, zero-config). If Brave
@@ -221,7 +219,7 @@ pub async fn search(
     endpoint: &str,
 ) -> Result<Vec<SearchHit>, FetchError> {
     match brave_key {
-        Some(key) => match search_brave(query, limit, key, deny, timeout).await {
+        Some(key) => match brave::search_brave(query, limit, key, deny, timeout).await {
             Ok(hits) => Ok(hits),
             Err(e) => {
                 tracing::warn!(
@@ -234,86 +232,6 @@ pub async fn search(
         },
         None => search_tier1(query, limit, deny, timeout, endpoint).await,
     }
-}
-
-/// Brave web search: GET the Brave API through the same proxy-honoring reqwest
-/// path, authenticated with `X-Subscription-Token`. Screens the endpoint host
-/// via the SSRF guard exactly like a fetch. Brave returns real URLs directly
-/// (no `uddg` redirect to decode) as structured JSON.
-async fn search_brave(
-    query: &str,
-    limit: usize,
-    key: &str,
-    deny: &[String],
-    timeout: Duration,
-) -> Result<Vec<SearchHit>, FetchError> {
-    let mut url = url::Url::parse(BRAVE_ENDPOINT).expect("static URL is valid");
-    url.query_pairs_mut()
-        .append_pair("q", query)
-        .append_pair("count", &limit.to_string());
-    let screened = screen_url_blocking(url.as_str(), deny)
-        .await
-        .map_err(FetchError::Guard)?;
-
-    let client = build_client(timeout)?;
-    let resp = client
-        .get(screened.clone())
-        .header("X-Subscription-Token", key)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|e| FetchError::Http(e.to_string()))?;
-    let status = resp.status();
-    if !status.is_success() {
-        return Err(FetchError::Http(format!(
-            "brave api status {}",
-            status.as_u16()
-        )));
-    }
-    if let Some(len) = resp.content_length()
-        && len > MAX_BODY_BYTES as u64
-    {
-        return Err(FetchError::TooLarge);
-    }
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| FetchError::Http(e.to_string()))?;
-    parse_brave_hits(&body, limit).map_err(FetchError::Http)
-}
-
-/// Parse Brave's `web.results[]` JSON into hits. A missing `web` block (Brave
-/// returns none when there are zero web results) is a valid empty result, not
-/// an error; malformed JSON is an error so the caller falls back to DDG.
-fn parse_brave_hits(json: &str, limit: usize) -> Result<Vec<SearchHit>, String> {
-    #[derive(serde::Deserialize)]
-    struct BraveResp {
-        web: Option<BraveWeb>,
-    }
-    #[derive(serde::Deserialize)]
-    struct BraveWeb {
-        results: Vec<BraveResult>,
-    }
-    #[derive(serde::Deserialize)]
-    struct BraveResult {
-        title: String,
-        url: String,
-        #[serde(default)]
-        description: String,
-    }
-    let resp: BraveResp = serde_json::from_str(json).map_err(|e| e.to_string())?;
-    Ok(resp
-        .web
-        .map(|w| w.results)
-        .unwrap_or_default()
-        .into_iter()
-        .take(limit)
-        .map(|r| SearchHit {
-            title: r.title,
-            url: r.url,
-            snippet: r.description,
-        })
-        .collect())
 }
 
 /// Short human label for a `FetchError` used in the Brave→DDG fallback log.
@@ -678,35 +596,5 @@ mod tests {
         assert!(out.contains("[truncated 6 chars]"));
         // Never split a codepoint: the kept prefix is valid UTF-8 of 4 'é's.
         assert_eq!(out.chars().take_while(|&c| c == 'é').count(), 4);
-    }
-
-    #[test]
-    fn parse_brave_hits_extracts_results_and_respects_limit() {
-        // Trimmed real Brave web-search JSON shape.
-        let json = r#"{"web":{"results":[
-            {"title":"First","url":"https://a.example","description":"snippet a"},
-            {"title":"Second","url":"https://b.example","description":"snippet b"},
-            {"title":"Third","url":"https://c.example"}
-        ]}}"#;
-        let hits = parse_brave_hits(json, 2).unwrap();
-        assert_eq!(hits.len(), 2); // limit respected
-        assert_eq!(hits[0].url, "https://a.example");
-        assert_eq!(hits[0].snippet, "snippet a");
-    }
-
-    #[test]
-    fn parse_brave_hits_missing_web_block_is_empty_not_error() {
-        // Brave omits `web` when there are zero web results — valid, not a parse error.
-        assert!(
-            parse_brave_hits(r#"{"query":{"original":"x"}}"#, 8)
-                .unwrap()
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn parse_brave_hits_malformed_json_is_error() {
-        // Malformed → Err so the dispatcher falls back to DDG.
-        assert!(parse_brave_hits("not json", 8).is_err());
     }
 }

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -204,12 +204,12 @@ fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
         .map_err(|e| FetchError::Http(e.to_string()))
 }
 
-mod brave;
-
 /// Pluggable web search: `brave_key.is_some()` → Brave's first-class API;
 /// `None` → scrape DuckDuckGo's HTML endpoint (keyless, zero-config). If Brave
 /// is configured but errors (bad key, quota, transport), degrade to DDG rather
 /// than fail the search — a misconfigured key must never black out research.
+mod brave;
+
 pub async fn search(
     query: &str,
     limit: usize,
@@ -222,15 +222,15 @@ pub async fn search(
         Some(key) => match brave::search_brave(query, limit, key, deny, timeout).await {
             Ok(hits) => Ok(hits),
             Err(e) => {
+                let why = fetch_err_brief(&e);
                 tracing::warn!(
                     target: "research_gateway",
-                    "brave search failed ({}), falling back to DuckDuckGo",
-                    fetch_err_brief(&e)
+                    "brave search failed ({why}), falling back to DuckDuckGo"
                 );
-                search_tier1(query, limit, deny, timeout, endpoint).await
+                search_tier1(query, limit, deny, timeout, endpoint, Some(&why)).await
             }
         },
-        None => search_tier1(query, limit, deny, timeout, endpoint).await,
+        None => search_tier1(query, limit, deny, timeout, endpoint, None).await,
     }
 }
 
@@ -253,6 +253,9 @@ pub async fn search_tier1(
     deny: &[String],
     timeout: Duration,
     endpoint: &str,
+    // Why Brave did not carry this search, when a key was configured. `None`
+    // when no key is set — only then is "configure a key" the right advice.
+    brave_failure: Option<&str>,
 ) -> Result<Vec<SearchHit>, FetchError> {
     // Operator-supplied (config/env), so a bad value must surface as an error
     // the worker can read — never a panic that takes the gateway down.
@@ -294,21 +297,33 @@ pub async fn search_tier1(
     // silently.
     match last_err {
         Some(e) => Err(e),
-        None => Err(search_blocked_error()),
+        None => Err(search_blocked_error(brave_failure)),
     }
 }
 
 /// The explicit error returned when DDG's anti-bot challenge never clears.
-/// Names both the worker-side workaround (direct `fetch`) and the operator
-/// fix (Brave key) so the message is actionable at both levels.
-fn search_blocked_error() -> FetchError {
+/// Names the worker-side workaround (direct `fetch`) and, when there is one,
+/// the operator fix.
+///
+/// `brave_failure` is why the configured Brave key did not carry the search.
+/// Telling an operator who already HAS a key to configure one sent a real
+/// investigation down the wrong path for an hour, so that advice is now
+/// printed only when no key is set.
+fn search_blocked_error(brave_failure: Option<&str>) -> FetchError {
+    let operator_fix = match brave_failure {
+        Some(why) => format!(
+            "Brave was tried first and did not carry it: {why}. Operator fix: address that, \
+             not the DuckDuckGo block."
+        ),
+        None => "Operator fix: configure a free Brave Search API key \
+             (research_gateway.brave_api_key — or brave_api_key_ref, e.g. keychain:mur/brave — \
+             in ~/.mur/config.yaml, or MUR_RESEARCH_BRAVE_KEY) to switch search off DuckDuckGo."
+            .to_string(),
+    };
     FetchError::Http(format!(
         "DuckDuckGo returned its anti-bot challenge (HTTP {DDG_CHALLENGE_STATUS}) on all \
          {SEARCH_MAX_ATTEMPTS} attempts — this host's IP appears persistently blocked, \
-         retrying will not help. Use direct `fetch` of known URLs instead. Operator fix: \
-         configure a free Brave Search API key (research_gateway.brave_api_key — or \
-         brave_api_key_ref, e.g. keychain:mur/brave — in \
-         ~/.mur/config.yaml, or MUR_RESEARCH_BRAVE_KEY) to switch search off DuckDuckGo."
+         retrying will not help. Use direct `fetch` of known URLs instead. {operator_fix}"
     ))
 }
 
@@ -454,7 +469,7 @@ mod tests {
         // `.expect("static URL is valid")`d it, which was only safe while the
         // endpoint was a hardcoded const. No network is touched: the URL fails
         // to parse before any request is built.
-        let err = search_tier1("q", 3, &[], Duration::from_secs(1), "not a url")
+        let err = search_tier1("q", 3, &[], Duration::from_secs(1), "not a url", None)
             .await
             .expect_err("a malformed endpoint must be an error, not a panic");
         let FetchError::Http(msg) = err else {
@@ -472,7 +487,7 @@ mod tests {
     fn search_blocked_error_names_workaround_and_operator_fix() {
         // Pin the actionable pointers so they can't silently rot: the worker
         // pivot (`fetch`) and both operator config paths for the Brave key.
-        let FetchError::Http(msg) = search_blocked_error() else {
+        let FetchError::Http(msg) = search_blocked_error(None) else {
             panic!("blocked error must be FetchError::Http");
         };
         assert!(msg.contains("fetch"));
@@ -596,5 +611,27 @@ mod tests {
         assert!(out.contains("[truncated 6 chars]"));
         // Never split a codepoint: the kept prefix is valid UTF-8 of 4 'é's.
         assert_eq!(out.chars().take_while(|&c| c == 'é').count(), 4);
+    }
+
+    /// The regression this whole change exists for: telling an operator who
+    /// already HAS a Brave key to configure one.
+    #[test]
+    fn the_blocked_message_only_advises_a_key_when_none_is_set() {
+        let no_key = format!("{:?}", search_blocked_error(None));
+        assert!(
+            no_key.contains("configure a free Brave Search API key"),
+            "{no_key}"
+        );
+
+        let with_key = format!(
+            "{:?}",
+            search_blocked_error(Some("brave quota exhausted (next window in 394h)"))
+        );
+        assert!(
+            !with_key.contains("configure a free Brave Search API key"),
+            "must not advise a fix already applied: {with_key}"
+        );
+        assert!(with_key.contains("Brave was tried first"), "{with_key}");
+        assert!(with_key.contains("quota exhausted"), "{with_key}");
     }
 }

--- a/mur-research-gateway/src/fetcher/brave.rs
+++ b/mur-research-gateway/src/fetcher/brave.rs
@@ -1,0 +1,127 @@
+//! Brave Search: the first-class search backend.
+//!
+//! Everything Brave-shaped, moved out of `fetcher.rs` verbatim. That file keeps
+//! the keyless DuckDuckGo tier, the SSRF screen, and `fetch`.
+
+use std::time::Duration;
+
+use super::{FetchError, MAX_BODY_BYTES, SearchHit, build_client, screen_url_blocking};
+
+/// Brave Search API web-search endpoint. First-class (real index, JSON, no
+/// scraping) — used when a subscription token is configured.
+const BRAVE_ENDPOINT: &str = "https://api.search.brave.com/res/v1/web/search";
+
+/// Brave web search: GET the Brave API through the same proxy-honoring reqwest
+/// path, authenticated with `X-Subscription-Token`. Screens the endpoint host
+/// via the SSRF guard exactly like a fetch. Brave returns real URLs directly
+/// (no `uddg` redirect to decode) as structured JSON.
+pub(super) async fn search_brave(
+    query: &str,
+    limit: usize,
+    key: &str,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<Vec<SearchHit>, FetchError> {
+    let mut url = url::Url::parse(BRAVE_ENDPOINT).expect("static URL is valid");
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("count", &limit.to_string());
+    let screened = screen_url_blocking(url.as_str(), deny)
+        .await
+        .map_err(FetchError::Guard)?;
+
+    let client = build_client(timeout)?;
+    let resp = client
+        .get(screened.clone())
+        .header("X-Subscription-Token", key)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(FetchError::Http(format!(
+            "brave api status {}",
+            status.as_u16()
+        )));
+    }
+    if let Some(len) = resp.content_length()
+        && len > MAX_BODY_BYTES as u64
+    {
+        return Err(FetchError::TooLarge);
+    }
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    parse_brave_hits(&body, limit).map_err(FetchError::Http)
+}
+
+/// Parse Brave's `web.results[]` JSON into hits. A missing `web` block (Brave
+/// returns none when there are zero web results) is a valid empty result, not
+/// an error; malformed JSON is an error so the caller falls back to DDG.
+fn parse_brave_hits(json: &str, limit: usize) -> Result<Vec<SearchHit>, String> {
+    #[derive(serde::Deserialize)]
+    struct BraveResp {
+        web: Option<BraveWeb>,
+    }
+    #[derive(serde::Deserialize)]
+    struct BraveWeb {
+        results: Vec<BraveResult>,
+    }
+    #[derive(serde::Deserialize)]
+    struct BraveResult {
+        title: String,
+        url: String,
+        #[serde(default)]
+        description: String,
+    }
+    let resp: BraveResp = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    Ok(resp
+        .web
+        .map(|w| w.results)
+        .unwrap_or_default()
+        .into_iter()
+        .take(limit)
+        .map(|r| SearchHit {
+            title: r.title,
+            url: r.url,
+            snippet: r.description,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_brave_hits_extracts_results_and_respects_limit() {
+        // Trimmed real Brave web-search JSON shape.
+        let json = r#"{"web":{"results":[
+            {"title":"First","url":"https://a.example","description":"snippet a"},
+            {"title":"Second","url":"https://b.example","description":"snippet b"},
+            {"title":"Third","url":"https://c.example"}
+        ]}}"#;
+        let hits = parse_brave_hits(json, 2).unwrap();
+        assert_eq!(hits.len(), 2); // limit respected
+        assert_eq!(hits[0].url, "https://a.example");
+        assert_eq!(hits[0].snippet, "snippet a");
+    }
+
+    #[test]
+    fn parse_brave_hits_missing_web_block_is_empty_not_error() {
+        // Brave omits `web` when there are zero web results — valid, not a parse error.
+        assert!(
+            parse_brave_hits(r#"{"query":{"original":"x"}}"#, 8)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn parse_brave_hits_malformed_json_is_error() {
+        // Malformed → Err so the dispatcher falls back to DDG.
+        assert!(parse_brave_hits("not json", 8).is_err());
+    }
+}

--- a/mur-research-gateway/src/fetcher/brave.rs
+++ b/mur-research-gateway/src/fetcher/brave.rs
@@ -1,15 +1,80 @@
-//! Brave Search: the first-class search backend.
+//! Brave Search: the first-class search backend, and the 429 handling that
+//! tells its two failure modes apart.
 //!
-//! Everything Brave-shaped, moved out of `fetcher.rs` verbatim. That file keeps
-//! the keyless DuckDuckGo tier, the SSRF screen, and `fetch`.
+//! Split out of `fetcher.rs` when the 429 classifier pushed that file past the
+//! repo's 800-line limit. Everything Brave-shaped lives here; `fetcher.rs`
+//! keeps the keyless DuckDuckGo tier, the SSRF screen, and `fetch`.
 
 use std::time::Duration;
 
 use super::{FetchError, MAX_BODY_BYTES, SearchHit, build_client, screen_url_blocking};
 
-/// Brave Search API web-search endpoint. First-class (real index, JSON, no
-/// scraping) — used when a subscription token is configured.
 const BRAVE_ENDPOINT: &str = "https://api.search.brave.com/res/v1/web/search";
+
+/// Brave's free/credit tier allows **1 query per second**, and most plans
+/// enforce that burst window AND a monthly quota at the same time. Both return
+/// HTTP 429, and the two need opposite handling: a per-second trip clears in
+/// about a second, a spent monthly quota clears next month. Treating them alike
+/// is why a run once retried a request that could never succeed and then
+/// reported "configure a Brave API key" to an operator who already had one.
+///
+/// `X-RateLimit-Reset` carries the seconds until each window frees up. We read
+/// the SOONEST of them: if relief is close it is the burst window and worth
+/// waiting for; if it is far away, no amount of backoff will help.
+const BRAVE_RETRYABLE_RESET_SECS: u64 = 10;
+
+/// Attempts against Brave when a 429 says the burst window will clear shortly.
+/// Deliberately small: with several workers sharing one key the honest fix is
+/// fewer concurrent searches, not a longer retry train.
+const BRAVE_MAX_ATTEMPTS: u32 = 3;
+
+/// What a Brave 429 actually meant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BraveThrottle {
+    /// Burst window; free again in `secs`.
+    Burst { secs: u64 },
+    /// Quota window; `secs` away, so retrying inside this run is pointless.
+    Exhausted { secs: u64 },
+    /// No usable `X-RateLimit-Reset`. Retried once as a burst, because a
+    /// missing header is more likely a proxy stripping it than a spent quota.
+    Unknown,
+}
+
+/// Classify a Brave 429 from its `X-RateLimit-Reset` header.
+///
+/// The header may carry one value per policy window (`"1, 1419704"`), so every
+/// number is parsed and the minimum wins — that is when search can next work.
+fn classify_brave_429(reset_header: Option<&str>) -> BraveThrottle {
+    let Some(soonest) = reset_header.and_then(|h| {
+        h.split(',')
+            .filter_map(|part| part.trim().parse::<u64>().ok())
+            .min()
+    }) else {
+        return BraveThrottle::Unknown;
+    };
+    if soonest <= BRAVE_RETRYABLE_RESET_SECS {
+        BraveThrottle::Burst { secs: soonest }
+    } else {
+        BraveThrottle::Exhausted { secs: soonest }
+    }
+}
+
+impl BraveThrottle {
+    /// How this 429 reads to a human, so the fallback message says what
+    /// actually happened instead of guessing.
+    fn describe(self) -> String {
+        match self {
+            BraveThrottle::Burst { secs } => format!(
+                "brave rate limit (1 query/sec on the free tier; window clears in {secs}s) —                  several workers are sharing one key"
+            ),
+            BraveThrottle::Exhausted { secs } => format!(
+                "brave quota exhausted (next window in {}h) — retrying will not help;                  raise the plan or reduce searches",
+                secs / 3600
+            ),
+            BraveThrottle::Unknown => "brave rate limit (429, no reset header)".to_string(),
+        }
+    }
+}
 
 /// Brave web search: GET the Brave API through the same proxy-honoring reqwest
 /// path, authenticated with `X-Subscription-Token`. Screens the endpoint host
@@ -31,13 +96,40 @@ pub(super) async fn search_brave(
         .map_err(FetchError::Guard)?;
 
     let client = build_client(timeout)?;
-    let resp = client
-        .get(screened.clone())
-        .header("X-Subscription-Token", key)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let mut resp = None;
+    for attempt in 0..BRAVE_MAX_ATTEMPTS {
+        let r = client
+            .get(screened.clone())
+            .header("X-Subscription-Token", key)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .send()
+            .await
+            .map_err(|e| FetchError::Http(e.to_string()))?;
+        if r.status().as_u16() != 429 {
+            resp = Some(r);
+            break;
+        }
+        // A 429 is two different failures wearing one status code. Wait only
+        // for the one waiting can fix, and name the other instead of burning
+        // attempts on it.
+        let throttle = classify_brave_429(
+            r.headers()
+                .get("x-ratelimit-reset")
+                .and_then(|v| v.to_str().ok()),
+        );
+        let wait = match throttle {
+            BraveThrottle::Burst { secs } => secs.max(1),
+            BraveThrottle::Unknown => 1,
+            BraveThrottle::Exhausted { .. } => {
+                return Err(FetchError::Http(throttle.describe()));
+            }
+        };
+        if attempt + 1 == BRAVE_MAX_ATTEMPTS {
+            return Err(FetchError::Http(throttle.describe()));
+        }
+        tokio::time::sleep(Duration::from_secs(wait)).await;
+    }
+    let resp = resp.expect("loop returns on every non-retry path");
     let status = resp.status();
     if !status.is_success() {
         return Err(FetchError::Http(format!(
@@ -94,6 +186,31 @@ fn parse_brave_hits(json: &str, limit: usize) -> Result<Vec<SearchHit>, String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A 429 is two different failures wearing one status code. Waiting fixes
+    /// exactly one of them; conflating them once produced an hour of retrying
+    /// a request that could never succeed.
+    #[test]
+    fn a_burst_429_is_told_apart_from_a_spent_quota() {
+        // 1 query/sec window: relief is immediate, so retry.
+        assert_eq!(
+            classify_brave_429(Some("1")),
+            BraveThrottle::Burst { secs: 1 }
+        );
+        // Monthly window: no backoff inside this run can clear it.
+        assert!(matches!(
+            classify_brave_429(Some("1419704")),
+            BraveThrottle::Exhausted { .. }
+        ));
+        // Both windows reported together — the SOONEST is when search can work.
+        assert_eq!(
+            classify_brave_429(Some("1, 1419704")),
+            BraveThrottle::Burst { secs: 1 }
+        );
+        // A stripped header is likelier a proxy than a spent quota: retry once.
+        assert_eq!(classify_brave_429(None), BraveThrottle::Unknown);
+        assert_eq!(classify_brave_429(Some("garbage")), BraveThrottle::Unknown);
+    }
 
     #[test]
     fn parse_brave_hits_extracts_results_and_respects_limit() {


### PR DESCRIPTION
Two commits, in the order `CLAUDE.md` asks for: **`c7ad9c3c` is pure movement**, **`0a0754c2` is the actual logic**. Review the second one; the first adds and removes nothing (test count unchanged at 77 — the two new tests arrive in the behavior commit, taking it to 79).

## The bug

A 429 from Brave is **two different failures wearing one status code**. The free/credit tier allows **1 query per second**, and most plans enforce that burst window *and* a monthly quota simultaneously. Waiting fixes exactly one of them.

The gateway treated both alike — three attempts, then fall back to DuckDuckGo. On a machine whose IP DuckDuckGo also blocks, that means search is simply gone.

A real deep-research run made **nine search calls; all nine 429'd**. The workers finished the research by direct-`fetch`ing URLs they already knew — which is both a quality ceiling (no source discovery at all) and the expensive path, since a fetch returns whole pages rather than snippets.

## The fix

`classify_brave_429` reads `X-RateLimit-Reset`, which may carry one value per policy window (`"1, 1419704"`), and takes the **soonest** — that is when search can next work.

| reset | meaning | action |
|---|---|---|
| ≤ 10s | burst window (1 QPS) | wait that long, retry |
| > 10s | quota window | return immediately, say retrying won't help |
| absent | likely a proxy stripped it | retry once as a burst |

## The part that actually cost an hour

When DuckDuckGo's challenge never cleared, the error told the operator to *"configure a free Brave Search API key"* — with **no idea a key was configured and had been rate-limited**.

That advice sent a real investigation down the wrong path until someone asked *"isn't the Brave key already set?"*. It is now printed only when no key is set; with one, the message names what Brave actually did:

> Brave was tried first and did not carry it: brave quota exhausted (next window in 394h). Operator fix: address that, not the DuckDuckGo block.

## Two limits this does NOT fix

**The 1 QPS ceiling belongs to the key, not the process.** Three research workers each spawn their own gateway, so three independent backoffs still collide. Serialising across processes needs a lock this change does not introduce — the honest workaround is fewer concurrent searchers, or a higher plan.

**Brave removed its free tier in February 2026.** Newer keys get monthly credits and then bill the card. On such a key `Exhausted` is the normal end state, not an anomaly.

## Why the split ships in the same PR

`fetcher.rs` was 712 lines; the classifier pushed it to 860, past the repo's 800-line limit. Splitting first and landing the behavior change second is the rule's order, and that is how the commits read — but they ship together, because the alternative is landing a PR that violates the limit.

## Verification

- `cargo test -p mur-research-gateway` — 69 + 10 passed, 0 failed
- `cargo clippy -p mur-research-gateway --all-targets -- -D warnings` — clean
- `cargo fmt` — clean
- `fetcher.rs` 637 lines, `fetcher/brave.rs` 244 — both inside the limit

The classifier is unit-tested against the header shapes; the retry path is not exercised against a live 429, so the timing behaviour rests on Brave's documented `X-RateLimit-Reset` semantics rather than on an observed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
