### PR TITLE
chore(release): bump workspace version to 2.71.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.19"
+version = "2.71.20"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.19"
+version = "2.71.20"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Merging this **is** the release: `tag.yml` tags `v2.71.20` on the merge commit and dispatches `release.yml`, which publishes to crates.io. There is no later gate — this PR is the approval.

## What 2.71.20 carries

Everything merged since the 2.71.19 bump (`4d67c165`):

- **[#1143](https://github.com/mur-run/mur/pull/1143)** `mur agent routing` — the read surface for background routing decisions. Smart swaps the model on turns nobody is watching; until now the only place that rendered a decision was the Hub chat caption, which a scheduled or companion-outbox turn never reaches. `↓` marks the turns MUR chose for you.
- **[#1145](https://github.com/mur-run/mur/pull/1145)** Brave 429 classification — tells the two 429s apart and stops misadvising the operator.

**Why this release exists:** 2.71.19's bump merged *below* #1143, so the routing reader missed that release by one commit. Anyone on brew has the capability gate (2.71.18/19) but no way to see what the router did.

## Checks

- `Cargo.toml` → 2.71.20; both lock files moved with it (`mur-core` reads 2.71.20 in the root lock and in `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy and breaks the Hub build when it disagrees).
- Version edit verified by reading the file back, not by trusting the writer — `sed -i ''` fails silently on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
