### PR TITLE
docs(readme): the router's decisions are no longer write-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,12 @@ Agent** wizard offers the same catalog as a source.
   (`mur model smart on`), and per agent it's genuinely three-state:
   `mur agent smart <name> follow|on|off`, where `follow` means follow. The
   toggle used to lie in the other direction too — an agent with no fallback
-  chain never ran Smart at all, whatever the setting said.
+  chain never ran Smart at all, whatever the setting said. And the decisions
+  are no longer write-only: `mur agent routing <name> --downgrades-only` reads
+  them back out of the telemetry that was always being written, marking with
+  `↓` the turns MUR chose the model for you. The gate stops the failure MUR can
+  recognise; no automated check can tell you the cheap model was simply *worse*
+  at something without paying to run the turn twice. That's what looking is for.
 
 ### 🔌 Power the tools you already pay for
 


### PR DESCRIPTION
Third of the three canonical doc locations, catching up to [#1143](https://github.com/mur-run/mur/pull/1143). The docs site already has it ([mur-server#70](https://github.com/mur-run/mur-server/pull/70)); the command tree row landed with #1143 itself; this is the README feature bullet.

The bullet was written before the reader existed, and leaned on the invisibility as part of the problem:

> the decision caption only renders in Hub chat, which background turns never reach

Accurate when written, half the story now. Adds the reader and — the part worth keeping honest — the boundary the capability gate cannot cross: it stops the failure MUR can *recognise*, and no automated check can tell you the cheap model was simply worse at something without paying to run the turn twice.

Command tree unchanged (`routing` is already in the `agent` row; no new top-level command, so the count stays 28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
