### PR TITLE
fix(deep-research): the render browser can be granted, and a denial says so

### DIFF
--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -232,6 +232,57 @@ pub(crate) fn provision_one(
 /// Sets the process-global `MUR_HOME` env var for its duration, same
 /// caveat as [`provision`]'s `# Concurrency` note (`cmd_mcp_set_network`
 /// re-derives its home directory from that env var).
+/// Let `worker`'s gateway spawn the render browser.
+///
+/// The sandbox's exec allowlist searches a fixed set of directories that does
+/// NOT include a user's npm prefix, and `agent-browser` is a bare name resolved
+/// through `PATH` — so adding the NAME grants nothing. `from_entitlements`
+/// keeps an entry containing a path separator as-is when it resolves to an
+/// executable, which is why obscura grants absolute paths and why this must
+/// too. Resolving here, at provision time, also means an operator who has not
+/// installed the browser finds out now rather than mid-research.
+///
+/// Consent-gated by the caller: this is the right to EXECUTE a browser inside
+/// the worker's sandbox, which is a larger grant than egress and is asked for
+/// separately in the wizard.
+pub fn grant_render_browser(mur_home: &Path, worker: &str) -> Result<()> {
+    // Same reason `grant_egress` does this: the profile helpers below resolve
+    // their home from `MUR_HOME`, so a caller passing an explicit home must
+    // publish it or the edit lands in the wrong tree.
+    unsafe {
+        std::env::set_var("MUR_HOME", mur_home);
+    }
+    let Ok(abs) = which_agent_browser() else {
+        // Not installed is not a provisioning failure — the worker simply has
+        // no rendered fetch, and `browser.rs` says so when a page needs it.
+        eprintln!(
+            "  note: `agent-browser` is not on PATH, so {worker} gets no rendered fetch.              Install it and re-run setup to grant it."
+        );
+        return Ok(());
+    };
+    let (path, mut profile) = super::super::agent::load_profile_for_edit(worker)?;
+    let allowed = &mut profile.entitlements.processes.spawn.allowed;
+    if allowed.contains(&abs) {
+        return Ok(());
+    }
+    allowed.push(abs.clone());
+    super::super::agent::save_profile(&path, &mut profile)?;
+    println!("Granted {worker} permission to spawn {abs}");
+    Ok(())
+}
+
+/// Absolute path of `agent-browser` on `PATH`, for the exec allowlist.
+fn which_agent_browser() -> Result<String> {
+    let path = std::env::var_os("PATH").ok_or_else(|| anyhow::anyhow!("PATH unset"))?;
+    for dir in std::env::split_paths(&path) {
+        let cand = dir.join("agent-browser");
+        if cand.is_file() {
+            return Ok(cand.canonicalize().unwrap_or(cand).to_string_lossy().into());
+        }
+    }
+    anyhow::bail!("agent-browser not found on PATH")
+}
+
 pub fn grant_egress(mur_home: &Path, worker: &str, deny_hosts: &[String], yes: bool) -> Result<()> {
     unsafe {
         std::env::set_var("MUR_HOME", mur_home);

--- a/mur-core/src/cmd/deep_research/setup.rs
+++ b/mur-core/src/cmd/deep_research/setup.rs
@@ -26,6 +26,10 @@ pub struct WizardAnswers {
     pub count: usize,
     pub budget_usd: f64,
     pub egress: bool,
+    /// Grant the workers' gateway permission to spawn the render browser.
+    /// Separate consent from egress: egress is "may it reach the web", this is
+    /// "may it start a browser to do so".
+    pub browser: bool,
 }
 
 fn read_line(input: &mut dyn BufRead) -> Result<String> {
@@ -117,11 +121,32 @@ pub fn run_wizard(
     output.flush()?;
     let egress = read_line(input)? == "yes";
 
+    // Q5: render-browser consent — literal "yes" only, like egress above.
+    // Asked separately because it grants something egress does not: the right
+    // to EXECUTE a browser inside the sandbox. Without it, pages that only
+    // render client-side (many government dataset portals) come back as an
+    // empty JS shell — a real quality ceiling, but not a reason to grant
+    // execution silently.
+    writeln!(
+        output,
+        "\nRender browser: some pages return only a JS shell to a plain fetch.\n\
+         Rendering them means the gateway EXECUTES `agent-browser` inside the\n\
+         worker's sandbox. Skipping this leaves plain fetch working; those pages\n\
+         are simply reported as unrenderable."
+    )?;
+    write!(
+        output,
+        "Type 'yes' to allow spawning the render browser (anything else = skip): "
+    )?;
+    output.flush()?;
+    let browser = read_line(input)? == "yes";
+
     Ok(WizardAnswers {
         model,
         count,
         budget_usd,
         egress,
+        browser,
     })
 }
 
@@ -232,6 +257,14 @@ pub fn cmd_setup(mur_home: &Path) -> Result<()> {
     fleet.loop_cfg = Some(loop_cfg);
     crate::cmd::fleet::store::save_fleet(mur_home, &fleet)?;
 
+    // Render browser: same consent discipline as egress — literal "yes" only,
+    // applied to every target worker, never revoked here.
+    if a.browser {
+        for name in &target_names {
+            super::provision::grant_render_browser(mur_home, name)?;
+        }
+    }
+
     // Egress: only when the wizard answer is the literal "yes", and only
     // for workers that don't already have it — never revoke.
     if a.egress {
@@ -279,23 +312,38 @@ mod tests {
 
     #[test]
     fn defaults_accepted_with_empty_lines_and_explicit_yes() {
-        // model=default, count=default, budget=default, egress consent "yes"
-        let a = answers("\n\n\nyes\n", &["claude_haiku", "claude_opus"]).unwrap();
+        // model=default, count=default, budget=default, egress "yes", browser "yes"
+        let a = answers("\n\n\nyes\nyes\n", &["claude_haiku", "claude_opus"]).unwrap();
         assert_eq!(a.model, "claude_haiku");
         assert_eq!(a.count, super::super::provision::DEFAULT_WORKER_COUNT);
         assert_eq!(a.budget_usd, DEFAULT_RUN_BUDGET_USD);
         assert!(a.egress);
+        assert!(a.browser);
     }
 
     #[test]
     fn egress_requires_literal_yes() {
-        let a = answers("\n\n\ny\n", &["claude_haiku"]).unwrap();
+        let a = answers("\n\n\ny\nno\n", &["claude_haiku"]).unwrap();
         assert!(!a.egress, "'y' must NOT count as egress consent");
+    }
+
+    /// The browser grant is EXEC permission inside the sandbox, so it obeys the
+    /// same literal-"yes" rule egress does — and is a separate answer, so one
+    /// consent can never buy both.
+    #[test]
+    fn browser_requires_its_own_literal_yes() {
+        let a = answers("\n\n\nyes\ny\n", &["claude_haiku"]).unwrap();
+        assert!(a.egress, "egress said yes");
+        assert!(!a.browser, "'y' must NOT count as browser consent");
+
+        let b = answers("\n\n\nno\nyes\n", &["claude_haiku"]).unwrap();
+        assert!(!b.egress, "egress declined");
+        assert!(b.browser, "browser consent is independent of egress");
     }
 
     #[test]
     fn model_picked_by_number() {
-        let a = answers("2\n\n\nno\n", &["claude_haiku", "claude_opus"]).unwrap();
+        let a = answers("2\n\n\nno\nno\n", &["claude_haiku", "claude_opus"]).unwrap();
         assert_eq!(a.model, "claude_opus");
     }
 

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -269,6 +269,25 @@ fn version_ge(v: &str, maj: u32, min: u32) -> bool {
     a > maj || (a == maj && b >= min)
 }
 
+/// Why a spawn failed, in terms the operator can act on.
+///
+/// `PermissionDenied` here is almost never file permissions — it is the agent's
+/// kernel sandbox refusing an exec that is not on its allowlist. The raw
+/// `Operation not permitted (os error 1)` reads like a broken install and sent
+/// a real investigation looking at the binary instead of at the policy, so the
+/// denial names itself and the grant that lifts it.
+fn spawn_error_message(bin: &str, e: &std::io::Error) -> String {
+    if e.kind() == std::io::ErrorKind::PermissionDenied {
+        return format!(
+            "spawn {bin}: refused by the agent's sandbox (exec allowlist). Rendered fetch \
+             needs that binary granted at provision time — re-run `mur deep-research setup` \
+             and answer 'yes' to the research browser, or add its ABSOLUTE path to the \
+             agent's entitlements.processes.spawn.allowed. Plain `fetch` still works."
+        );
+    }
+    format!("spawn {bin}: {e}")
+}
+
 /// Spawn agent-browser with `argv`, bounded by `timeout` (same source tier-1
 /// uses), and return its stdout. Enforces the tier-1 body cap on stdout so a
 /// runaway render can't buffer unbounded. Shared by `fetch_rendered`/`search`.
@@ -281,7 +300,7 @@ async fn run_agent_browser(
     let out = tokio::time::timeout(timeout, fut)
         .await
         .map_err(|_| FetchError::Http("agent-browser timed out".into()))?
-        .map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
+        .map_err(|e| FetchError::Http(spawn_error_message(bin, &e)))?;
     if !out.status.success() {
         return Err(FetchError::Http(
             String::from_utf8_lossy(&out.stderr).into(),
@@ -370,6 +389,30 @@ pub async fn fetch_rendered(
 
 #[cfg(test)]
 mod tests {
+
+    /// The message that cost an investigation an hour. `PermissionDenied` from
+    /// a spawn is the kernel sandbox refusing an exec, not a broken install —
+    /// the raw OS text reads like the latter.
+    #[test]
+    fn a_denied_spawn_names_the_sandbox_and_the_grant() {
+        let e = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let msg = super::spawn_error_message("agent-browser", &e);
+        assert!(msg.contains("sandbox"), "{msg}");
+        assert!(msg.contains("deep-research setup"), "{msg}");
+        // and it must not leave the reader thinking plain fetch is gone too
+        assert!(msg.contains("`fetch` still works"), "{msg}");
+    }
+
+    /// Any other spawn failure keeps the OS text — inventing a sandbox story
+    /// for a missing binary would be the same mistake pointing the other way.
+    #[test]
+    fn other_spawn_failures_keep_their_own_error() {
+        let e = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let msg = super::spawn_error_message("agent-browser", &e);
+        assert!(!msg.contains("sandbox"), "{msg}");
+        assert!(msg.starts_with("spawn agent-browser:"), "{msg}");
+    }
+
     use super::*;
 
     // Process-global env — serialize with the same lock style config.rs tests use.


### PR DESCRIPTION
A deep-research worker could **never** use rendered fetch. Not misconfigured — structurally impossible.

## Root cause

`provision.rs` grants spawn paths only when `render_engine == Some("obscura")`. The **default** engine's binary was never granted, so every rendered fetch died on:

```
spawn agent-browser: Operation not permitted (os error 1)
```

That is the kernel sandbox refusing an exec. It reads like a broken install, and it sent a real investigation looking at the binary instead of at the policy. Pages that render client-side — several government dataset portals among them — came back as an empty JS shell with no way to tell why.

## Granting the name would not have worked

`agent-browser` is a **bare name resolved through `PATH`**, and the sandbox's exec allowlist searches a fixed set of directories that excludes a user's npm prefix. Only an entry containing a path separator is kept as-is.

That is why obscura grants absolute paths, and why this resolves one at provision time — with the side benefit that an operator who has not installed the browser finds out **then**, not mid-research. A missing browser is a printed note, not a provisioning failure.

## Consent is its own question

| question | grants |
|---|---|
| egress (existing) | may it reach the web |
| **render browser** (new) | may it **EXECUTE a browser** inside the sandbox |

The second is the larger grant, so it is asked separately. Both obey the same literal-`"yes"` rule the wizard already uses, and a test pins that one answer can never buy the other — `egress=yes / browser=y` grants only egress; `egress=no / browser=yes` grants only the browser.

**Existing workers are unaffected.** An upgrade does not hand out exec permission. Re-run `mur deep-research setup` and answer yes to the new question.

## The message, in both directions

A denied spawn now names the sandbox, the grant that lifts it, and the fact that plain `fetch` still works — the last part matters, or a reader concludes fetching is dead entirely.

A spawn that fails for **any other** reason keeps its own OS error. Inventing a sandbox story for a missing binary would be the same mistake pointing the other way, so there is a test for each direction.

## Verification

- `cargo test -p mur-research-gateway` — 71 + 10 passed, 0 failed
- `cargo nextest run -p mur-core --lib` — **2677 passed**, 0 failed
- `cargo clippy -p mur-core -p mur-research-gateway --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Three wizard fixtures needed an extra input line for the new question — the tests catching that is them doing their job, and none of them was changed to agree with the code.

## Not verified

The grant path is unit-tested for consent and for the message; **it has not been exercised end-to-end against a live sandbox**. The mechanism is the same one obscura already uses, but that is reasoning from a sibling, not an observed rendered fetch succeeding inside a worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
