### PR TITLE
fix(routing): an image the agent fetched itself gates like one you pasted

### DIFF
--- a/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
+++ b/docs/superpowers/specs/2026-09-01-smart-routing-capability-gate-design.md
@@ -89,10 +89,19 @@ pub fn pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>,
 ```rust
 // mur-agent-runtime — LlmRequest lives here
 fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
-    // messages contains RichMessage::ImageText  -> Vision
-    // !req.tools.is_empty()                     -> Tools
+    // messages contains RichMessage::ImageText              -> Vision
+    // ...or a ToolResults entry whose `images` is non-empty -> Vision
+    // !req.tools.is_empty()                                 -> Tools
 }
 ```
+
+**An image reaches a turn by two doors, and the obvious one is the rarer one
+in automated work.** A user can attach a picture (`ImageText`), but an agent can
+also fetch one itself — `read_file` on a PNG, an MCP tool returning an image —
+and those arrive inside `ToolResults`, which the Anthropic adapter renders as
+real `image` blocks. The first cut of this gate checked only `ImageText`, which
+left exactly the case it exists for unprotected: nobody pastes a picture into a
+scheduled vehicle-recognition run. Both doors are checked.
 
 `Requirement::permitted_when_undeclared` carries the per-requirement rule from
 §2, so `satisfies` enforces a declared capability list exactly and treats an

--- a/mur-agent-runtime/src/llm/fallback/mod.rs
+++ b/mur-agent-runtime/src/llm/fallback/mod.rs
@@ -419,13 +419,22 @@ fn truncate_chars(s: &str, max: usize) -> String {
 /// The capabilities this request needs from whatever model serves it. Derived
 /// from the request, never from config: an image in the messages means the
 /// model has to be able to see it, a tool list means it has to be able to call.
+///
+/// An image reaches a turn by two different doors, and only one of them is the
+/// obvious one. A user can attach a picture (`ImageText`), but an agent can
+/// also fetch one itself — `read_file` on a PNG, or an MCP tool that returns an
+/// image — and those arrive inside `ToolResults`, which the Anthropic adapter
+/// renders as real `image` blocks. Checking only the first door left automated
+/// work, the exact case this gate exists for, unprotected: nobody pastes a
+/// picture into a scheduled vehicle-recognition run.
 fn requirements_of(req: &LlmRequest) -> Vec<Requirement> {
     let mut out = Vec::new();
-    if req
-        .messages
-        .iter()
-        .any(|m| matches!(m, RichMessage::ImageText { .. }))
-    {
+    let carries_image = req.messages.iter().any(|m| match m {
+        RichMessage::ImageText { .. } => true,
+        RichMessage::ToolResults { results } => results.iter().any(|r| !r.images.is_empty()),
+        _ => false,
+    });
+    if carries_image {
         out.push(Requirement::Vision);
     }
     if !req.tools.is_empty() {

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -606,4 +606,53 @@ fn background_image_turn_drops_a_cheap_model_that_cannot_see() {
         vec!["primary".to_string()],
         "nothing declares vision, so the explicit primary is all that is left"
     );
+
+    // The other door: the agent fetched the picture itself. Nobody pastes an
+    // image into a scheduled vehicle-recognition run — it arrives from
+    // `read_file` or an MCP tool, inside a tool result, and the Anthropic
+    // adapter renders those as real image blocks. Checking only the user turn
+    // left automated work — the exact case this gate exists for — unprotected.
+    let tool_image_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        messages: vec![RichMessage::ToolResults {
+            results: vec![crate::llm::ToolResultEntry {
+                call_id: "c1".into(),
+                content: "[image /plates/frame-0412.png]".into(),
+                is_error: false,
+                status: Default::default(),
+                images: vec![crate::tools::ToolImage {
+                    media_type: "image/png".into(),
+                    data: "aGk=".into(),
+                }],
+            }],
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&tool_image_turn),
+        vec!["primary".to_string()],
+        "an image the agent fetched itself must gate the same as one pasted in"
+    );
+
+    // Negative control: the same shape with no images is not a vision request,
+    // so Smart still downgrades. Otherwise the check above would pass for the
+    // wrong reason — every tool-using turn would look like vision.
+    let tool_text_turn = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        messages: vec![RichMessage::ToolResults {
+            results: vec![crate::llm::ToolResultEntry {
+                call_id: "c1".into(),
+                content: "plain text output".into(),
+                is_error: false,
+                status: Default::default(),
+                images: vec![],
+            }],
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        fb.candidates_for(&tool_text_turn),
+        vec!["cheap".to_string(), "primary".into()],
+        "a tool result without images is ordinary background work"
+    );
 }


### PR DESCRIPTION
A hole in the capability gate from [#1138](https://github.com/mur-run/mur/pull/1138), found by a user asking whether smart routing could be disabled per agent — they run vehicle recognition, where a cheap model *finishes* but is much less accurate.

The answer to their question was yes (`mur agent smart <name> off`). The better answer was that the protection they should not have needed to reach for did not cover their case.

## The hole

`requirements_of` derived Vision from `RichMessage::ImageText` alone — a picture attached to a **user turn**. But an agent can fetch an image itself:

- `read_file` on a PNG returns it in `ToolResultEntry.images`
- an MCP tool can return one the same way

and `anthropic.rs` renders those as real `image` blocks in the `tool_result`. The field's own doc comment says so: *"Rendered as real `image` blocks inside the provider's `tool_result` … so an agent can look at what its own tool fetched."*

So a background turn doing image work could still be handed to a cheap text-tier model — silently — which is the incident the whole feature was built to prevent. **Nobody pastes a picture into a scheduled vehicle-recognition run.** The obvious door is the rare one in automated work; I checked only that one.

## The fix

Both doors:

```rust
let carries_image = req.messages.iter().any(|m| match m {
    RichMessage::ImageText { .. } => true,
    RichMessage::ToolResults { results } => results.iter().any(|r| !r.images.is_empty()),
    _ => false,
});
```

## Test plan

Three assertions in the existing incident test, because a passing test here could pass for the wrong reason:

1. user-pasted image → primary only (unchanged behaviour)
2. **tool-returned image → primary only** (the fix)
3. **tool result with no images → still downgrades to cheap** (negative control)

Without #3, the fix would also pass if I had written "any `ToolResults` means vision" — which would stop every tool-using background turn from downgrading, disabling Smart entirely while the suite stayed green.

**Mutation-verified**: reverting the new match arm makes assertion #2 fail with `left: ["cheap", "primary"]` against `right: ["primary"]`, naming the added message — so the test reaches the changed path rather than passing beside it.

- `cargo nextest run -p mur-agent-runtime -E 'test(llm::fallback)'` — 21 passed
- `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Spec §3.1 updated: it documented the single-door rule, so leaving it would set the same trap for the next reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
