### PR TITLE
chore(release): bump workspace version to 2.71.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.21"
+version = "2.71.22"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.21"
+version = "2.71.22"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Summary
Cuts v2.71.22. Merging this tags the release and publishes to crates.io.

Since v2.71.21 (18 commits), the headline is two subscription providers that let agents run on plans you already pay for, with no API key:

- **ChatGPT Subscription** (`provider: codex`, #1154) — Codex-managed login, models from `codex app-server`, loopback-only `/codex/v1`
- **Claude Subscription** (`provider: claude`, #1155) — Claude Code-managed login, models from the models.dev catalog, loopback-only `/v1`
- Both refuse a `secret` and any non-loopback `base_url` at startup, so no edit can silently move an agent onto metered billing
- Registry entries carry `billing` and `catalog_verified`; pickers and fallback chains show the billing label, and MUR never adds a usage-billed fallback behind a subscription model on its own
- `mur model doctor` flags entries off the loopback contract (warn-only, as always)
- Both verified end-to-end on real accounts (#1156 records the Claude run)

Pairs with mur-model-gateway v0.2.0+ (`/__mur/health` reports the credential kind for both).

## Test plan
- [x] Both lock files moved with `Cargo.toml` (root and `mur-hub-gui/src-tauri`)
- [ ] CI green — `validate-version` confirms the tag will match `Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)