### PR TITLE
fix(runtime): quote a dead MCP server's stderr in the startup error

### DIFF
--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -11,6 +11,31 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
 
+/// How much of a dead child's stderr to read back, and how many of its trailing
+/// lines to quote. A crashing server can have written megabytes; the failure
+/// reason is almost always in the last handful of lines.
+const STDERR_TAIL_BYTES: u64 = 8 * 1024;
+const STDERR_TAIL_LINES: usize = 5;
+
+/// Last non-empty lines of a child's stderr, joined for a single-line error.
+/// `None` when the child said nothing, so the caller can omit the clause
+/// entirely rather than print an empty one.
+fn tail_lines(raw: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(raw);
+    let mut lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .rev()
+        .take(STDERR_TAIL_LINES)
+        .collect();
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    Some(lines.join(" | "))
+}
+
 /// Stdio (subprocess) MCP transport.
 pub struct StdioMcpClient {
     /// Raw std child — used for kill/wait in `shutdown`.
@@ -271,6 +296,27 @@ impl StdioMcpClient {
         self.stderr.lock().await.take()
     }
 
+    /// The last few lines the child wrote to stderr, consumed once.
+    ///
+    /// Only called after the child has exited: its write end is closed, so the
+    /// read hits EOF instead of blocking. This is the operator's ONLY chance to
+    /// see why it died during the handshake — the pool starts draining stderr
+    /// *after* `initialize` succeeds, so a server killed by a sandbox EPERM on
+    /// startup had its stderr discarded entirely, leaving an exit status that
+    /// looks identical to a genuine crash (#1161).
+    async fn stderr_tail(&self) -> Option<String> {
+        let mut pipe = self.stderr.lock().await.take()?;
+        let raw = tokio::task::spawn_blocking(move || {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let _ = pipe.by_ref().take(STDERR_TAIL_BYTES).read_to_end(&mut buf);
+            buf
+        })
+        .await
+        .ok()?;
+        tail_lines(&raw)
+    }
+
     /// Send a JSON-RPC *notification* (no `id`, no response expected).
     /// Used for the MCP lifecycle `notifications/initialized` handshake step.
     async fn notify(&self, method: &str, params: Value) -> Result<(), McpError> {
@@ -294,10 +340,16 @@ impl StdioMcpClient {
             child.try_wait()
         };
         match status {
-            Ok(Some(st)) => McpError::Server(format!(
-                "mcp server `{}` exited before replying ({st})",
-                self.server_name
-            )),
+            Ok(Some(st)) => {
+                let mut msg = format!(
+                    "mcp server `{}` exited before replying ({st})",
+                    self.server_name
+                );
+                if let Some(tail) = self.stderr_tail().await {
+                    msg.push_str(&format!("; stderr: {tail}"));
+                }
+                McpError::Server(msg)
+            }
             // Still alive, or we cannot tell — say so rather than implying an exit.
             Ok(None) => McpError::StreamClosed,
             Err(e) => McpError::Server(format!(
@@ -441,6 +493,27 @@ mod tests {
     use super::*;
     use mur_common::agent::{McpNetMode, McpServerNetwork};
     use std::collections::HashMap;
+
+    #[test]
+    fn stderr_tail_quotes_the_last_lines_and_nothing_when_silent() {
+        // The line that went missing in practice: a sandbox EPERM on the state
+        // dir the server writes at startup. It exits 1; without this the error
+        // is indistinguishable from a genuine crash (#1161).
+        let raw = b"boot\n\nEACCES: permission denied, mkdir '/Users/d/.claude-server-commander'\n";
+        let tail = tail_lines(raw).unwrap();
+        assert!(tail.contains("EACCES"));
+        assert!(!tail.contains("\n"), "must stay one line: {tail}");
+        assert!(!tail.contains(" |  |"), "blank lines dropped, not joined");
+
+        // Only the trailing window survives, in original order.
+        let many: Vec<String> = (1..=20).map(|i| format!("line{i}")).collect();
+        let tail = tail_lines(many.join("\n").as_bytes()).unwrap();
+        assert_eq!(tail, "line16 | line17 | line18 | line19 | line20");
+
+        // A silent child gets no clause at all.
+        assert!(tail_lines(b"").is_none());
+        assert!(tail_lines(b"\n  \n").is_none());
+    }
 
     #[test]
     fn proxy_env_only_for_restricted_servers() {


### PR DESCRIPTION
P0 of #1161.

## Problem

`McpPool::client` drains the child's stderr only *after* `initialize()` returns Ok. A server that dies during the handshake therefore has its stderr thrown away — and the error the operator sees is identical whether it crashed on its own or the B1 sandbox denied it:

```
mcp tools/list failed: mcp error: mcp server `desktop-commander` exited before replying (exit status: 1)
```

Real case: `@wonderwhy-er/desktop-commander` writes `~/.claude-server-commander` at startup, which was outside the agent's write grants. EPERM, exit 1, no clue. `mur agent mcp inspect` said CLEAN, the pin verified, and the same command run by hand outside the sandbox worked — three hypotheses had to be falsified by hand before the actual cause surfaced. The child had been printing the reason all along.

## Fix

`stream_closed_error` already exists to explain a closed stdout by inspecting the child. Read the unread stderr pipe there and quote its trailing lines:

```
mcp server `desktop-commander` exited before replying (exit status: 1); stderr: EACCES: permission denied, mkdir '/Users/d/.claude-server-commander'
```

Only reached from the branch that has already reaped the child, so the write end is closed and the read hits EOF instead of blocking. If the pool did take the pipe (server started fine, failed later) `take()` yields `None` and the message is unchanged.

## Test

`tail_lines` is the non-trivial part and is unit-tested directly: window size, original order, one-line output, blank lines dropped, `None` for a silent child. Mutation-verified — widening the window to `STDERR_TAIL_LINES + 1` fails the test (`left: "line15 | line16 | …"`), reverted after.

`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` → 0. `cargo fmt --check` → 0.

## Not in scope

The other two parts of #1161: a preflight that actually spawns the server under the agent's sandbox in `mcp inspect`, and declared `state_paths` on an entry. A legible error may well be enough on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)