### PR TITLE
feat(hub): PR 1 of Hub 2.0 — one status vocabulary and neutral-first tokens

### DIFF
--- a/mur-hub-gui/ui/src/components/agents/AgentsPage.tsx
+++ b/mur-hub-gui/ui/src/components/agents/AgentsPage.tsx
@@ -4,7 +4,8 @@ import type { AgentEntry, AgentRuntimeStatus } from "../../types";
 import { Mascot } from "../Mascot";
 import type { MascotMood } from "../Mascot";
 import { useT } from "../../i18n";
-import { CATEGORY_COLORS, avatarInitials, runtimePill, timeGreetingKey } from "../../utils";
+import { CATEGORY_COLORS, avatarInitials, timeGreetingKey } from "../../utils";
+import { StatusPill, statusOf } from "../shell/Status";
 import { GridCard, Ico } from "./GridCard";
 
 // ─── ListRow ───────────────────────────────────────────────────────────────
@@ -19,7 +20,6 @@ export function ListRow({ agent, runtime, isSelected }: ListRowProps) {
   const { t } = useT();
   const { setSelected } = useAgents();
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
-  const pill = runtimePill(runtime?.state);
   const model =
     agent.model_id.length > 24 ? agent.model_id.slice(0, 24) + "…" : agent.model_id;
   return (
@@ -40,10 +40,7 @@ export function ListRow({ agent, runtime, isSelected }: ListRowProps) {
       <span className="list-model" title={agent.model_id}>
         {model}
       </span>
-      <span className={pill.cls}>
-        <span className="pill__dot" />
-        {t(pill.key)}
-      </span>
+      <StatusPill kind={statusOf(runtime?.state)} />
       <button
         className="list-row__settings"
         onClick={(e) => { e.stopPropagation(); setSelected(isSelected ? null : agent.name); }}

--- a/mur-hub-gui/ui/src/components/agents/AgentsPage.tsx
+++ b/mur-hub-gui/ui/src/components/agents/AgentsPage.tsx
@@ -203,7 +203,7 @@ export function AgentsPage({
               <Mascot floating size={96} mood="excited" bubble={t("mascot.bubble.excited")} />
               <h3>{t("dashboard.empty.title")}</h3>
               <p>{t("dashboard.empty.body")}</p>
-              <button className="btn btn--primary" onClick={onNewAgent}>
+              <button className="btn btn--accent" onClick={onNewAgent}>
                 {t("dashboard.empty.cta")}
               </button>
             </div>

--- a/mur-hub-gui/ui/src/components/agents/GridCard.tsx
+++ b/mur-hub-gui/ui/src/components/agents/GridCard.tsx
@@ -7,7 +7,8 @@ import type { AgentEntry, AgentRuntimeStatus } from "../../types";
 import { useUnreadCount } from "../CompanionInbox";
 import { PetFace } from "../PetFace";
 import { useT } from "../../i18n";
-import { CATEGORY_COLORS, avatarInitials, avatarPreset, familyOf, runtimePill } from "../../utils";
+import { CATEGORY_COLORS, avatarInitials, avatarPreset, familyOf } from "../../utils";
+import { StatusPill, statusOf } from "../shell/Status";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -53,7 +54,6 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
   const { setSelected } = useAgents();
   const unread = useUnreadCount(agent.name);
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
-  const pill = runtimePill(runtime?.state);
   const isRunning = runtime?.state.state === "running";
   const isBusy = runtime?.state.state === "restarting";
 
@@ -225,10 +225,7 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
 
         </div>
         <div className="grid-card__foot">
-          <span className={pill.cls}>
-            <span className="pill__dot" />
-            {t(pill.key)}
-          </span>
+          <StatusPill kind={statusOf(runtime?.state)} />
           <button
             className="grid-card__settings"
             onClick={(e) => { e.stopPropagation(); setSelected(agent.name); }}

--- a/mur-hub-gui/ui/src/components/fleet/FleetDetail.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetDetail.tsx
@@ -8,6 +8,7 @@ import type { TranslationKey } from "../../i18n/types";
 import type { AgentEntry } from "../../types";
 import { CATEGORY_COLORS, avatarPreset, familyOf } from "../../utils";
 import { PetFace } from "../PetFace";
+import { StatusPill, fleetStatusOf } from "../shell/Status";
 import type { FleetDetail as Detail, JobRow, LabelView } from "./types";
 import { DURATION_RE } from "./fleetCreateForm";
 import { labelIdFrom, makePrimary, toggleAssignment } from "./fleetLabels";
@@ -34,6 +35,8 @@ import {
 interface Props {
   detail: Detail;
   jobs: JobRow[];
+  /** Live `running` from the fleet summary — FleetDetail carries only `stopped`. */
+  running: boolean;
   agentMap: Map<string, AgentEntry>;
   /** The whole registry, in registry order — the chips offered here. */
   labels: LabelView[];
@@ -51,21 +54,11 @@ function showToast(msg: string, durationMs = 2500) {
   setTimeout(() => el.remove(), durationMs);
 }
 
-function statusPillClass(d: Detail): string {
-  if (d.stopped) return "fleet-detail__status-pill fleet-detail__status-pill--stopped";
-  return "fleet-detail__status-pill fleet-detail__status-pill--idle";
-}
-
-function statusLabel(d: Detail): string {
-  if (d.stopped) return "⏸ stopped";
-  return "● idle";
-}
-
 function jobStatusClass(status: JobRow["status"]): string {
   return `fleet-job__status fleet-job__status--${status}`;
 }
 
-export function FleetDetail({ detail, jobs, agentMap, labels, fleetLabels, onRefresh, onDelete }: Props) {
+export function FleetDetail({ detail, jobs, running, agentMap, labels, fleetLabels, onRefresh, onDelete }: Props) {
   const { t } = useT();
   const [busy, setBusy] = useState<string | null>(null);
   const [sendInput, setSendInput] = useState("");
@@ -369,7 +362,7 @@ export function FleetDetail({ detail, jobs, agentMap, labels, fleetLabels, onRef
       <div className="fleet-detail__header">
         <div className="fleet-detail__title-row">
           <h2 className="fleet-detail__title">{detail.display_name}</h2>
-          <span className={statusPillClass(detail)}>{statusLabel(detail)}</span>
+          <StatusPill kind={fleetStatusOf({ stopped: detail.stopped, running })} />
           {modeBadgeLabel(detail.parallel_summary, t) && (
             <span className="fleet-detail__mode-badge">{modeBadgeLabel(detail.parallel_summary, t)}</span>
           )}

--- a/mur-hub-gui/ui/src/components/fleet/FleetRail.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetRail.tsx
@@ -1,6 +1,7 @@
 import { useT } from "../../i18n";
 import type { FleetSummary, LabelView } from "./types";
 import { filterByLabels, groupFleets, UNGROUPED } from "./fleetLabels";
+import { StatusDot, fleetStatusOf } from "../shell/Status";
 
 interface Props {
   fleets: FleetSummary[];
@@ -11,12 +12,6 @@ interface Props {
   selectedName: string | null;
   onSelect: (name: string) => void;
   onNew: () => void;
-}
-
-function statusClass(f: FleetSummary): string {
-  if (f.stopped) return "fleet-rail__status--stopped";
-  if (f.running) return "fleet-rail__status--running";
-  return "fleet-rail__status--idle";
 }
 
 export function FleetRail({
@@ -83,7 +78,7 @@ export function FleetRail({
                     onClick={() => onSelect(f.name)}
                   >
                     <div className="fleet-rail__row">
-                      <span className={`fleet-rail__status ${statusClass(f)}`} />
+                      <StatusDot kind={fleetStatusOf(f)} />
                       <span className="fleet-rail__name">{f.display_name}</span>
                       {f.active_jobs > 0 && (
                         <span className="fleet-rail__jobs-badge">{f.active_jobs}</span>

--- a/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
@@ -177,6 +177,7 @@ export function FleetView({ query, onSelect }: { query?: string; onSelect?: (nam
             jobs={jobs}
             agentMap={agentMap}
             labels={labels}
+            running={fleets.find((f) => f.name === detail.name)?.running ?? false}
             fleetLabels={fleets.find((f) => f.name === detail.name)?.labels ?? []}
             onRefresh={handleRefresh}
             onDelete={handleDelete}

--- a/mur-hub-gui/ui/src/components/home/HomePage.tsx
+++ b/mur-hub-gui/ui/src/components/home/HomePage.tsx
@@ -62,7 +62,7 @@ export function HomePage({
           <p className="home-empty__sub">{t("home.empty.subtitle")}</p>
           <div className="home-empty__actions">
             <button
-              className="btn btn--primary"
+              className="btn btn--accent"
               onClick={() => onNavigate("chats")}
             >
               {t("home.quick.newChat")}

--- a/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
@@ -23,7 +23,8 @@ import { MobileTab } from "../MobileTab";
 import { MemoryTab } from "../MemoryTab";
 import { useT } from "../../i18n";
 import type { TranslationKey } from "../../i18n/types";
-import { CATEGORY_COLORS, TAB_ICONS, avatarInitials, avatarPreset, familyOf, runtimePill } from "../../utils";
+import { CATEGORY_COLORS, TAB_ICONS, avatarInitials, avatarPreset, familyOf } from "../../utils";
+import { StatusPill, statusOf } from "../shell/Status";
 import { PetFace } from "../PetFace";
 import { PersonaTab } from "./tabs/PersonaTab";
 import { StyleTab } from "./tabs/StyleTab";
@@ -143,7 +144,6 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
   // pill and the card never disagree.
   const rtState = runtime?.state.state;
   const isRunning = rtState === "running" || rtState === "restarting";
-  const statusPill = runtimePill(runtime?.state);
 
   function handleSaved(updated: AgentDetail) {
     setDetail(updated);
@@ -196,10 +196,7 @@ export function AgentInspector({ agentName, agents, runtime, onClose }: Props) {
           )}
           <div className="detail-panel__ident">
             <div className="detail-panel__name">{name}</div>
-            <span className={statusPill.cls}>
-              <span className="pill__dot" />
-              {t(statusPill.key)}
-            </span>
+            <StatusPill kind={statusOf(runtime?.state)} />
           </div>
           <button
             className="detail-panel__close"

--- a/mur-hub-gui/ui/src/components/shell/Status.test.tsx
+++ b/mur-hub-gui/ui/src/components/shell/Status.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NeedsYouBadge, StatusDot, fleetStatusOf, statusOf } from "./Status";
+
+describe("statusOf", () => {
+  it("maps every runtime state; stopped and unknown read as idle", () => {
+    expect(statusOf({ state: "running", pid: 1 })).toBe("running");
+    expect(statusOf({ state: "restarting", attempt: 1, backoff_secs: 2 })).toBe("restarting");
+    expect(statusOf({ state: "failed" })).toBe("failed");
+    expect(statusOf({ state: "stopped" })).toBe("idle");
+    expect(statusOf(undefined)).toBe("idle");
+  });
+});
+
+describe("fleetStatusOf", () => {
+  it("kill-switch wins over running", () => {
+    expect(fleetStatusOf({ stopped: true, running: true })).toBe("stopped");
+    expect(fleetStatusOf({ stopped: false, running: true })).toBe("running");
+    expect(fleetStatusOf({ stopped: false, running: false })).toBe("idle");
+  });
+});
+
+describe("markup", () => {
+  it("dot carries the kind as a modifier class", () => {
+    expect(renderToStaticMarkup(<StatusDot kind="failed" />)).toContain("status-dot--failed");
+  });
+  it("badge renders nothing at zero and caps at 99+", () => {
+    expect(renderToStaticMarkup(<NeedsYouBadge count={0} />)).toBe("");
+    expect(renderToStaticMarkup(<NeedsYouBadge count={120} />)).toContain("99+");
+    expect(renderToStaticMarkup(<NeedsYouBadge count={3} />)).toContain(">3<");
+  });
+});

--- a/mur-hub-gui/ui/src/components/shell/Status.tsx
+++ b/mur-hub-gui/ui/src/components/shell/Status.tsx
@@ -1,0 +1,68 @@
+import { useT } from "../../i18n";
+import type { TranslationKey } from "../../i18n/types";
+import type { RuntimeState } from "../../types";
+
+/** The only status vocabulary in the Hub (spec §4.5). Amber on a BADGE means
+ *  "needs you"; amber on a PILL means restarting. They never share a shape. */
+export type StatusKind = "running" | "idle" | "restarting" | "stopped" | "failed";
+
+/** Agent runtime → kind. A stopped agent is the ordinary not-running state and
+ *  reads as idle; the red `stopped` kind is reserved for a fleet kill-switch. */
+export function statusOf(rt: RuntimeState | undefined): StatusKind {
+  switch (rt?.state) {
+    case "running":
+      return "running";
+    case "restarting":
+      return "restarting";
+    case "failed":
+      return "failed";
+    default:
+      return "idle";
+  }
+}
+
+export function fleetStatusOf(f: { stopped: boolean; running: boolean }): StatusKind {
+  if (f.stopped) return "stopped";
+  return f.running ? "running" : "idle";
+}
+
+const LABEL_KEY: Record<StatusKind, TranslationKey> = {
+  running: "status.running",
+  idle: "status.idle",
+  restarting: "status.restarting",
+  stopped: "status.stopped",
+  failed: "status.failed",
+};
+
+export function StatusDot({ kind, title }: { kind: StatusKind; title?: string }) {
+  return (
+    <span
+      className={`status-dot status-dot--${kind}`}
+      title={title}
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+    />
+  );
+}
+
+export function StatusPill({ kind }: { kind: StatusKind }) {
+  const { t } = useT();
+  return (
+    <span className={`status-pill status-pill--${kind}`}>
+      <span className="status-pill__dot" aria-hidden="true" />
+      {t(LABEL_KEY[kind])}
+    </span>
+  );
+}
+
+const BADGE_CAP = 99;
+
+export function NeedsYouBadge({ count, title }: { count: number; title?: string }) {
+  if (count <= 0) return null;
+  return (
+    <span className="needs-you" title={title} aria-label={title}>
+      {count > BADGE_CAP ? `${BADGE_CAP}+` : count}
+    </span>
+  );
+}

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -52,6 +52,10 @@ export const en = {
   "status.running": "running",
   "status.idle": "idle",
   "status.error": "error",
+  "status.restarting": "restarting",
+  "status.stopped": "stopped",
+  "status.failed": "failed",
+  "status.needsYou": "{count} waiting for you",
   "settings.language": "Language",
   // ── Settings panel ──
   "settings.title": "Settings",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -54,6 +54,10 @@ export const zhTW: Table = {
   "status.running": "執行中",
   "status.idle": "閒置",
   "status.error": "錯誤",
+  "status.restarting": "重啟中",
+  "status.stopped": "已停止",
+  "status.failed": "失敗",
+  "status.needsYou": "{count} 件等你處理",
   "settings.language": "語言",
   // ── Settings panel ──
   "settings.title": "設定",

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -23,9 +23,7 @@
 }
 
 .dashboard {
-  background:
-    radial-gradient(900px 300px at 80% -120px, rgba(74,144,217,.12), transparent 70%),
-    var(--surface-bg);
+  background: var(--surface-window);
   min-height: 100vh;
 }
 
@@ -246,10 +244,10 @@
   gap: 18px;
   margin: 4px 24px 8px;
   padding: 18px 22px;
-  background: linear-gradient(120deg, var(--surface-card), var(--surface-secondary));
+  background: var(--surface-card);
   border: 1px solid var(--border-line);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-1);
+  border-radius: var(--radius-lg);
+  box-shadow: none;
 }
 .dashboard__hero h3 {
   margin: 0;
@@ -348,7 +346,7 @@
   position: relative;
   background: var(--surface-card);
   border: 1px solid var(--border-line);
-  border-radius: var(--radius-2xl);
+  border-radius: var(--radius-lg);
   padding: 16px;
   cursor: pointer;
   overflow: hidden;

--- a/mur-hub-gui/ui/src/styles/components/detail-panel.css
+++ b/mur-hub-gui/ui/src/styles/components/detail-panel.css
@@ -23,7 +23,7 @@
 .detail-panel__header {
   position: relative;
   padding: 20px 20px 16px;
-  background: linear-gradient(135deg, var(--color-brand-soft), var(--surface-card));
+  background: var(--surface-card);
   border-bottom: 1px solid var(--border-line);
 }
 .detail-panel__top {

--- a/mur-hub-gui/ui/src/styles/components/fleet.css
+++ b/mur-hub-gui/ui/src/styles/components/fleet.css
@@ -224,17 +224,7 @@
 
 /* ── Status dot ─────────────────────────────────────────────────────────── */
 
-.fleet-rail__status {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex: none;
-  margin-top: 1px;
-}
 
-.fleet-rail__status--idle    { background: var(--text-tertiary, #6b7280); }
-.fleet-rail__status--running { background: #22c55e; box-shadow: 0 0 4px #22c55e88; }
-.fleet-rail__status--stopped { background: var(--color-error, #ef4444); }
 
 /* ── Fleet detail panel ─────────────────────────────────────────────────── */
 
@@ -255,28 +245,7 @@
   color: var(--text-primary);
 }
 
-.fleet-detail__status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 11px;
-  font-weight: 600;
-}
 
-.fleet-detail__status-pill--idle {
-  background: rgba(107,114,128,0.15);
-  color: var(--text-secondary);
-}
-.fleet-detail__status-pill--running {
-  background: rgba(34,197,94,0.15);
-  color: #16a34a;
-}
-.fleet-detail__status-pill--stopped {
-  background: rgba(245,158,11,0.15);
-  color: #d97706;
-}
 
 .fleet-detail__goal {
   font-size: 12px;

--- a/mur-hub-gui/ui/src/styles/components/primitives.css
+++ b/mur-hub-gui/ui/src/styles/components/primitives.css
@@ -2,8 +2,11 @@
 .btn { font-size:var(--text-base); font-weight:var(--fw-bold); padding:9px 16px;
   border-radius:var(--radius-md); border:1px solid transparent; cursor:pointer;
   transition:transform var(--dur-fast) var(--ease-out), background var(--dur-fast), box-shadow var(--dur-fast); }
-.btn--primary { background:var(--color-accent); color:#fff; box-shadow:0 3px 10px rgba(251,107,83,.32); }
-.btn--primary:hover { background:var(--color-accent-strong); transform:translateY(-1px); }
+.btn--primary { background:var(--color-brand); color:var(--text-on-brand); }
+.btn--primary:hover { background:var(--color-brand-strong); }
+/* The coral CTA: used once per screen (spec §5.1). */
+.btn--accent { background:var(--color-accent); color:#fff; }
+.btn--accent:hover { background:var(--color-accent-strong); }
 .btn--blue { background:var(--color-brand); color:#fff; }
 .btn--blue:hover { background:var(--color-brand-strong); }
 .btn--secondary { background:var(--surface-card); color:var(--text-primary); border-color:var(--border-line); }

--- a/mur-hub-gui/ui/src/styles/components/primitives.css
+++ b/mur-hub-gui/ui/src/styles/components/primitives.css
@@ -20,14 +20,7 @@
 .badge { font-size:var(--text-xs); font-weight:var(--fw-semi); padding:3px 9px; border-radius:var(--radius-sm); }
 /* width:fit-content keeps the pill hugging its text even when it lands as a
    grid/flex item (list-row column, work pane) where the default is stretch. */
-.pill { display:inline-flex; width:fit-content; align-items:center; gap:6px; font-size:var(--text-xs);
-  font-weight:var(--fw-bold); padding:4px 9px; border-radius:var(--radius-full); }
-.pill__dot { width:6px; height:6px; border-radius:50%; background:currentColor; }
 /* Status-tinted translucent fills so the pill reads on both light and dark surfaces. */
-.pill--run { background:color-mix(in srgb, var(--status-running) 16%, transparent); color:var(--status-running); }
-.pill--run .pill__dot { animation:pulse-dot 2.4s ease-in-out infinite; }
-.pill--idle { background:color-mix(in srgb, var(--status-idle) 20%, transparent); color:var(--text-secondary); }
-.pill--fail { background:color-mix(in srgb, var(--status-failed) 16%, transparent); color:var(--status-failed); }
 
 /* Field */
 .field { display:flex; align-items:center; gap:8px; background:var(--surface-card);

--- a/mur-hub-gui/ui/src/styles/components/shell.css
+++ b/mur-hub-gui/ui/src/styles/components/shell.css
@@ -82,8 +82,8 @@
 }
 
 .shell-sidebar-item--active {
-  background: var(--color-brand);
-  color: var(--text-on-brand);
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
 }
 
 .shell-sidebar-item__icon {
@@ -103,12 +103,14 @@
 .shell-sidebar-item__badge {
   font-size: 11px;
   line-height: 1;
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--status-attention);
+  color: var(--text-on-attention);
   padding: 2px 6px;
   border-radius: 10px;
   flex: none;
 }
 
 .shell-sidebar-item--active .shell-sidebar-item__badge {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--status-attention);
+  color: var(--text-on-attention);
 }

--- a/mur-hub-gui/ui/src/styles/components/status.css
+++ b/mur-hub-gui/ui/src/styles/components/status.css
@@ -1,0 +1,24 @@
+/* One status vocabulary (spec §4.5). Colours come only from semantic tokens. */
+.status-dot {
+  display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  background: currentColor; flex: none;
+}
+.status-pill {
+  display: inline-flex; align-items: center; gap: 6px; height: 22px;
+  padding: 0 9px 0 8px; border-radius: var(--radius-full);
+  font-size: var(--text-xs); font-weight: var(--fw-semi); white-space: nowrap;
+  background: var(--surface-secondary); color: var(--text-secondary);
+}
+.status-pill__dot { width: 7px; height: 7px; border-radius: 50%; background: var(--dot, currentColor); }
+.status-dot--running, .status-pill--running { color: var(--status-running); }
+.status-dot--idle { color: var(--status-idle); }
+.status-pill--idle { --dot: var(--status-idle); }
+.status-dot--restarting, .status-pill--restarting { color: var(--status-restarting); }
+.status-dot--failed, .status-pill--failed { color: var(--status-failed); }
+.status-dot--stopped, .status-pill--stopped { color: var(--status-stopped); }
+.needs-you {
+  display: inline-grid; place-items: center; min-width: 18px; height: 18px; padding: 0 6px;
+  border-radius: var(--radius-full); font-size: var(--text-xs); font-weight: var(--fw-semi);
+  font-variant-numeric: tabular-nums; background: var(--status-attention); color: var(--text-on-attention);
+  flex: none;
+}

--- a/mur-hub-gui/ui/src/styles/index.css
+++ b/mur-hub-gui/ui/src/styles/index.css
@@ -3,6 +3,7 @@
 @import "./base.css";
 @import "./motion.css";
 @import "./components/primitives.css";
+@import "./components/status.css";
 @import "./components/dashboard.css";
 @import "./components/detail-panel.css";
 @import "./components/chat.css";

--- a/mur-hub-gui/ui/src/styles/tokens/primitives.css
+++ b/mur-hub-gui/ui/src/styles/tokens/primitives.css
@@ -1,30 +1,37 @@
 /* Raw scales. Never referenced directly by components — only by semantic.css. */
 :root {
   /* brand blue */
-  --blue-700:#2F6FB0; --blue-500:#4A90D9; --blue-300:#8FC1EC; --blue-soft:#EAF3FC; --blue-soft-dark:rgba(74,144,217,.22);
+  --blue-700:#2F6FB0; --blue-500:#4A90D9; --blue-400:#5B9CE0; --blue-300:#8FC1EC;
+  --blue-soft:rgba(74,144,217,.14); --blue-soft-dark:rgba(91,156,224,.18);
   /* accent coral */
   --coral-600:#F0563D; --coral-500:#FB6B53; --coral-300:#FFA290; --coral-soft:#FFF1EE; --coral-soft-dark:rgba(251,107,83,.20);
   /* category */
   --cat-research:#4A90D9; --cat-automation:#10B981; --cat-monitor:#F59E0B;
   --cat-notify:#EF4444; --cat-commerce:#8B5CF6; --cat-custom:#64748B;
   /* status */
-  --green-500:#22C55E; --green-600:#16A34A; --amber-500:#F59E0B;
-  --red-500:#EF4444; --red-600:#DC2626; --slate-400:#94A3B8;
-  /* neutral light */
-  --n-bg:#F6FAFE; --n-secondary:#EAF3FC; --n-card:#FFFFFF; --n-hover:#EAF1F9;
-  --n-line:#EAF0F7; --n-text:#16243B; --n-text2:#64758A; --n-text3:#9AA8B8;
+  --green-500:#22C55E; --green-600:#16A34A; --amber-500:#F59E0B; --amber-600:#D97706;
+  --red-500:#EF4444; --red-600:#DC2626; --slate-400:#94A3B8; --slate-500:#7C8798;
+  /* neutral light — cool-biased greys, no blue tint (spec §5.1) */
+  --n-bg:#F4F5F8; --n-sidebar:#EEF0F4; --n-list:#F9FAFC; --n-detail:#FFFFFF;
+  --n-secondary:#F4F5F8; --n-card:#FFFFFF; --n-hover:#ECEEF2;
+  --n-line:rgba(22,36,59,.10); --n-line-subtle:rgba(22,36,59,.06);
+  --n-text:#16243B; --n-text2:#5F6C80; --n-text3:#98A3B3;
   /* neutral dark */
-  --d-bg:#0F1117; --d-secondary:#161922; --d-card:#1A1E29; --d-hover:#232838;
-  --d-line:rgba(255,255,255,.08); --d-text:#F1F5F9; --d-text2:#94A3B8; --d-text3:#6B7688;
+  --d-bg:#0F1117; --d-sidebar:#0F1117; --d-list:#13161E; --d-detail:#161922;
+  --d-secondary:#20263A; --d-card:#1B2030; --d-hover:#232838;
+  --d-line:rgba(255,255,255,.08); --d-line-subtle:rgba(255,255,255,.05);
+  --d-text:#EEF2F7; --d-text2:#94A3B8; --d-text3:#6B7688;
   /* space (4px base) */
   --space-1:2px; --space-2:4px; --space-3:6px; --space-4:8px; --space-5:12px;
   --space-6:16px; --space-7:20px; --space-8:24px; --space-9:32px; --space-10:40px;
-  /* radius */
-  --radius-sm:6px; --radius-md:10px; --radius-lg:14px; --radius-xl:18px; --radius-2xl:20px; --radius-full:9999px;
+  /* radius — 6 controls, 8 rows, 12 cards/panes. lg/xl/2xl are aliases kept
+     until nothing references them (spec §5.2). */
+  --radius-sm:6px; --radius-md:8px; --radius-lg:12px; --radius-xl:12px; --radius-2xl:12px; --radius-full:9999px;
   /* type */
   --font-sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"PingFang TC","Microsoft JhengHei",sans-serif;
+  --font-mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
   --text-xs:11px; --text-sm:12.5px; --text-base:14px; --text-md:15px;
-  --text-lg:17px; --text-xl:19px; --text-2xl:22px;
+  --text-lg:17px; --text-xl:20px; --text-2xl:22px;
   --fw-regular:400; --fw-semi:600; --fw-bold:700; --fw-heavy:800;
   /* shadow */
   --shadow-sm:0 1px 2px rgba(16,40,80,.06);
@@ -35,11 +42,12 @@
   --dur-fast:130ms; --dur-base:180ms; --dur-slow:280ms;
   --ease-out:cubic-bezier(.2,.85,.25,1);
   --ease-spring:cubic-bezier(.34,1.56,.64,1);
-  /* shell layout (Phase 1 three-pane) */
-  --shell-sidebar-width:220px; --shell-inspector-width:320px;
-  --shell-blur:20px;
+  /* shell layout (spec §3.1) */
+  --shell-sidebar-width:220px; --shell-sidebar-collapsed-width:56px; --shell-inspector-width:320px;
+  --shell-list-width:300px; --shell-list-width-compact:280px; --shell-list-min:240px; --shell-list-max:400px;
+  --shell-titlebar-inset:28px; --shell-blur:20px;
   /* sidebar vibrancy: translucent bg over backdrop-filter blur, with a
      solid fallback if WKWebView renders artifacts (flip via --sidebar-bg). */
-  --n-sidebar-vibrancy:rgba(246,250,254,.72); --n-sidebar-solid:#F6FAFE;
+  --n-sidebar-vibrancy:rgba(238,240,244,.72); --n-sidebar-solid:#EEF0F4;
   --d-sidebar-vibrancy:rgba(15,17,23,.6); --d-sidebar-solid:#0F1117;
 }

--- a/mur-hub-gui/ui/src/styles/tokens/semantic.css
+++ b/mur-hub-gui/ui/src/styles/tokens/semantic.css
@@ -3,9 +3,11 @@
   --text-on-brand:#fff;
   --color-accent:var(--coral-500); --color-accent-strong:var(--coral-600);
   --color-accent-soft:var(--coral-soft); --color-brand-soft:var(--blue-soft);
-  --surface-bg:var(--n-bg); --surface-secondary:var(--n-secondary);
-  --surface-card:var(--n-card); --surface-hover:var(--n-hover);
-  --border-line:var(--n-line);
+  /* surfaces (spec §5.1): window < sidebar < list < detail = card */
+  --surface-bg:var(--n-bg); --surface-window:var(--n-bg); --surface-sidebar:var(--n-sidebar);
+  --surface-list:var(--n-list); --surface-detail:var(--n-detail);
+  --surface-secondary:var(--n-secondary); --surface-card:var(--n-card); --surface-hover:var(--n-hover);
+  --border-line:var(--n-line); --border-line-subtle:var(--n-line-subtle);
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);
   --status-running:var(--green-600); --status-idle:var(--slate-400);
   --status-restarting:var(--amber-500); --status-failed:var(--red-600);
@@ -16,38 +18,43 @@
   --sidebar-bg:var(--n-sidebar-vibrancy); --sidebar-bg-solid:var(--n-sidebar-solid);
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    /* Soft tints must darken too: the light pastels (#EAF3FC / #FFF1EE)
-       under light text made selected rows unreadable in dark mode. The
-       paired -strong text colors lighten so they stay readable on the
-       dark tints. */
+  :root:not([data-theme="light"]) {
+    --color-brand:var(--blue-400); --color-brand-strong:var(--blue-300);
     --color-brand-soft:var(--blue-soft-dark); --color-accent-soft:var(--coral-soft-dark);
-    --color-brand-strong:var(--blue-300); --color-accent-strong:var(--coral-300);
-    --surface-bg:var(--d-bg); --surface-secondary:var(--d-secondary);
-    --surface-card:var(--d-card); --surface-hover:var(--d-hover);
-    --border-line:var(--d-line);
-  --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
-    --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
+    --color-accent-strong:var(--coral-300);
+    --surface-bg:var(--d-bg); --surface-window:var(--d-bg); --surface-sidebar:var(--d-sidebar);
+    --surface-list:var(--d-list); --surface-detail:var(--d-detail);
+    --surface-secondary:var(--d-secondary); --surface-card:var(--d-card); --surface-hover:var(--d-hover);
+    --border-line:var(--d-line); --border-line-subtle:var(--d-line-subtle);
     --text-primary:var(--d-text); --text-secondary:var(--d-text2); --text-tertiary:var(--d-text3);
+    --status-running:var(--green-500); --status-idle:var(--slate-500); --status-failed:var(--red-500);
+    --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
     --sidebar-bg:var(--d-sidebar-vibrancy); --sidebar-bg-solid:var(--d-sidebar-solid);
   }
 }
 :root[data-theme="dark"] {
+  --color-brand:var(--blue-400); --color-brand-strong:var(--blue-300);
   --color-brand-soft:var(--blue-soft-dark); --color-accent-soft:var(--coral-soft-dark);
-  --color-brand-strong:var(--blue-300); --color-accent-strong:var(--coral-300);
-  --surface-bg:var(--d-bg); --surface-secondary:var(--d-secondary);
-  --surface-card:var(--d-card); --surface-hover:var(--d-hover);
-  --border-line:var(--d-line);
+  --color-accent-strong:var(--coral-300);
+  --surface-bg:var(--d-bg); --surface-window:var(--d-bg); --surface-sidebar:var(--d-sidebar);
+  --surface-list:var(--d-list); --surface-detail:var(--d-detail);
+  --surface-secondary:var(--d-secondary); --surface-card:var(--d-card); --surface-hover:var(--d-hover);
+  --border-line:var(--d-line); --border-line-subtle:var(--d-line-subtle);
   --text-primary:var(--d-text); --text-secondary:var(--d-text2); --text-tertiary:var(--d-text3);
+  --status-running:var(--green-500); --status-idle:var(--slate-500); --status-failed:var(--red-500);
+  --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
   --sidebar-bg:var(--d-sidebar-vibrancy); --sidebar-bg-solid:var(--d-sidebar-solid);
 }
 :root[data-theme="light"] {
+  --color-brand:var(--blue-500); --color-brand-strong:var(--blue-700);
   --color-brand-soft:var(--blue-soft); --color-accent-soft:var(--coral-soft);
-  --color-brand-strong:var(--blue-700); --color-accent-strong:var(--coral-600);
-  --surface-bg:var(--n-bg); --surface-secondary:var(--n-secondary);
-  --surface-card:var(--n-card); --surface-hover:var(--n-hover);
-  --border-line:var(--n-line);
-  --status-stopped:var(--red-600); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
+  --color-accent-strong:var(--coral-600);
+  --surface-bg:var(--n-bg); --surface-window:var(--n-bg); --surface-sidebar:var(--n-sidebar);
+  --surface-list:var(--n-list); --surface-detail:var(--n-detail);
+  --surface-secondary:var(--n-secondary); --surface-card:var(--n-card); --surface-hover:var(--n-hover);
+  --border-line:var(--n-line); --border-line-subtle:var(--n-line-subtle);
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);
+  --status-running:var(--green-600); --status-idle:var(--slate-400); --status-failed:var(--red-600);
+  --status-stopped:var(--red-600); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
   --sidebar-bg:var(--n-sidebar-vibrancy); --sidebar-bg-solid:var(--n-sidebar-solid);
 }

--- a/mur-hub-gui/ui/src/styles/tokens/semantic.css
+++ b/mur-hub-gui/ui/src/styles/tokens/semantic.css
@@ -9,6 +9,7 @@
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);
   --status-running:var(--green-600); --status-idle:var(--slate-400);
   --status-restarting:var(--amber-500); --status-failed:var(--red-600);
+  --status-stopped:var(--red-600); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
   --shadow-1:var(--shadow-card); --shadow-pop:var(--shadow-pop); --shadow-focus:var(--shadow-focus);
   /* Sidebar vibrancy: set --sidebar-bg to a `-solid` variant (below) to
      disable backdrop-filter blur if WKWebView renders artifacts. */
@@ -25,6 +26,8 @@
     --surface-bg:var(--d-bg); --surface-secondary:var(--d-secondary);
     --surface-card:var(--d-card); --surface-hover:var(--d-hover);
     --border-line:var(--d-line);
+  --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
+    --status-stopped:var(--red-500); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
     --text-primary:var(--d-text); --text-secondary:var(--d-text2); --text-tertiary:var(--d-text3);
     --sidebar-bg:var(--d-sidebar-vibrancy); --sidebar-bg-solid:var(--d-sidebar-solid);
   }
@@ -44,6 +47,7 @@
   --surface-bg:var(--n-bg); --surface-secondary:var(--n-secondary);
   --surface-card:var(--n-card); --surface-hover:var(--n-hover);
   --border-line:var(--n-line);
+  --status-stopped:var(--red-600); --status-attention:var(--amber-500); --text-on-attention:#1A1200;
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);
   --sidebar-bg:var(--n-sidebar-vibrancy); --sidebar-bg-solid:var(--n-sidebar-solid);
 }

--- a/mur-hub-gui/ui/src/utils.ts
+++ b/mur-hub-gui/ui/src/utils.ts
@@ -28,7 +28,7 @@ export const TAB_ICONS: Record<string, string> = {
   plugins: "🧩",
 };
 
-import { BUILTIN_PRESETS, type AgentEntry, type RuntimeState } from "./types";
+import { BUILTIN_PRESETS, type AgentEntry } from "./types";
 
 // preset id → family, for theming the vector mascot avatar (cards + detail).
 const PRESET_FAMILY: Record<string, string> = Object.fromEntries(
@@ -57,21 +57,6 @@ export function avatarPreset(agent: AgentEntry): string {
  * list/cards AND the detail panel so they never disagree (was a bug: the
  * detail panel derived status from the lock-based AgentEntry.status instead).
  */
-export function runtimePill(rt: RuntimeState | undefined): {
-  cls: string;
-  key: "status.running" | "status.idle" | "status.error";
-} {
-  switch (rt?.state) {
-    case "running":
-    case "restarting":
-      return { cls: "pill pill--run", key: "status.running" };
-    case "failed":
-      return { cls: "pill pill--fail", key: "status.error" };
-    default:
-      return { cls: "pill pill--idle", key: "status.idle" };
-  }
-}
-
 export function avatarInitials(displayName: string): string {
   return displayName
     .split(" ")


### PR DESCRIPTION
First of the five PRs in `docs/superpowers/plans/2026-09-06-mur-hub-master-detail-shell.md` (spec + plan on #1164). Recolor only — no layout changes.

- `StatusDot` / `StatusPill` / `NeedsYouBadge` in `components/shell/Status.tsx` are now the only status rendering in the Hub; `runtimePill`, the `.pill*` rules and the fleet rail/detail status classes are deleted. A stopped agent reads as grey idle; red "stopped" is reserved for a fleet kill-switch.
- Tokens: neutral cool-grey light surfaces (no light-blue tint), radius 6/8/12 (lg/xl/2xl kept as 12px aliases), `--font-mono`, shell size primitives for PR 2, `--status-attention` for the amber "needs you" badge. Every new token is defined for light, both dark blocks, and the explicit light block.
- Sidebar selection is a translucent brand tint; primary buttons are brand blue; the coral `.btn--accent` is used once per screen (the two empty-state CTAs).

Verified: `npm test` 26 files / 229 tests, `npm run build`, `npm run lint` (0 errors; the 6 warnings are pre-existing `exhaustive-deps` in untouched files). Light and dark checked in a browser with a Tauri stub: agents grid + list, fleet rail dots, fleet detail header (running / idle / failed / stopped).

Side effect stated in the spec (§5.4): every page recolors now; layouts change in PR 4/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)