### PR TITLE
feat(hub): PR 2 of Hub 2.0 — shell breakpoints, overlay title bar, list divider

### DIFF
--- a/mur-hub-gui/src-tauri/capabilities/default.json
+++ b/mur-hub-gui/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:default",
     "core:window:allow-set-size",
     "core:window:allow-set-min-size",
+    "core:window:allow-start-dragging",
     "shell:allow-open",
     "dialog:allow-confirm",
     "dialog:allow-open",

--- a/mur-hub-gui/src-tauri/tauri.conf.json
+++ b/mur-hub-gui/src-tauri/tauri.conf.json
@@ -14,13 +14,15 @@
         "label": "dashboard",
         "title": "MUR Hub",
         "url": "index.html",
-        "width": 960,
-        "height": 620,
-        "minWidth": 720,
-        "minHeight": 480,
+        "width": 1200,
+        "height": 760,
+        "minWidth": 900,
+        "minHeight": 560,
         "resizable": true,
         "fullscreen": false,
-        "visible": false
+        "visible": false,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       },
       {
         "label": "popover",

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { currentMonitor, getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAgents } from "../context/AgentContext";
 import type { AgentEntry, AgentRuntimeStatus, NudgeStatus } from "../types";
 import { WizardModal } from "./wizard/WizardModal";
@@ -235,37 +235,6 @@ export function DashboardApp() {
     const unlisten = listen("need-model", () => setModelPickerOpen(true));
     return () => { unlisten.then((fn) => fn()); };
   }, []);
-
-  // Auto-resize the window when the contextual inspector opens/closes, so the
-  // main pane keeps a usable width instead of being squeezed by the 320px
-  // inspector column. Keys on ANY inspector selection (agent/chat/fleet/
-  // library), matching the shell's --shell-inspector-width. Clamped to the
-  // monitor so the window never grows past the visible screen.
-  const inspectorOpen = hasInspector(page, {
-    agent: selectedAgent,
-    chatAgent: chatAgent?.name ?? null,
-    chatDisplayName: chatAgent?.displayName,
-    fleet: fleetName,
-    library: libItem,
-  });
-  useEffect(() => {
-    (async () => {
-      const win = getCurrentWindow();
-      const monitor = await currentMonitor().catch(() => null);
-      const scale = monitor?.scaleFactor ?? 1;
-      const availW = monitor ? monitor.size.width / scale - 16 : 1440;
-      const availH = monitor ? monitor.size.height / scale - 60 : 800;
-      const desiredW = 960 + (inspectorOpen ? 320 : 0);
-      const desiredH = inspectorOpen ? 720 : 620;
-      const width = Math.min(desiredW, availW);
-      const height = Math.min(desiredH, availH);
-      win.setSize(new LogicalSize(width, height)).catch(console.error);
-      const minW = Math.min(720 + (inspectorOpen ? 320 : 0), availW);
-      win
-        .setMinSize(new LogicalSize(minW, Math.min(480, availH)))
-        .catch(console.error);
-    })().catch(console.error);
-  }, [inspectorOpen]);
 
   // First-launch check: show banner if not running from /Applications
   useEffect(() => {

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -517,6 +517,7 @@ export function DashboardApp() {
           onNavigate={(id) => setPage(id)}
           badge={badgeCount}
           inspector={inspectorNode}
+          onSettings={() => setSettingsOpen(true)}
         >
           {page === "home" ? (
             <HomePage

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -325,103 +325,109 @@ export function DashboardApp() {
     />
   ) : undefined;
 
+  // Banners render inside the content column (Shell `banners` slot), so
+  // they never push the sidebar down (spec §3.3).
+  const banners = (
+    <>
+    {showAppsBanner && (
+      <div className="onboarding-banner">
+        <span>
+          {t("dashboard.moveToAppsBody", {
+            folder: t("dashboard.applicationsFolder"),
+          })
+            .split(t("dashboard.applicationsFolder"))
+            .flatMap((part, i) =>
+              i === 0
+                ? [part]
+                : [
+                    <strong key={i}>{t("dashboard.applicationsFolder")}</strong>,
+                    part,
+                  ],
+            )}
+        </span>
+        <button
+          className="toolbar-btn"
+          onClick={() => setShowAppsBanner(false)}
+          title={t("dashboard.dismiss")}
+        >
+          ✕
+        </button>
+      </div>
+    )}
+    {showUpgradeNudge && !nudgeDismissed && (
+      <div className="upgrade-nudge-banner">
+        <span>{t("dashboard.nudgePrompt")}</span>
+        <div className="upgrade-nudge-actions">
+          <button
+            className="toolbar-btn"
+            onClick={() => {
+              invoke("nudge_dismiss").catch(() => {});
+              setNudgeDismissed(true);
+            }}
+          >
+            {t("dashboard.nudgeDecline")}
+          </button>
+          <button
+            className="toolbar-btn toolbar-btn--primary"
+            onClick={() => {
+              setShowUpgradeNudge(false);
+              setModelPickerOpen(true);
+            }}
+          >
+            {t("dashboard.nudgeAccept")}
+          </button>
+        </div>
+      </div>
+    )}
+    {appUpdate && (
+      <div className="upgrade-nudge-banner">
+        <span>
+          {updateError
+            ? t("dashboard.updateError", { error: updateError })
+            : updateProgress !== null
+              ? t("dashboard.updateDownloading", {
+                  version: appUpdate.version,
+                  pct: updateProgress,
+                })
+              : t("dashboard.updateAvailable", { version: appUpdate.version })}
+        </span>
+        {updateProgress === null && (
+          <div className="upgrade-nudge-actions">
+            <button className="toolbar-btn" onClick={() => setAppUpdate(null)}>
+              {t("dashboard.updateLater")}
+            </button>
+            <button
+              className="toolbar-btn toolbar-btn--primary"
+              onClick={installUpdate}
+            >
+              {updateError
+                ? t("dashboard.updateRetry")
+                : t("dashboard.updateInstall")}
+            </button>
+          </div>
+        )}
+      </div>
+    )}
+    {cliSkew && (
+      <div className="upgrade-nudge-banner">
+        <span>
+          {t("dashboard.cliSkew", { cli: cliSkew.cli, hub: cliSkew.hub, hint: cliSkew.upgrade_hint })}
+        </span>
+        <button
+          className="toolbar-btn"
+          onClick={() => setCliSkew(null)}
+          title={t("dashboard.dismiss")}
+        >
+          ✕
+        </button>
+      </div>
+    )}
+    </>
+  );
+
   return (
     <div className="dashboard-root">
       <div className="dashboard-main dashboard">
-        {showAppsBanner && (
-          <div className="onboarding-banner">
-            <span>
-              {t("dashboard.moveToAppsBody", {
-                folder: t("dashboard.applicationsFolder"),
-              })
-                .split(t("dashboard.applicationsFolder"))
-                .flatMap((part, i) =>
-                  i === 0
-                    ? [part]
-                    : [
-                        <strong key={i}>{t("dashboard.applicationsFolder")}</strong>,
-                        part,
-                      ],
-                )}
-            </span>
-            <button
-              className="toolbar-btn"
-              onClick={() => setShowAppsBanner(false)}
-              title={t("dashboard.dismiss")}
-            >
-              ✕
-            </button>
-          </div>
-        )}
-        {showUpgradeNudge && !nudgeDismissed && (
-          <div className="upgrade-nudge-banner">
-            <span>{t("dashboard.nudgePrompt")}</span>
-            <div className="upgrade-nudge-actions">
-              <button
-                className="toolbar-btn"
-                onClick={() => {
-                  invoke("nudge_dismiss").catch(() => {});
-                  setNudgeDismissed(true);
-                }}
-              >
-                {t("dashboard.nudgeDecline")}
-              </button>
-              <button
-                className="toolbar-btn toolbar-btn--primary"
-                onClick={() => {
-                  setShowUpgradeNudge(false);
-                  setModelPickerOpen(true);
-                }}
-              >
-                {t("dashboard.nudgeAccept")}
-              </button>
-            </div>
-          </div>
-        )}
-        {appUpdate && (
-          <div className="upgrade-nudge-banner">
-            <span>
-              {updateError
-                ? t("dashboard.updateError", { error: updateError })
-                : updateProgress !== null
-                  ? t("dashboard.updateDownloading", {
-                      version: appUpdate.version,
-                      pct: updateProgress,
-                    })
-                  : t("dashboard.updateAvailable", { version: appUpdate.version })}
-            </span>
-            {updateProgress === null && (
-              <div className="upgrade-nudge-actions">
-                <button className="toolbar-btn" onClick={() => setAppUpdate(null)}>
-                  {t("dashboard.updateLater")}
-                </button>
-                <button
-                  className="toolbar-btn toolbar-btn--primary"
-                  onClick={installUpdate}
-                >
-                  {updateError
-                    ? t("dashboard.updateRetry")
-                    : t("dashboard.updateInstall")}
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-        {cliSkew && (
-          <div className="upgrade-nudge-banner">
-            <span>
-              {t("dashboard.cliSkew", { cli: cliSkew.cli, hub: cliSkew.hub, hint: cliSkew.upgrade_hint })}
-            </span>
-            <button
-              className="toolbar-btn"
-              onClick={() => setCliSkew(null)}
-              title={t("dashboard.dismiss")}
-            >
-              ✕
-            </button>
-          </div>
-        )}
-
         <div className="dashboard__bar">
           <span className="dashboard__brand">MUR</span>
           <label className="field dashboard__bar-search">
@@ -486,6 +492,7 @@ export function DashboardApp() {
           onNavigate={(id) => setPage(id)}
           badge={badgeCount}
           inspector={inspectorNode}
+          banners={banners}
           onSettings={() => setSettingsOpen(true)}
         >
           {page === "home" ? (

--- a/mur-hub-gui/ui/src/components/shell/ListDivider.tsx
+++ b/mur-hub-gui/ui/src/components/shell/ListDivider.tsx
@@ -1,0 +1,15 @@
+import type { ResizableColumn } from "./useResizableColumn";
+
+export function ListDivider({ column, label }: { column: ResizableColumn; label: string }) {
+  return (
+    <div
+      className="list-divider"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={label}
+      title={label}
+      onPointerDown={column.onPointerDown}
+      onDoubleClick={column.reset}
+    />
+  );
+}

--- a/mur-hub-gui/ui/src/components/shell/Shell.tsx
+++ b/mur-hub-gui/ui/src/components/shell/Shell.tsx
@@ -1,17 +1,25 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { Sidebar } from "./Sidebar";
 import type { PageId } from "./nav";
+import {
+  readSidebarPref, sidebarModeFor, togglePref, writeSidebarPref, type SidebarPref,
+} from "./breakpoints";
+import { useWindowWidth } from "./useWindowWidth";
+import { isMac } from "./platform";
 
 // ⌘⌥I toggles the inspector column, independent of whether the caller
 // currently provides an `inspector` node. No other modifiers may be held.
 export function isInspectorToggle(e: KeyboardEvent): boolean {
-  return (
-    e.metaKey &&
-    e.altKey &&
-    !e.ctrlKey &&
-    !e.shiftKey &&
-    e.key.toLowerCase() === "i"
-  );
+  return e.metaKey && e.altKey && !e.ctrlKey && !e.shiftKey && e.key.toLowerCase() === "i";
+}
+
+/** ⌘\ toggles the sidebar between labels and the icon rail (spec §3.1). */
+export function isSidebarToggle(e: KeyboardEvent): boolean {
+  return e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey && e.key === "\\";
+}
+
+function initialPref(): SidebarPref {
+  return typeof localStorage === "undefined" ? "auto" : readSidebarPref(localStorage);
 }
 
 export interface ShellProps {
@@ -19,17 +27,32 @@ export interface ShellProps {
   onNavigate: (id: PageId) => void;
   badge: number;
   inspector?: ReactNode;
+  /** Banners render at the top of the content column, never above the sidebar. */
+  banners?: ReactNode;
+  onSettings: () => void;
   children: ReactNode;
 }
 
-export function Shell({ page, onNavigate, badge, inspector, children }: ShellProps) {
+export function Shell({ page, onNavigate, badge, inspector, banners, onSettings, children }: ShellProps) {
   const [inspectorVisible, setInspectorVisible] = useState(true);
+  const [pref, setPref] = useState<SidebarPref>(initialPref);
+  const width = useWindowWidth();
+  const sidebarMode = sidebarModeFor(width, pref);
 
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (isInspectorToggle(e)) {
         e.preventDefault();
         setInspectorVisible((v) => !v);
+        return;
+      }
+      if (isSidebarToggle(e)) {
+        e.preventDefault();
+        setPref((p) => {
+          const next = togglePref(p, window.innerWidth);
+          writeSidebarPref(localStorage, next);
+          return next;
+        });
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -37,13 +60,28 @@ export function Shell({ page, onNavigate, badge, inspector, children }: ShellPro
   }, []);
 
   const showInspector = inspector !== undefined && inspectorVisible;
+  const cls = [
+    "shell",
+    showInspector ? "shell--with-inspector" : "",
+    sidebarMode === "collapsed" ? "shell--sidebar-collapsed" : "",
+    isMac() ? "shell--titlebar-inset" : "",
+  ].filter(Boolean).join(" ");
 
   return (
-    <div className={`shell${showInspector ? " shell--with-inspector" : ""}`}>
-      <div className="shell__sidebar">
-        <Sidebar active={page} badge={badge} onSelect={onNavigate} />
+    <div className={cls}>
+      <div className="shell__sidebar" data-tauri-drag-region>
+        <Sidebar
+          active={page}
+          badge={badge}
+          onSelect={onNavigate}
+          collapsed={sidebarMode === "collapsed"}
+          onSettings={onSettings}
+        />
       </div>
-      <div className="shell__content">{children}</div>
+      <div className="shell__content">
+        {banners}
+        <div className="shell__page">{children}</div>
+      </div>
       {showInspector && <div className="shell__inspector">{inspector}</div>}
     </div>
   );

--- a/mur-hub-gui/ui/src/components/shell/Sidebar.tsx
+++ b/mur-hub-gui/ui/src/components/shell/Sidebar.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { useT } from "../../i18n";
 import type { TranslationKey } from "../../i18n/types";
 import { NAV_ITEMS, type PageId } from "./nav";
@@ -63,14 +64,29 @@ const GLYPHS: Record<PageId, ReactNode> = {
   ),
 };
 
+const GEAR = (
+  <>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9l2.1 2.1M17 17l2.1 2.1M19.1 4.9L17 7M7 17l-2.1 2.1" />
+  </>
+);
+
 export interface SidebarProps {
   active: PageId;
   badge: number;
   onSelect: (id: PageId) => void;
+  /** Icon rail (56 px): labels and group headers hide, items keep a title. */
+  collapsed: boolean;
+  onSettings: () => void;
 }
 
-export function Sidebar({ active, badge, onSelect }: SidebarProps) {
+export function Sidebar({ active, badge, onSelect, collapsed, onSettings }: SidebarProps) {
   const { t } = useT();
+  // Same read as AboutSettings: the bundle version, shown under Settings.
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    getVersion().then(setVersion).catch(() => {});
+  }, []);
   const workspace = NAV_ITEMS.filter((i) => i.group === "workspace");
   const library = NAV_ITEMS.filter((i) => i.group === "library");
 
@@ -81,6 +97,7 @@ export function Sidebar({ active, badge, onSelect }: SidebarProps) {
       className={`shell-sidebar-item${active === id ? " shell-sidebar-item--active" : ""}`}
       onClick={() => onSelect(id)}
       aria-current={active === id ? "page" : undefined}
+      title={t(labelKey)}
     >
       <span className="shell-sidebar-item__icon">
         <Ico>{GLYPHS[id]}</Ico>
@@ -93,14 +110,21 @@ export function Sidebar({ active, badge, onSelect }: SidebarProps) {
   );
 
   return (
-    <nav className="shell-sidebar" aria-label="Primary">
+    <nav className={`shell-sidebar${collapsed ? " shell-sidebar--collapsed" : ""}`} aria-label="Primary">
       <div className="shell-sidebar__group">
-        <div className="shell-sidebar__group-label">{t("nav.groupWorkspace" as TranslationKey)}</div>
+        <div className="shell-sidebar__group-label">{t("nav.groupWorkspace")}</div>
         {workspace.map((i) => renderItem(i.id, i.labelKey))}
       </div>
       <div className="shell-sidebar__group">
-        <div className="shell-sidebar__group-label">{t("nav.groupLibrary" as TranslationKey)}</div>
+        <div className="shell-sidebar__group-label">{t("nav.groupLibrary")}</div>
         {library.map((i) => renderItem(i.id, i.labelKey))}
+      </div>
+      <div className="shell-sidebar__footer">
+        <button type="button" className="shell-sidebar-item" onClick={onSettings} title={t("app.settings")}>
+          <span className="shell-sidebar-item__icon"><Ico>{GEAR}</Ico></span>
+          <span className="shell-sidebar-item__label">{t("app.settings")}</span>
+        </button>
+        {version && <div className="shell-sidebar__version">{t("shell.version", { version })}</div>}
       </div>
     </nav>
   );

--- a/mur-hub-gui/ui/src/components/shell/breakpoints.test.ts
+++ b/mur-hub-gui/ui/src/components/shell/breakpoints.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  BP_COMPACT, BP_WIDE, SIDEBAR_PREF_KEY, listModeFor, readSidebarPref,
+  sidebarModeFor, togglePref, writeSidebarPref,
+} from "./breakpoints";
+
+function mem(): Pick<Storage, "getItem" | "setItem"> & { data: Record<string, string> } {
+  const data: Record<string, string> = {};
+  return { data, getItem: (k) => data[k] ?? null, setItem: (k, v) => { data[k] = v; } };
+}
+
+describe("sidebarModeFor", () => {
+  it("auto follows the width", () => {
+    expect(sidebarModeFor(BP_WIDE, "auto")).toBe("expanded");
+    expect(sidebarModeFor(BP_WIDE - 1, "auto")).toBe("collapsed");
+    expect(sidebarModeFor(BP_COMPACT - 1, "auto")).toBe("collapsed");
+  });
+  it("a pin wins over the width", () => {
+    expect(sidebarModeFor(800, "expanded")).toBe("expanded");
+    expect(sidebarModeFor(2000, "collapsed")).toBe("collapsed");
+  });
+});
+
+describe("listModeFor", () => {
+  it("three bands", () => {
+    expect(listModeFor(BP_WIDE)).toBe("wide");
+    expect(listModeFor(BP_COMPACT)).toBe("compact");
+    expect(listModeFor(BP_COMPACT - 1)).toBe("overlay");
+  });
+});
+
+describe("togglePref", () => {
+  it("toggles relative to what is shown, and returns to auto when the pin matches auto", () => {
+    expect(togglePref("auto", 1400)).toBe("collapsed");
+    expect(togglePref("collapsed", 1400)).toBe("auto");
+    expect(togglePref("auto", 1000)).toBe("expanded");
+    expect(togglePref("expanded", 1000)).toBe("auto");
+  });
+});
+
+describe("pref persistence", () => {
+  it("round-trips and defaults to auto on junk", () => {
+    const s = mem();
+    expect(readSidebarPref(s)).toBe("auto");
+    writeSidebarPref(s, "collapsed");
+    expect(s.data[SIDEBAR_PREF_KEY]).toBe("collapsed");
+    expect(readSidebarPref(s)).toBe("collapsed");
+    s.data[SIDEBAR_PREF_KEY] = "sideways";
+    expect(readSidebarPref(s)).toBe("auto");
+  });
+});

--- a/mur-hub-gui/ui/src/components/shell/breakpoints.ts
+++ b/mur-hub-gui/ui/src/components/shell/breakpoints.ts
@@ -1,0 +1,45 @@
+// Shell breakpoints (spec §3.1). These are the ONLY numbers that decide the
+// layout; the CSS custom properties carry the matching widths.
+export const BP_WIDE = 1200;
+export const BP_COMPACT = 960;
+export const SIDEBAR_PREF_KEY = "mur.shell.sidebar";
+
+export type SidebarPref = "auto" | "expanded" | "collapsed";
+export type SidebarMode = "expanded" | "collapsed";
+export type ListMode = "wide" | "compact" | "overlay";
+
+export function sidebarModeFor(width: number, pref: SidebarPref): SidebarMode {
+  if (pref !== "auto") return pref;
+  return width >= BP_WIDE ? "expanded" : "collapsed";
+}
+
+export function listModeFor(width: number): ListMode {
+  if (width >= BP_WIDE) return "wide";
+  if (width >= BP_COMPACT) return "compact";
+  return "overlay";
+}
+
+/** ⌘\ toggles what is currently shown; a pin equal to the auto result
+ *  collapses back to `auto` so a window resize takes over again. */
+export function togglePref(current: SidebarPref, width: number): SidebarPref {
+  const shown = sidebarModeFor(width, current);
+  const next: SidebarMode = shown === "expanded" ? "collapsed" : "expanded";
+  return next === sidebarModeFor(width, "auto") ? "auto" : next;
+}
+
+export function readSidebarPref(storage: Pick<Storage, "getItem">): SidebarPref {
+  try {
+    const v = storage.getItem(SIDEBAR_PREF_KEY);
+    return v === "expanded" || v === "collapsed" ? v : "auto";
+  } catch {
+    return "auto";
+  }
+}
+
+export function writeSidebarPref(storage: Pick<Storage, "setItem">, pref: SidebarPref): void {
+  try {
+    storage.setItem(SIDEBAR_PREF_KEY, pref);
+  } catch {
+    /* private mode / quota */
+  }
+}

--- a/mur-hub-gui/ui/src/components/shell/persist.ts
+++ b/mur-hub-gui/ui/src/components/shell/persist.ts
@@ -1,0 +1,18 @@
+/** localStorage wrappers that never throw (private mode, quota, no window). */
+export function readKey(key: string): string | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeKey(key: string, value: string | null): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    /* private mode / quota — the value simply does not persist this session */
+  }
+}

--- a/mur-hub-gui/ui/src/components/shell/platform.ts
+++ b/mur-hub-gui/ui/src/components/shell/platform.ts
@@ -1,0 +1,5 @@
+/** macOS gets the overlay title bar (traffic lights inside the sidebar);
+ *  other platforms keep native decorations, so their inset is 0. */
+export function isMac(): boolean {
+  return typeof navigator !== "undefined" && /Mac/.test(navigator.platform);
+}

--- a/mur-hub-gui/ui/src/components/shell/shell.test.ts
+++ b/mur-hub-gui/ui/src/components/shell/shell.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isInspectorToggle } from "./Shell";
+import { isInspectorToggle, isSidebarToggle } from "./Shell";
 
 function key(overrides: Partial<KeyboardEvent>): KeyboardEvent {
   return {
@@ -39,5 +39,16 @@ describe("isInspectorToggle", () => {
 
   it("rejects a different key", () => {
     expect(isInspectorToggle(key({ key: "j" }))).toBe(false);
+  });
+});
+
+describe("isSidebarToggle", () => {
+  const base = { key: "\\", metaKey: true, altKey: false, ctrlKey: false, shiftKey: false };
+  it("matches meta+backslash", () => {
+    expect(isSidebarToggle(base as KeyboardEvent)).toBe(true);
+  });
+  it("rejects extra modifiers and other keys", () => {
+    expect(isSidebarToggle({ ...base, altKey: true } as KeyboardEvent)).toBe(false);
+    expect(isSidebarToggle({ ...base, key: "/" } as KeyboardEvent)).toBe(false);
   });
 });

--- a/mur-hub-gui/ui/src/components/shell/useResizableColumn.test.ts
+++ b/mur-hub-gui/ui/src/components/shell/useResizableColumn.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { clampWidth, parseStoredWidth } from "./useResizableColumn";
+
+describe("clampWidth", () => {
+  it("rounds and clamps", () => {
+    expect(clampWidth(239.6, 240, 400)).toBe(240);
+    expect(clampWidth(1000, 240, 400)).toBe(400);
+    expect(clampWidth(300.4, 240, 400)).toBe(300);
+  });
+});
+
+describe("parseStoredWidth", () => {
+  it("falls back on junk and clamps stored values", () => {
+    expect(parseStoredWidth(null, 300, 240, 400)).toBe(300);
+    expect(parseStoredWidth("abc", 300, 240, 400)).toBe(300);
+    expect(parseStoredWidth("9999", 300, 240, 400)).toBe(400);
+    expect(parseStoredWidth("260", 300, 240, 400)).toBe(260);
+  });
+});

--- a/mur-hub-gui/ui/src/components/shell/useResizableColumn.ts
+++ b/mur-hub-gui/ui/src/components/shell/useResizableColumn.ts
@@ -1,0 +1,58 @@
+import { useCallback, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { readKey, writeKey } from "./persist";
+
+export function clampWidth(w: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(w)));
+}
+
+export function parseStoredWidth(raw: string | null, fallback: number, min: number, max: number): number {
+  const n = raw === null ? Number.NaN : Number(raw);
+  return Number.isFinite(n) ? clampWidth(n, min, max) : fallback;
+}
+
+export interface ResizableColumn {
+  width: number;
+  onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+  /** Double-click on the divider: back to the default width. */
+  reset: () => void;
+}
+
+/** A pointer-dragged column width, clamped to [min, max] and persisted under
+ *  `storageKey` on release (spec §3.1). */
+export function useResizableColumn(storageKey: string, fallback: number, min: number, max: number): ResizableColumn {
+  const [width, setWidth] = useState(() => parseStoredWidth(readKey(storageKey), fallback, min, max));
+  const drag = useRef<{ startX: number; startW: number } | null>(null);
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent<HTMLElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const target = e.currentTarget;
+      target.setPointerCapture(e.pointerId);
+      drag.current = { startX: e.clientX, startW: width };
+      function onMove(ev: PointerEvent) {
+        if (!drag.current) return;
+        setWidth(clampWidth(drag.current.startW + (ev.clientX - drag.current.startX), min, max));
+      }
+      function onUp() {
+        drag.current = null;
+        target.removeEventListener("pointermove", onMove);
+        target.removeEventListener("pointerup", onUp);
+        setWidth((w) => {
+          writeKey(storageKey, String(w));
+          return w;
+        });
+      }
+      target.addEventListener("pointermove", onMove);
+      target.addEventListener("pointerup", onUp);
+    },
+    [width, min, max, storageKey],
+  );
+
+  const reset = useCallback(() => {
+    setWidth(fallback);
+    writeKey(storageKey, null);
+  }, [fallback, storageKey]);
+
+  return { width, onPointerDown, reset };
+}

--- a/mur-hub-gui/ui/src/components/shell/useWindowWidth.ts
+++ b/mur-hub-gui/ui/src/components/shell/useWindowWidth.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export function useWindowWidth(): number {
+  const [width, setWidth] = useState(() => (typeof window === "undefined" ? 0 : window.innerWidth));
+  useEffect(() => {
+    function onResize() {
+      setWidth(window.innerWidth);
+    }
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -851,6 +851,7 @@ export const en = {
   "wizard.models.hint": "You can change this anytime in Settings → Models.",
   "nav.groupWorkspace": "Workspace",
   "nav.groupLibrary": "Library",
+  "shell.version": "MUR Hub {version}",
   "nav.home": "Home",
   "nav.chats": "Chats",
   "nav.agents": "Agents",

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -852,6 +852,7 @@ export const en = {
   "nav.groupWorkspace": "Workspace",
   "nav.groupLibrary": "Library",
   "shell.version": "MUR Hub {version}",
+  "shell.resizeList": "Drag to resize the list · double-click to reset",
   "nav.home": "Home",
   "nav.chats": "Chats",
   "nav.agents": "Agents",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -853,6 +853,7 @@ export const zhTW: Table = {
   "wizard.models.hint": "之後隨時可到 設定 → Models 調整。",
   "nav.groupWorkspace": "工作區",
   "nav.groupLibrary": "資源庫",
+  "shell.version": "MUR Hub {version}",
   "nav.home": "首頁",
   "nav.chats": "對話",
   "nav.agents": "代理人",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -854,6 +854,7 @@ export const zhTW: Table = {
   "nav.groupWorkspace": "工作區",
   "nav.groupLibrary": "資源庫",
   "shell.version": "MUR Hub {version}",
+  "shell.resizeList": "拖曳調整清單寬度 · 按兩下還原",
   "nav.home": "首頁",
   "nav.chats": "對話",
   "nav.agents": "代理人",

--- a/mur-hub-gui/ui/src/styles/components/shell.css
+++ b/mur-hub-gui/ui/src/styles/components/shell.css
@@ -128,3 +128,15 @@
 @media (prefers-reduced-motion: no-preference) {
   .shell { transition: grid-template-columns var(--dur-base) var(--ease-out); }
 }
+
+/* Master–detail page layout (spec §3.1): list | divider | detail. The page
+   sets --md-list-width from useResizableColumn. */
+.master-detail {
+  display: grid; grid-template-columns: var(--md-list-width, var(--shell-list-width)) 6px 1fr;
+  height: 100%; min-height: 0; overflow: hidden;
+}
+.list-divider { position: relative; cursor: col-resize; background: transparent; }
+.list-divider::after {
+  content: ""; position: absolute; top: 0; bottom: 0; left: 2px; width: 1px; background: var(--border-line);
+}
+.list-divider:hover::after, .list-divider:active::after { width: 2px; background: var(--color-brand); }

--- a/mur-hub-gui/ui/src/styles/components/shell.css
+++ b/mur-hub-gui/ui/src/styles/components/shell.css
@@ -3,18 +3,16 @@
 .shell {
   display: grid;
   grid-template-columns: var(--shell-sidebar-width) 1fr;
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-  font-family: var(--font-sans);
-  font-size: var(--text-base);
-  color: var(--text-primary);
-  background: var(--surface-bg);
+  flex: 1; min-height: 0; width: 100%;
+  font-family: var(--font-sans); font-size: var(--text-base);
+  color: var(--text-primary); background: var(--surface-window);
 }
-
-.shell--with-inspector {
-  grid-template-columns: var(--shell-sidebar-width) 1fr var(--shell-inspector-width);
+.shell--sidebar-collapsed { grid-template-columns: var(--shell-sidebar-collapsed-width) 1fr; }
+.shell--with-inspector { grid-template-columns: var(--shell-sidebar-width) 1fr var(--shell-inspector-width); }
+.shell--sidebar-collapsed.shell--with-inspector {
+  grid-template-columns: var(--shell-sidebar-collapsed-width) 1fr var(--shell-inspector-width);
 }
+.shell--titlebar-inset .shell__sidebar { padding-top: var(--shell-titlebar-inset); }
 
 .shell__sidebar {
   /* Vibrancy treatment: translucent bg + blur. Fallback (flip to solid if
@@ -26,10 +24,9 @@
   overflow-y: auto;
 }
 
-.shell__content {
-  overflow: auto;
-  min-width: 0;
-}
+.shell__content { display: flex; flex-direction: column; min-width: 0; overflow: hidden; }
+.shell__page { flex: 1; min-height: 0; overflow: auto; display: flex; flex-direction: column; }
+.shell__page > * { flex: 1; min-height: 0; }
 
 .shell__inspector {
   border-left: 1px solid var(--border-line);
@@ -44,6 +41,7 @@
   gap: 16px;
   padding: 12px 8px;
   width: 100%;
+  min-height: 100%;
   box-sizing: border-box;
 }
 
@@ -113,4 +111,20 @@
 .shell-sidebar-item--active .shell-sidebar-item__badge {
   background: var(--status-attention);
   color: var(--text-on-attention);
+}
+
+/* ── Collapsed icon rail + footer (spec §3.1) ─────────────────────────── */
+.shell-sidebar--collapsed .shell-sidebar__group-label,
+.shell-sidebar--collapsed .shell-sidebar-item__label,
+.shell-sidebar--collapsed .shell-sidebar__version { display: none; }
+.shell-sidebar--collapsed .shell-sidebar-item {
+  position: relative; justify-content: center; width: 40px; padding: 7px 0; margin: 0 auto;
+}
+.shell-sidebar--collapsed .shell-sidebar-item__badge {
+  position: absolute; top: 2px; right: 2px; min-width: 14px; height: 14px; padding: 0 4px; font-size: 9.5px;
+}
+.shell-sidebar__footer { margin-top: auto; display: flex; flex-direction: column; gap: 2px; }
+.shell-sidebar__version { font-size: var(--text-xs); color: var(--text-tertiary); padding: 4px 10px 0; }
+@media (prefers-reduced-motion: no-preference) {
+  .shell { transition: grid-template-columns var(--dur-base) var(--ease-out); }
 }


### PR DESCRIPTION
Second of the five PRs in `docs/superpowers/plans/2026-09-06-mur-hub-master-detail-shell.md` (spec + plan on #1164). Shell only — no page layouts change yet.

- **Breakpoints instead of window auto-resize.** `sidebarModeFor` / `listModeFor` / `togglePref` (pure, tested) decide the layout at 1200 / 960; the sidebar collapses to a 56 px icon rail below 1200, ⌘\ pins either mode (`mur.shell.sidebar`, persisted). `DashboardApp` no longer calls `setSize` / `setMinSize` when a selection opens.
- **Overlay title bar.** `titleBarStyle: Overlay` + `hiddenTitle` on the dashboard window (macOS; other platforms unchanged), default 1200×760, minimum 900×560, the sidebar is a drag region (`core:window:allow-start-dragging` added to the default capability).
- **Sidebar footer.** Settings and the Hub version (`getVersion()`, same read as About) move into the sidebar; the global bar's gear stays until PR 4 removes the bar.
- **Banners** render inside the content column (`Shell` `banners` slot) so they never push the sidebar down.
- **List divider.** `useResizableColumn` (clamped 240–400, persisted per page) + `ListDivider` + the `.master-detail` grid — unused until PR 4.

Verified: `npm test` 28 files / 238 tests, `npm run build`, `npm run lint` (0 errors, 6 pre-existing warnings). Browser check with a Tauri stub: banner in the content column, ⌘\ toggles collapsed ↔ auto and persists, Settings opens from the footer, version line renders.

Not verified here: the overlay title bar and the width-driven auto-collapse need the real Tauri window (the Chrome tab could not shrink below 1280 px and a local Tauri dev build needs ~24 GB with 36 GB free). The config keys are validated by `tauri-build` in the Hub GUI CI job; the collapse rule is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)