### PR TITLE
feat(hub): PR 11 of Hub 2.0 — side-peek from Home

### DIFF
--- a/docs/superpowers/specs/2026-09-06-mur-hub-master-detail-shell-design.md
+++ b/docs/superpowers/specs/2026-09-06-mur-hub-master-detail-shell-design.md
@@ -23,7 +23,7 @@ The visual language has the same accretion problem: pastel light-blue tint on ev
 | Detail navigation | **Master–detail**: fixed-width source list + full-width detail pane. Inspector column retired for Agents and Fleets. | Push navigation (full-page detail + back): loses list context, hides other agents' status while editing, back-stack state to manage, worse than today's fleet rail. Modal dialog: agent detail is a long-lived object with live state, not a task with an end; dims everything else; can't compare. Side drawer: option 3 with an overlay — the 11-tab width problem is unchanged. Resizable inspector (min 420): still squeezes the grid; wrong idiom for a primary editor. |
 | Pop-out | **"Open in window" (⌘↩) as an additive action in Phase 2**, reusing the Phase 1 detail component. Never the only path. | Separate window as the primary path: window management for 26 agents, and two windows fetching the same state — this codebase's most common failure. |
 | Scope of this spec | Sections 3–7 below are all Phase 1. They depend on each other: without breakpoints the tab IA doesn't fit; without the component family, Phase 2 rebuilds it. | Splitting tokens or components out into their own project. |
-| Deferred | Open-in-window, multi-select bulk start/stop, Quick Look preview, side-peek from Home. | — |
+| Deferred | Open-in-window, multi-select bulk start/stop, Quick Look preview (dropped in Phase 3(b): the detail pane already previews the selection), side-peek from Home (Phase 3(b)). | — |
 
 ## 3. Shell
 
@@ -225,4 +225,4 @@ Manual acceptance per PR 4 and PR 5, against the mockup: 960 and 1200 widths × 
 ## 10. Later phases
 
 - **Phase 2 — Library pages + open-in-window.** Skills / Workflows / MCP / Models / Plugins adopt `SourceList` + `DetailPage`; `LibraryInspector` retired; ⌘↩ opens the current detail in its own Tauri window reusing `DetailPage` (state read from the same Tauri commands, no second data path).
-- **Phase 3 — Home / Chats / Settings**, multi-select bulk actions in `SourceList`, Quick Look preview (space bar), side-peek from Home.
+- **Phase 3 — Home / Chats / Settings**, multi-select bulk actions in `SourceList`, side-peek from Home (Phase 3(b)); Quick Look was dropped there.

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -20,6 +20,8 @@ import { inboxBadge, visibleInboxItems } from "./home/inbox";
 import type { InboxItem } from "./home/inbox";
 import { ChatsPage } from "./chats/ChatsPage";
 import { popOutChat } from "./chats/ChatPane";
+import { PeekPanel } from "./peek/PeekPanel";
+import type { PeekTarget } from "./peek/peekModel";
 import { FleetView } from "./fleet/FleetView";
 import { useT } from "../i18n";
 import type { TranslationKey } from "../i18n/types";
@@ -115,6 +117,30 @@ export function DashboardApp() {
   const [paletteFleets, setPaletteFleets] = useState<FleetSummary[]>([]);
   // Handed to FleetView so a palette jump to the same fleet twice still fires.
   const clearFleetRequest = useCallback(() => setFleetRequest(null), []);
+  // Home's side-peek (spec 3(b) §3); rendered beside the Shell. Home gets
+  // its opener in 11.3.
+  const [peek, setPeek] = useState<PeekTarget | null>(null);
+  const closePeek = useCallback(() => setPeek(null), []);
+  const goFromPeek = useCallback((target: PeekTarget) => {
+    setPeek(null);
+    if (target.kind === "chat") openChatWith(target.agent);
+    else {
+      setFleetRequest(target.name);
+      setPage("fleets");
+    }
+  }, [openChatWith]);
+  const openWindowFromPeek = useCallback((target: PeekTarget) => {
+    setPeek(null);
+    if (target.kind === "chat") popOutChat(target.agent);
+    else {
+      const f = paletteFleets.find((x) => x.name === target.name);
+      void openDetailWindow("fleet", target.name, f?.display_name ?? target.name);
+    }
+  }, [paletteFleets]);
+  const openAgentFromPeek = useCallback((name: string) => {
+    setPeek(null);
+    openAgentFromChat(name);
+  }, [openAgentFromChat]);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [presetImportOpen, setPresetImportOpen] = useState(false);
   const [muragentImportOpen, setMuragentImportOpen] = useState(false);
@@ -348,6 +374,7 @@ export function DashboardApp() {
   // column). Ignored while a modal/input is focused so it doesn't fight them.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      if (peek) return; // PeekPanel owns Esc while open
       if (e.key !== "Escape") return;
       const el = document.activeElement;
       if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT")) return;
@@ -356,7 +383,7 @@ export function DashboardApp() {
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [setSelected]);
+  }, [setSelected, peek]);
 
   const selectedRuntime = selectedAgent ? runtimeMap.get(selectedAgent)?.state.state : undefined;
   const paletteItems: PaletteItem[] = [
@@ -594,6 +621,19 @@ export function DashboardApp() {
           )}
         </Shell>
       </div>
+
+      {peek && (
+        <PeekPanel
+          target={peek}
+          agents={agents}
+          runtimeMap={runtimeMap}
+          channels={channels}
+          onClose={closePeek}
+          onGo={goFromPeek}
+          onOpenInWindow={openWindowFromPeek}
+          onOpenAgent={openAgentFromPeek}
+        />
+      )}
 
       <WizardModal
         isOpen={wizardOpen}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -121,6 +121,7 @@ export function DashboardApp() {
   // its opener in 11.3.
   const [peek, setPeek] = useState<PeekTarget | null>(null);
   const closePeek = useCallback(() => setPeek(null), []);
+  const openPeek = useCallback((target: PeekTarget) => setPeek(target), []);
   const goFromPeek = useCallback((target: PeekTarget) => {
     setPeek(null);
     if (target.kind === "chat") openChatWith(target.agent);
@@ -129,14 +130,11 @@ export function DashboardApp() {
       setPage("fleets");
     }
   }, [openChatWith]);
-  const openWindowFromPeek = useCallback((target: PeekTarget) => {
+  const openWindowFromPeek = useCallback((target: PeekTarget, title: string) => {
     setPeek(null);
     if (target.kind === "chat") popOutChat(target.agent);
-    else {
-      const f = paletteFleets.find((x) => x.name === target.name);
-      void openDetailWindow("fleet", target.name, f?.display_name ?? target.name);
-    }
-  }, [paletteFleets]);
+    else void openDetailWindow("fleet", target.name, title);
+  }, []);
   const openAgentFromPeek = useCallback((name: string) => {
     setPeek(null);
     openAgentFromChat(name);
@@ -582,6 +580,7 @@ export function DashboardApp() {
               onDismiss={dismissInboxItem}
               onNavigate={(id) => setPage(id)}
               onCreateAgent={() => setWizardOpen(true)}
+              onPeek={openPeek}
             />
           ) : page === "chats" ? (
             <ChatsPage

--- a/mur-hub-gui/ui/src/components/detail/fleet/FleetDetailPane.tsx
+++ b/mur-hub-gui/ui/src/components/detail/fleet/FleetDetailPane.tsx
@@ -36,18 +36,20 @@ export interface FleetDetailPaneProps {
   onDeleted: () => void;
   /** Dashboard only: the ⋯ "Open in window" item. Undefined inside a window. */
   onOpenInWindow?: () => void;
+  /** Tab to open on; the Home peek opens on Jobs. Default Overview. */
+  initialTab?: FleetTabId;
 }
 
 /** One fleet's detail page (spec 2(b) §5): owns `fleet_detail` + `fleet_jobs`,
  *  reloads on `fleet:run_done` for this fleet, and renders the four tabs.
  *  Hosts key it by `name`, so a selection change remounts it. */
 export function FleetDetailPane({
-  name, summary, labels, agentMap, onRefresh, onDeleted, onOpenInWindow,
+  name, summary, labels, agentMap, onRefresh, onDeleted, onOpenInWindow, initialTab = "overview",
 }: FleetDetailPaneProps) {
   const { t } = useT();
   const [detail, setDetail] = useState<Detail | null>(null);
   const [jobs, setJobs] = useState<JobRow[]>([]);
-  const [tab, setTab] = useState<FleetTabId>("overview");
+  const [tab, setTab] = useState<FleetTabId>(initialTab);
 
   const load = useCallback(async () => {
     try {

--- a/mur-hub-gui/ui/src/components/detail/fleet/FleetHost.tsx
+++ b/mur-hub-gui/ui/src/components/detail/fleet/FleetHost.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { AgentEntry } from "../../../types";
+import { useAgents } from "../../../context/AgentContext";
+import type { FleetSummary, LabelView } from "../../fleet/types";
+import type { FleetTabId } from "../../shell/detailTabs";
+import { FleetDetailPane } from "./FleetDetailPane";
+
+export interface FleetHostProps {
+  name: string;
+  /** Tab to open on. Default Overview. */
+  initialTab?: FleetTabId;
+  onDeleted: () => void;
+  /** Rendered when fleet_list does not list `name`. */
+  missing: ReactNode;
+  onOpenInWindow?: () => void;
+  /** The fleet's display name once fleet_list answers (the peek's title). */
+  onTitle?: (displayName: string) => void;
+}
+
+/** Everything FleetDetailPane needs from outside a Fleets page: the summary
+ *  (status + labels) from fleet_list, the label registry, and the agent map
+ *  from the AgentProvider. Shared by the detail window and the Home peek. */
+export function FleetHost({ name, initialTab, onDeleted, missing, onOpenInWindow, onTitle }: FleetHostProps) {
+  const { agents } = useAgents();
+  const [fleets, setFleets] = useState<FleetSummary[] | null>(null);
+  const [labels, setLabels] = useState<LabelView[]>([]);
+  const [agentMap, setAgentMap] = useState<Map<string, AgentEntry>>(new Map());
+
+  useEffect(() => {
+    setAgentMap(new Map(agents.map((a) => [a.name, a])));
+  }, [agents]);
+
+  const load = useCallback(() => {
+    invoke<FleetSummary[]>("fleet_list").then(setFleets).catch(() => setFleets([]));
+    invoke<LabelView[]>("fleet_labels_list").then(setLabels).catch(() => setLabels([]));
+  }, []);
+  useEffect(load, [load]);
+
+  const displayName = fleets?.find((f) => f.name === name)?.display_name;
+  useEffect(() => {
+    if (displayName) onTitle?.(displayName);
+  }, [displayName, onTitle]);
+
+  if (fleets === null) return null;
+  const summary = fleets.find((f) => f.name === name);
+  if (!summary) return <>{missing}</>;
+  return (
+    <FleetDetailPane
+      name={name}
+      summary={summary}
+      labels={labels}
+      agentMap={agentMap}
+      onRefresh={load}
+      onDeleted={onDeleted}
+      onOpenInWindow={onOpenInWindow}
+      initialTab={initialTab}
+    />
+  );
+}

--- a/mur-hub-gui/ui/src/components/detail/window/DetailWindow.tsx
+++ b/mur-hub-gui/ui/src/components/detail/window/DetailWindow.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { AgentEntry } from "../../../types";
 import { AgentProvider, useAgents } from "../../../context/AgentContext";
 import { useT } from "../../../i18n";
-import type { FleetSummary, LabelView } from "../../fleet/types";
 import { visibleInboxItems } from "../../home/inbox";
 import { needsYouCounts } from "../../home/needsYouCounts";
 import { useChannels } from "../../home/useChannels";
@@ -12,7 +10,7 @@ import { useInbox } from "../../home/useInbox";
 import { DirtyProvider, useDirtyGuard } from "../../shell/dirty";
 import { isMac } from "../../shell/platform";
 import { AgentDetail } from "../agent/AgentDetail";
-import { FleetDetailPane } from "../fleet/FleetDetailPane";
+import { FleetHost } from "../fleet/FleetHost";
 import { parseDetailRoute, type DetailRoute } from "./detailRoute";
 
 /** Dismissals are session state in DashboardApp; a fresh window has none. */
@@ -61,7 +59,11 @@ function DetailWindowInner({ route }: { route: DetailRoute | null }) {
       ) : route.kind === "agent" ? (
         <AgentBody name={route.name} />
       ) : (
-        <FleetBody name={route.name} />
+        <FleetHost
+          name={route.name}
+          missing={<Missing text={t("detailWindow.missingFleet")} />}
+          onDeleted={() => void getCurrentWindow().close()}
+        />
       )}
     </div>
   );
@@ -102,39 +104,6 @@ function AgentBody({ name }: { name: string }) {
       onOpenHome={() => {
         invoke("open_dashboard", { page: "home" }).catch(console.error);
       }}
-    />
-  );
-}
-
-function FleetBody({ name }: { name: string }) {
-  const { t } = useT();
-  const { agents } = useAgents();
-  const [fleets, setFleets] = useState<FleetSummary[] | null>(null);
-  const [labels, setLabels] = useState<LabelView[]>([]);
-  const [agentMap, setAgentMap] = useState<Map<string, AgentEntry>>(new Map());
-
-  useEffect(() => {
-    setAgentMap(new Map(agents.map((a) => [a.name, a])));
-  }, [agents]);
-
-  // The pane's host data: the summary (status + labels) and the label registry.
-  const load = useCallback(() => {
-    invoke<FleetSummary[]>("fleet_list").then(setFleets).catch(() => setFleets([]));
-    invoke<LabelView[]>("fleet_labels_list").then(setLabels).catch(() => setLabels([]));
-  }, []);
-  useEffect(load, [load]);
-
-  if (fleets === null) return null;
-  const summary = fleets.find((f) => f.name === name);
-  if (!summary) return <Missing text={t("detailWindow.missingFleet")} />;
-  return (
-    <FleetDetailPane
-      name={name}
-      summary={summary}
-      labels={labels}
-      agentMap={agentMap}
-      onRefresh={load}
-      onDeleted={() => void getCurrentWindow().close()}
     />
   );
 }

--- a/mur-hub-gui/ui/src/components/home/HomePage.tsx
+++ b/mur-hub-gui/ui/src/components/home/HomePage.tsx
@@ -8,6 +8,7 @@ import { NowRunning } from "./NowRunning";
 import { RecentActivity } from "./RecentActivity";
 import { Mascot } from "../Mascot";
 import { useT } from "../../i18n";
+import { peekTargetForChannel, type PeekTarget } from "../peek/peekModel";
 
 interface Props {
   agents: AgentEntry[];
@@ -19,6 +20,8 @@ interface Props {
   onDismiss: (item: InboxItem) => void;
   onNavigate: (id: PageId) => void;
   onCreateAgent: () => void;
+  /** Open the side-peek (spec 3(b)). */
+  onPeek: (target: PeekTarget) => void;
 }
 
 /**
@@ -34,6 +37,7 @@ export function HomePage({
   onDismiss,
   onNavigate,
   onCreateAgent,
+  onPeek,
 }: Props) {
   const { t } = useT();
   const { channels, nowMs } = useChannels();
@@ -47,13 +51,19 @@ export function HomePage({
   const hasRecent = channels.some(isActivityChannel);
   const showEmpty = !hasRunningAgents && !hasRunningChannels && !hasRecent;
 
-  function openChat(_ch?: ChannelSummary) {
-    onNavigate("chats");
+  const agentNames = new Set(agents.map((a) => a.name));
+  // A channel row peeks its fleet or its agent's chat; other channels have no
+  // viewer yet and keep going to the Chats page (spec 3(b) §4).
+  function openChat(ch?: ChannelSummary) {
+    const target = ch ? peekTargetForChannel(ch, agentNames) : null;
+    if (target) onPeek(target);
+    else onNavigate("chats");
   }
+  const peekAgent = (name: string) => onPeek({ kind: "chat", agent: name });
 
   return (
     <div className="home-page">
-      <NeedsYou items={items} onRefresh={onRefresh} onDismiss={onDismiss} />
+      <NeedsYou items={items} onRefresh={onRefresh} onDismiss={onDismiss} onPeekAgent={peekAgent} />
 
       {showEmpty ? (
         <div className="home-empty">
@@ -85,7 +95,8 @@ export function HomePage({
             runtimeStatuses={runtimeStatuses}
             channels={channels}
             nowMs={nowMs}
-            onOpen={() => openChat()}
+            onOpen={openChat}
+            onPeekAgent={peekAgent}
           />
           <RecentActivity
             channels={channels}

--- a/mur-hub-gui/ui/src/components/home/NeedsYou.tsx
+++ b/mur-hub-gui/ui/src/components/home/NeedsYou.tsx
@@ -16,6 +16,8 @@ interface Props {
   onRefresh: () => void;
   /** Dismiss an item for this session; owned by the caller so the badge stays in sync. */
   onDismiss: (item: InboxItem) => void;
+  /** Peek the owning agent's conversation (spec 3(b) §4). */
+  onPeekAgent: (name: string) => void;
 }
 
 /**
@@ -24,7 +26,7 @@ interface Props {
  * the caller's dismissed-set so this list and the sidebar/Dock badge never
  * drift apart.
  */
-export function NeedsYou({ items, onRefresh, onDismiss }: Props) {
+export function NeedsYou({ items, onRefresh, onDismiss, onPeekAgent }: Props) {
   const { t } = useT();
 
   if (items.length === 0) return null;
@@ -42,6 +44,7 @@ export function NeedsYou({ items, onRefresh, onDismiss }: Props) {
                   item={it}
                   raw={it.payload as RawHitl}
                   onResolved={onRefresh}
+                  onPeekAgent={onPeekAgent}
                 />
               );
             case "install":
@@ -58,6 +61,7 @@ export function NeedsYou({ items, onRefresh, onDismiss }: Props) {
                   key={`companion:${it.id}`}
                   item={it}
                   raw={it.payload as RawCompanionEvent}
+                  onPeekAgent={onPeekAgent}
                 />
               );
             case "upgrade_blocked":
@@ -87,12 +91,15 @@ function HitlInboxCard({
   item,
   raw,
   onResolved,
+  onPeekAgent,
 }: {
   item: InboxItem;
   raw: RawHitl;
   onResolved: () => void;
+  onPeekAgent: (name: string) => void;
 }) {
   const { t } = useT();
+  const agent = item.agent;
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -121,6 +128,11 @@ function HitlInboxCard({
         <span className="hitl-card__icon">⏸</span>
         <span className="hitl-card__title">{item.title}</span>
         {raw.risk && <span className="home-card__tag">{raw.risk}</span>}
+        {agent && (
+          <button type="button" className="home-card__peek" onClick={() => onPeekAgent(agent)}>
+            {t("peek.viewConversation")}
+          </button>
+        )}
       </div>
       <div className="hitl-card__prompt">{item.subtitle}</div>
       <div className="hitl-card__actions">
@@ -169,14 +181,23 @@ function InstallInboxCard({ item, raw }: { item: InboxItem; raw: RawInstall }) {
 function CompanionInboxCard({
   item,
   raw,
+  onPeekAgent,
 }: {
   item: InboxItem;
   raw: RawCompanionEvent;
+  onPeekAgent: (name: string) => void;
 }) {
+  const { t } = useT();
+  const agent = item.agent;
   return (
     <div className="home-card inbox-msg inbox-msg--unread">
       <div className="inbox-msg-header">
         <span className="inbox-situation">{item.title}</span>
+        {agent && (
+          <button type="button" className="home-card__peek" onClick={() => onPeekAgent(agent)}>
+            {t("peek.viewConversation")}
+          </button>
+        )}
         <span className="inbox-time">
           {new Date(raw.generated_at).toLocaleTimeString([], {
             hour: "2-digit",

--- a/mur-hub-gui/ui/src/components/home/NowRunning.tsx
+++ b/mur-hub-gui/ui/src/components/home/NowRunning.tsx
@@ -11,8 +11,10 @@ interface Props {
   runtimeStatuses: AgentRuntimeStatus[];
   channels: ChannelSummary[];
   nowMs: number;
-  /** Jump to the chats surface for a given channel/agent. */
-  onOpen: () => void;
+  /** A channel row: the Home page maps it to a peek or the Chats page. */
+  onOpen: (channel: ChannelSummary) => void;
+  /** An agent chip: peek that agent's conversation (spec 3(b) §4). */
+  onPeekAgent: (name: string) => void;
 }
 
 /**
@@ -27,6 +29,7 @@ export function NowRunning({
   channels,
   nowMs,
   onOpen,
+  onPeekAgent,
 }: Props) {
   const { t } = useT();
 
@@ -51,7 +54,13 @@ export function NowRunning({
             const entry = entryFor(s.name);
             const preset = entry ? avatarPreset(entry) : "starling";
             return (
-              <div key={s.name} className="home-run-agent">
+              <button
+                key={s.name}
+                type="button"
+                className="home-run-agent"
+                onClick={() => onPeekAgent(s.name)}
+                aria-label={entry?.display_name ?? s.name}
+              >
                 <span className="home-run-agent__avatar">
                   <PetFace
                     presetId={preset}
@@ -65,7 +74,7 @@ export function NowRunning({
                   {entry?.display_name ?? s.name}
                 </span>
                 <span className="home-run-agent__dot" aria-hidden="true" />
-              </div>
+              </button>
             );
           })}
         </div>
@@ -75,7 +84,7 @@ export function NowRunning({
         <ul className="home-run-list">
           {runningChannels.map((ch) => (
             <li key={ch.id}>
-              <button className="home-run-row" onClick={onOpen}>
+              <button className="home-run-row" onClick={() => onOpen(ch)}>
                 <span className="home-run-row__title">
                   {ch.title || ch.id.slice(0, 8)}
                 </span>

--- a/mur-hub-gui/ui/src/components/peek/PeekPanel.tsx
+++ b/mur-hub-gui/ui/src/components/peek/PeekPanel.tsx
@@ -17,8 +17,9 @@ export interface PeekPanelProps {
   onClose: () => void;
   /** Leave Home for the page that owns the target, with it selected. */
   onGo: (t: PeekTarget) => void;
-  /** The chat window or the fleet detail window; the caller closes the peek. */
-  onOpenInWindow: (t: PeekTarget) => void;
+  /** The chat window or the fleet detail window; the caller closes the peek.
+   *  `title` is the display name when the panel knows it. */
+  onOpenInWindow: (t: PeekTarget, title: string) => void;
   /** ChatPane's "Open agent": the Agents page with that agent selected. */
   onOpenAgent: (name: string) => void;
 }
@@ -48,7 +49,7 @@ export function PeekPanel({ target, agents, runtimeMap, channels, onClose, onGo,
       } else if (isOpenInWindowShortcut(e) && !isEditingTarget(document.activeElement)) {
         e.stopPropagation();
         e.preventDefault();
-        onOpenInWindow(target);
+        onOpenInWindow(target, titleRef.current);
       }
     }
     window.addEventListener("keydown", onKey, true);
@@ -57,6 +58,9 @@ export function PeekPanel({ target, agents, runtimeMap, channels, onClose, onGo,
 
   const entry = target.kind === "chat" ? agents.find((a) => a.name === target.agent) : undefined;
   const title = target.kind === "chat" ? (entry?.display_name ?? target.agent) : (fleetTitle ?? target.name);
+  // The key handler reads the latest title without re-subscribing per render.
+  const titleRef = useRef(title);
+  titleRef.current = title;
 
   return (
     <>
@@ -68,7 +72,7 @@ export function PeekPanel({ target, agents, runtimeMap, channels, onClose, onGo,
             <button type="button" className="btn btn--secondary" onClick={() => onGo(target)}>
               {t("peek.go")}
             </button>
-            <button type="button" className="btn btn--secondary" onClick={() => onOpenInWindow(target)}>
+            <button type="button" className="btn btn--secondary" onClick={() => onOpenInWindow(target, title)}>
               {t("action.openInWindow")}
             </button>
             <button ref={closeRef} type="button" className="peek__close" onClick={onClose} aria-label={t("detail.close")}>

--- a/mur-hub-gui/ui/src/components/peek/PeekPanel.tsx
+++ b/mur-hub-gui/ui/src/components/peek/PeekPanel.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from "react";
+import type { AgentEntry, AgentRuntimeStatus } from "../../types";
+import type { ChannelSummary } from "../../work/types";
+import { useT } from "../../i18n";
+import { useConversations } from "../../conversation/ConversationContext";
+import { buildChatList } from "../chats/chatList";
+import { ChatPane } from "../chats/ChatPane";
+import { FleetHost } from "../detail/fleet/FleetHost";
+import { isEditingTarget, isOpenInWindowShortcut } from "../detail/window/openInWindow";
+import type { PeekTarget } from "./peekModel";
+
+export interface PeekPanelProps {
+  target: PeekTarget;
+  agents: AgentEntry[];
+  runtimeMap: Map<string, AgentRuntimeStatus>;
+  channels: ChannelSummary[];
+  onClose: () => void;
+  /** Leave Home for the page that owns the target, with it selected. */
+  onGo: (t: PeekTarget) => void;
+  /** The chat window or the fleet detail window; the caller closes the peek. */
+  onOpenInWindow: (t: PeekTarget) => void;
+  /** ChatPane's "Open agent": the Agents page with that agent selected. */
+  onOpenAgent: (name: string) => void;
+}
+
+/** The right-side slide-over Home peeks into (spec 3(b) §5). Esc and the
+ *  scrim close it; ⌘↩ opens the target in its window. */
+export function PeekPanel({ target, agents, runtimeMap, channels, onClose, onGo, onOpenInWindow, onOpenAgent }: PeekPanelProps) {
+  const { t } = useT();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const [fleetTitle, setFleetTitle] = useState<string | null>(null);
+
+  // Focus the close button on open; give focus back on close.
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+    return () => previous?.focus();
+  }, []);
+
+  // Esc closes only the peek (capture phase, stopPropagation: the page's
+  // global Esc must not also clear a selection); ⌘↩ opens in a window.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        onClose();
+      } else if (isOpenInWindowShortcut(e) && !isEditingTarget(document.activeElement)) {
+        e.stopPropagation();
+        e.preventDefault();
+        onOpenInWindow(target);
+      }
+    }
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [target, onClose, onOpenInWindow]);
+
+  const entry = target.kind === "chat" ? agents.find((a) => a.name === target.agent) : undefined;
+  const title = target.kind === "chat" ? (entry?.display_name ?? target.agent) : (fleetTitle ?? target.name);
+
+  return (
+    <>
+      <div className="peek__scrim" onClick={onClose} />
+      <aside className="peek" role="dialog" aria-modal="true" aria-label={title}>
+        <header className="peek__bar">
+          <span className="peek__title">{title}</span>
+          <div className="peek__actions">
+            <button type="button" className="btn btn--secondary" onClick={() => onGo(target)}>
+              {t("peek.go")}
+            </button>
+            <button type="button" className="btn btn--secondary" onClick={() => onOpenInWindow(target)}>
+              {t("action.openInWindow")}
+            </button>
+            <button ref={closeRef} type="button" className="peek__close" onClick={onClose} aria-label={t("detail.close")}>
+              ×
+            </button>
+          </div>
+        </header>
+        <div className="peek__body">
+          {target.kind === "chat" ? (
+            <ChatBody agent={target.agent} entry={entry} runtimeMap={runtimeMap} channels={channels} onOpenAgent={onOpenAgent} />
+          ) : (
+            <FleetHost
+              name={target.name}
+              initialTab="jobs"
+              missing={<p className="peek__missing">{t("detailWindow.missingFleet")}</p>}
+              onDeleted={onClose}
+              onTitle={setFleetTitle}
+            />
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function ChatBody({ agent, entry, runtimeMap, channels, onOpenAgent }: {
+  agent: string;
+  entry: AgentEntry | undefined;
+  runtimeMap: Map<string, AgentRuntimeStatus>;
+  channels: ChannelSummary[];
+  onOpenAgent: (name: string) => void;
+}) {
+  const { t } = useT();
+  const { attention, openConversation, focusConversation, blurConversation } = useConversations();
+
+  // Reading the conversation: the Chats page's attention rule (spec 3(a) §4).
+  useEffect(() => {
+    openConversation(agent);
+    focusConversation(agent);
+    return () => blurConversation();
+  }, [agent, openConversation, focusConversation, blurConversation]);
+
+  if (!entry) return <p className="peek__missing">{t("detailWindow.missingAgent")}</p>;
+  const item = buildChatList([entry], attention, channels)[0];
+  return <ChatPane item={item} runtime={runtimeMap.get(agent)} onOpenAgent={onOpenAgent} />;
+}

--- a/mur-hub-gui/ui/src/components/peek/peekModel.test.ts
+++ b/mur-hub-gui/ui/src/components/peek/peekModel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { peekTargetForChannel } from "./peekModel";
+
+const agents = new Set(["aura", "scout"]);
+
+describe("peekTargetForChannel", () => {
+  it("maps a fleet channel to its fleet", () => {
+    expect(peekTargetForChannel({ id: "fleet-night-ops" }, agents)).toEqual({ kind: "fleet", name: "night-ops" });
+  });
+  it("maps an agent's primary channel to its chat", () => {
+    expect(peekTargetForChannel({ id: "aura" }, agents)).toEqual({ kind: "chat", agent: "aura" });
+  });
+  it("has no target for other channels", () => {
+    expect(peekTargetForChannel({ id: "aura-2" }, agents)).toBeNull();
+    expect(peekTargetForChannel({ id: "shared-x" }, agents)).toBeNull();
+    expect(peekTargetForChannel({ id: "fleet-" }, agents)).toBeNull();
+  });
+});

--- a/mur-hub-gui/ui/src/components/peek/peekModel.ts
+++ b/mur-hub-gui/ui/src/components/peek/peekModel.ts
@@ -1,0 +1,16 @@
+/** What the Home peek can show (spec 3(b) §3). */
+export type PeekTarget = { kind: "chat"; agent: string } | { kind: "fleet"; name: string };
+
+export const FLEET_CHANNEL_PREFIX = "fleet-";
+
+/** A fleet's channel → that fleet; an agent's primary channel (id == agent
+ *  name) → that chat; anything else → null, and the caller keeps today's
+ *  navigation. */
+export function peekTargetForChannel(channel: { id: string }, agentNames: ReadonlySet<string>): PeekTarget | null {
+  if (channel.id.startsWith(FLEET_CHANNEL_PREFIX)) {
+    const name = channel.id.slice(FLEET_CHANNEL_PREFIX.length);
+    return name ? { kind: "fleet", name } : null;
+  }
+  if (agentNames.has(channel.id)) return { kind: "chat", agent: channel.id };
+  return null;
+}

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -967,6 +967,8 @@ export const en = {
   "placeholder.open": "Open Model Library",
   "home.needsYou": "Needs you",
   "home.nowRunning": "Now running",
+  "peek.go": "Go",
+  "peek.viewConversation": "View conversation",
   "home.recentActivity": "Recent activity",
   "home.recentActivity.empty": "No recent activity yet.",
   "home.running.agents": "Running agents",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -969,6 +969,8 @@ export const zhTW: Table = {
   "placeholder.open": "開啟模型庫",
   "home.needsYou": "需要你處理",
   "home.nowRunning": "進行中",
+  "peek.go": "前往",
+  "peek.viewConversation": "查看對話",
   "home.recentActivity": "近期活動",
   "home.recentActivity.empty": "目前沒有近期活動。",
   "home.running.agents": "執行中的 agent",

--- a/mur-hub-gui/ui/src/styles/components/home.css
+++ b/mur-hub-gui/ui/src/styles/components/home.css
@@ -114,7 +114,9 @@
   border: 1px solid var(--border-line);
   border-radius: var(--radius-xl);
   background: var(--surface-card);
+  font: inherit; color: inherit; cursor: pointer; text-align: left;
 }
+.home-run-agent:hover { background: var(--surface-hover); }
 
 .home-run-agent__name {
   font-size: 13px;
@@ -216,3 +218,9 @@
   flex-wrap: wrap;
   justify-content: center;
 }
+
+.home-card__peek {
+  margin-left: auto; background: none; border: 0; padding: 2px 6px; border-radius: var(--radius-sm);
+  color: var(--color-brand); font: inherit; font-size: var(--text-xs); cursor: pointer; white-space: nowrap;
+}
+.home-card__peek:hover { background: var(--surface-hover); }

--- a/mur-hub-gui/ui/src/styles/components/peek.css
+++ b/mur-hub-gui/ui/src/styles/components/peek.css
@@ -1,0 +1,24 @@
+/* Home side-peek (Phase 3(b) §5): scrim + right-anchored slide-over hosting ChatPane / FleetDetailPane. */
+.peek__scrim { position: fixed; inset: 0; z-index: var(--z-peek); background: var(--scrim); }
+.peek {
+  position: fixed; top: 0; right: 0; bottom: 0; z-index: calc(var(--z-peek) + 1);
+  width: min(560px, calc(100vw - var(--shell-sidebar-width) - 40px));
+  display: flex; flex-direction: column; min-height: 0;
+  background: var(--surface-detail); box-shadow: var(--shadow-pop);
+  animation: peek-in var(--dur-base) var(--ease-out);
+}
+@keyframes peek-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+@media (prefers-reduced-motion: reduce) { .peek { animation: none; } }
+.peek__bar {
+  display: flex; align-items: center; gap: var(--space-4); height: 44px; flex: none;
+  padding: 0 var(--space-5) 0 var(--space-6); border-bottom: 1px solid var(--border-line);
+}
+.peek__title { flex: 1; min-width: 0; font-weight: var(--fw-semi); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.peek__actions { display: flex; align-items: center; gap: var(--space-3); }
+.peek__close {
+  background: none; border: 0; color: var(--text-tertiary); font-size: 18px; line-height: 1;
+  padding: 2px 6px; border-radius: var(--radius-sm); cursor: pointer;
+}
+.peek__close:hover { background: var(--surface-hover); color: var(--text-primary); }
+.peek__body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.peek__missing { margin: var(--space-8); color: var(--text-secondary); font-size: var(--text-sm); }

--- a/mur-hub-gui/ui/src/styles/index.css
+++ b/mur-hub-gui/ui/src/styles/index.css
@@ -22,6 +22,7 @@
 @import "./components/detail-page.css";
 @import "./components/detail-window.css";
 @import "./components/chats.css";
+@import "./components/peek.css";
 @import "./components/library.css";
 @import "./components/menus.css";
 @import "./components/palette.css";

--- a/mur-hub-gui/ui/src/styles/tokens/primitives.css
+++ b/mur-hub-gui/ui/src/styles/tokens/primitives.css
@@ -36,7 +36,7 @@
   /* shadow */
   --shadow-sm:0 1px 2px rgba(16,40,80,.06);
   --shadow-card:0 1px 3px rgba(16,40,80,.08),0 1px 2px rgba(16,40,80,.04);
-  --shadow-pop:0 16px 40px rgba(16,40,80,.16);
+  --shadow-pop:0 16px 40px rgba(16,40,80,.16); --z-peek:900; --scrim-light:rgba(16,24,40,.32); --scrim-dark:rgba(0,0,0,.5);
   --shadow-focus:0 0 0 3px rgba(74,144,217,.18);
   /* motion */
   --dur-fast:130ms; --dur-base:180ms; --dur-slow:280ms;

--- a/mur-hub-gui/ui/src/styles/tokens/semantic.css
+++ b/mur-hub-gui/ui/src/styles/tokens/semantic.css
@@ -6,6 +6,7 @@
   /* surfaces (spec §5.1): window < sidebar < list < detail = card */
   --surface-bg:var(--n-bg); --surface-window:var(--n-bg); --surface-sidebar:var(--n-sidebar);
   --surface-list:var(--n-list); --surface-detail:var(--n-detail);
+  --scrim:var(--scrim-light);
   --surface-secondary:var(--n-secondary); --surface-card:var(--n-card); --surface-hover:var(--n-hover);
   --border-line:var(--n-line); --border-line-subtle:var(--n-line-subtle);
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);
@@ -24,6 +25,7 @@
     --color-accent-strong:var(--coral-300);
     --surface-bg:var(--d-bg); --surface-window:var(--d-bg); --surface-sidebar:var(--d-sidebar);
     --surface-list:var(--d-list); --surface-detail:var(--d-detail);
+    --scrim:var(--scrim-dark);
     --surface-secondary:var(--d-secondary); --surface-card:var(--d-card); --surface-hover:var(--d-hover);
     --border-line:var(--d-line); --border-line-subtle:var(--d-line-subtle);
     --text-primary:var(--d-text); --text-secondary:var(--d-text2); --text-tertiary:var(--d-text3);
@@ -38,6 +40,7 @@
   --color-accent-strong:var(--coral-300);
   --surface-bg:var(--d-bg); --surface-window:var(--d-bg); --surface-sidebar:var(--d-sidebar);
   --surface-list:var(--d-list); --surface-detail:var(--d-detail);
+  --scrim:var(--scrim-dark);
   --surface-secondary:var(--d-secondary); --surface-card:var(--d-card); --surface-hover:var(--d-hover);
   --border-line:var(--d-line); --border-line-subtle:var(--d-line-subtle);
   --text-primary:var(--d-text); --text-secondary:var(--d-text2); --text-tertiary:var(--d-text3);
@@ -51,6 +54,7 @@
   --color-accent-strong:var(--coral-600);
   --surface-bg:var(--n-bg); --surface-window:var(--n-bg); --surface-sidebar:var(--n-sidebar);
   --surface-list:var(--n-list); --surface-detail:var(--n-detail);
+  --scrim:var(--scrim-light);
   --surface-secondary:var(--n-secondary); --surface-card:var(--n-card); --surface-hover:var(--n-hover);
   --border-line:var(--n-line); --border-line-subtle:var(--n-line-subtle);
   --text-primary:var(--n-text); --text-secondary:var(--n-text2); --text-tertiary:var(--n-text3);


### PR DESCRIPTION
## Summary

PR 11 of the Hub 2.0 plan: Phase 3(b) (`docs/superpowers/plans/2026-09-06-mur-hub-home-peek.md`; spec + plan in #1179).

- **`FleetHost`** extracted from `DetailWindow` (pure movement) and `FleetDetailPane.initialTab`, so a fleet can be hosted outside the Fleets page and opened on a chosen tab.
- **`PeekPanel`**: a right-anchored slide-over (scrim, `--z-peek` below the modal overlay, `--scrim` per theme, reduced-motion aware) hosting the existing `ChatPane` or `FleetHost` (Jobs tab) under Go / Open in window / close. Esc and ⌘↩ are handled in the capture phase and stopped so the page's global Esc stays out; focus goes to the close button and back on close; a chat peek applies the Chats page's attention rule (open + focus, blur on close).
- **Home entry points**: the Now-running agent chips are buttons that peek the chat; channel rows now pass their channel and `peekTargetForChannel` maps a `fleet-*` channel to its fleet and an agent's primary channel to its chat, anything else still goes to Chats; HITL and companion cards gain **View conversation**. Go lands on Chats / Fleets with the target selected; Open in window opens the chat window / fleet detail window with the display name as title.
- Quick Look on lists is dropped (the shell spec's deferred list says so): the detail pane already previews the selection.

## Verification

- `npm test` 43 files / 272 tests (new: `peekTargetForChannel`), `npm run build`, `npm run lint` (0 errors; 6 pre-existing warnings).
- Browser acceptance against `npm run dev` with a stubbed bridge: the agent chip, the HITL card's View conversation, and the `fleet-night-ops` row each open the panel (chat: model · channel · turns + compose; fleet: Jobs tab active, title "Night Ops"); the `shared-x` row navigates to Chats with no panel; Esc, the scrim, and ⌘↩ (→ `open_detail_window {kind:"fleet", title:"Night Ops"}`) close it; Go lands on Chats with AURA selected / Fleets with Night Ops selected; with the panel open Esc does not clear the Agents page's selection; a `chat-delta` fired while the agent is peeked leaves its Chats row without the unread dot and one fired afterwards sets it; removing the agent from the roster shows "This agent no longer exists."; `#/detail/fleet/<name>` and `/nope` still render after the `FleetHost` extraction.
- Not verified: the slide-in motion / reduced-motion, the scrim colour in light theme, a real streamed reply inside a peek, and whether a fleet peek's Run ▾ popover is clipped by the panel — the manual list is in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)