### PR TITLE
chore(release): bump workspace version to 2.72.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.71.24"
+version = "2.72.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.71.24"
+version = "2.72.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Merging this PR **is** the v2.72.0 release: `tag.yml` tags the merge commit and dispatches `release.yml` (cross-platform build, GitHub Release, Homebrew formula, installer deploy, crates.io publish — irreversible).

## What ships since v2.71.24

Hub 2.0, Phases 1–3 (#1164–#1184): the master–detail shell on every page — Agents, Fleets, the four Library pages, Chats, Settings — with one status vocabulary and neutral-first tokens, the ⌘K command palette, ⌘↩ open-in-window for agent and fleet detail, the Home side-peek, ⌘-click / ⇧-click multi-select with bulk Start / Stop, and the inspector column and settings modal retired. The Chats list's unread / HITL badges work again (the attention reducer had been unfed since the tabbed view was removed).

No CLI, daemon, or runtime change; the Rust diff is the Hub crate only (`open_detail_window`, `open_dashboard` bridge, `skills_installed` usage data).

## Known unverified

The redesign was accepted on the stubbed dev server, never in a real Tauri window (the dev drive could not hold the Hub target for most of the work). The first real-app check should walk the manual lists at the end of the four Hub plans under `docs/superpowers/plans/2026-09-06-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)