### PR TITLE
fix(hub): detail windows could not be closed (missing allow-destroy)

### DIFF
--- a/mur-hub-gui/src-tauri/capabilities/detail.json
+++ b/mur-hub-gui/src-tauri/capabilities/detail.json
@@ -8,6 +8,7 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:window:allow-set-size",


### PR DESCRIPTION
## Summary
- Tauri v2 hands the close to the frontend when a `close-requested` listener exists: `await handler(evt); if (!evt.isPreventDefault()) await this.destroy();`
- `DetailWindow.tsx` registers that listener (unsaved-edits prompt), so every close of a `detail-*` window goes through `destroy()`
- The detail capability granted `allow-close` but not `allow-destroy`; the ACL refused it with no visible error and the traffic-light close button did nothing
- Grants `core:window:allow-destroy` to `capabilities/detail.json`

## Test plan
- [x] Local debug build installed, `capabilities.json` in the build output carries `allow-destroy`
- [x] ⌘↩ opens a detail window; red traffic light now closes it (user-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)