### PR TITLE
fix(cli): perm set-mode help lists proxy_only

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -779,7 +779,7 @@ pub enum AgentPermAction {
         name: String,
         section: Option<String>,
     },
-    /// Set a mode (currently only `network.outbound <restricted|unrestricted|off>`)
+    /// Set a mode (currently only `network.outbound <restricted|unrestricted|proxy_only|off>`)
     SetMode {
         name: String,
         key: String,


### PR DESCRIPTION
The parser has accepted `proxy_only` since #1189 (`parse_outbound_mode`, and its error string lists it), but the clap doc comment still advertised only `restricted|unrestricted|off`. Help now matches the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)