### PR TITLE
chore(release): bump workspace version to 2.74.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.73.0"
+version = "2.74.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6615,7 +6615,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6634,7 +6634,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6799,7 +6799,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.73.0"
+version = "2.74.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.74.0. Merging this PR **is** the release: `tag.yml` tags `v2.74.0` on the merge commit and dispatches `release.yml`, which publishes to crates.io (irreversible). There is no gate after this one.

## What ships since v2.73.0

- **#1201** — conversations survive a runtime restart (#1199), and multi-turn history is capped by an estimated token budget instead of a 20-turn count (#1200).

Both were user-visible as the agent "blanking out" mid-session: a restart dropped the conversation entirely, and long conversations silently lost their oldest turns. Restarts are not rare — editing an entitlement forces one — so the ordinary *hit a denial → grant the path → restart → carry on* loop was destroying the conversation that motivated the grant.

## Version hygiene

- `Cargo.toml` workspace version → 2.74.0
- Root `Cargo.lock` and `mur-hub-gui/src-tauri/Cargo.lock` both moved (the Hub lock keeps its own copy of every workspace crate's version and breaks the Hub release build when it disagrees)
- No `2.73.0` string remains in any of the three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)