### PR TITLE
docs(readme): HITL bullet describes the P3 chat gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,8 +436,15 @@ Agent** wizard offers the same catalog as a source.
   grant takes two presses — typing an ordinary sentence can't hand a tool
   blanket approval. An open gate always renders somewhere, `/auto off` revokes
   the per-tool grants it claims to revoke, and a gate that times out stops
-  asking. Reads never have to stop the run: `--auto-reads` covers `read_file`
-  and provably read-only shell commands, in the TUI and in `--plain` alike.
+  asking. Tool calls from one model response arrive as a single card rather
+  than one prompt each — every call is still decided on its own, and there is
+  no approve-all. A settled decision is remembered by action hash, so the same
+  call stops being asked twice, and an explicit no outranks any standing grant.
+  *Always* writes the narrowest exact tool rule; where a call reaches outside
+  its entitlements the card offers that grant as a separate control, never
+  folded into the rule. Reads never have to stop the run: `--auto-reads` covers
+  `read_file` and provably read-only shell commands, in the TUI and in
+  `--plain` alike.
 - **Build lane** — a toolchain that compiles its own executables can't be
   expressed as a list of binaries: `cargo` runs build scripts and test
   executables at paths that don't exist until the build creates them. Grant the


### PR DESCRIPTION
## Summary

P3 shipped in #1196 (v2.74.0) but the README's **Human-in-the-loop** bullet still described the pre-P3 behaviour — one prompt per tool call, nothing remembered.

Amended to state what the gate does now:

- Tool calls from one model response arrive as a **single card**, not one prompt each. Each call is still decided on its own; there is no approve-all (spec §3.4).
- A settled decision is **remembered by action hash**, so the same call stops being asked twice; an explicit no outranks a standing grant (§3.2).
- **Always** writes the narrowest exact tool rule, and where a call reaches outside its entitlements the card offers that grant as a **separate control**, never folded into the rule (§3.3).

No command-tree change: P3 added no CLI surface.

## Test plan

Prose only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)