### PR TITLE
fix(hub): chat window rail switches the channel and shows titles + time

### DIFF
--- a/mur-hub-gui/src-tauri/src/chat.rs
+++ b/mur-hub-gui/src-tauri/src/chat.rs
@@ -85,6 +85,8 @@ pub async fn agent_chat_send(
     text: String,
     task_id: String,
     context_task_id: Option<String>,
+    // Channel picked in the chat window's rail; `None` = the agent's latest.
+    channel_id: Option<String>,
 ) -> Result<ChatReply, String> {
     let home = crate::mur_home_path();
     // Register the in-flight id synchronously so a Stop pressed mid-turn can
@@ -99,6 +101,7 @@ pub async fn agent_chat_send(
     // duplicate user turns on retry, and pins both halves to one channel.
     let persist_home = home.clone();
     let persist_name = name.clone();
+    let persist_channel = channel_id;
     let persist_user_text = text.clone();
     let user_task_id = task_id.clone();
 
@@ -194,6 +197,7 @@ pub async fn agent_chat_send(
     persist_exchange(
         &persist_home,
         &persist_name,
+        persist_channel.as_deref(),
         &persist_user_text,
         Some(&user_task_id),
         &reply,
@@ -267,15 +271,17 @@ fn extract_text(message: &Value) -> String {
 
 // ─── Channel persistence ───────────────────────────────────────────────────
 
-/// Persist one user→agent exchange into the agent's channel, resolving the
-/// channel ONCE so both halves land together (never split across channels if a
-/// newer channel appears mid-turn). Best-effort: failures are logged, never
+/// Persist one user→agent exchange into the agent's channel — the explicit
+/// `channel_id` when the chat window's rail picked one, else the agent's latest —
+/// resolving the channel ONCE so both halves land together (never split across
+/// channels if a newer channel appears mid-turn). Best-effort: failures are logged, never
 /// surfaced to the chat. The channel is created here on the first real exchange,
 /// so a failed/empty turn writes nothing (no orphaned user message).
 #[allow(clippy::too_many_arguments)]
 fn persist_exchange(
     home: &std::path::Path,
     agent: &str,
+    channel_id: Option<&str>,
     user_text: &str,
     user_task_id: Option<&str>,
     agent_text: &str,
@@ -284,9 +290,12 @@ fn persist_exchange(
 ) {
     let res = (|| -> anyhow::Result<()> {
         let svc = ChannelService::open(home)?;
-        let id = match svc.latest_for_agent(agent)? {
-            Some(id) => id,
-            None => svc.create_for_agent(agent)?.id,
+        let id = match channel_id {
+            Some(id) => id.to_string(),
+            None => match svc.latest_for_agent(agent)? {
+                Some(id) => id,
+                None => svc.create_for_agent(agent)?.id,
+            },
         };
         svc.append_message(
             &id,
@@ -322,15 +331,32 @@ fn persist_exchange(
     }
 }
 
-/// Tauri command: load the agent's latest channel events for hydration.
-#[tauri::command]
-pub async fn channel_load(name: String) -> Result<Vec<ChannelEvent>, String> {
-    let home = crate::mur_home_path();
-    let svc = ChannelService::open(&home).map_err(|e| e.to_string())?;
-    let Some(id) = svc.latest_for_agent(&name).map_err(|e| e.to_string())? else {
-        return Ok(vec![]);
+/// Events for hydration: the explicit `channel_id` when given, else the agent's
+/// latest channel (empty when the agent has none yet).
+fn load_channel_events(
+    home: &std::path::Path,
+    name: &str,
+    channel_id: Option<&str>,
+) -> anyhow::Result<Vec<ChannelEvent>> {
+    let svc = ChannelService::open(home)?;
+    let id = match channel_id {
+        Some(id) => id.to_string(),
+        None => match svc.latest_for_agent(name)? {
+            Some(id) => id,
+            None => return Ok(vec![]),
+        },
     };
-    svc.load_events(&id).map_err(|e| e.to_string())
+    svc.load_events(&id)
+}
+
+/// Tauri command: load channel events for hydration (see `load_channel_events`).
+#[tauri::command]
+pub async fn channel_load(
+    name: String,
+    channel_id: Option<String>,
+) -> Result<Vec<ChannelEvent>, String> {
+    let home = crate::mur_home_path();
+    load_channel_events(&home, &name, channel_id.as_deref()).map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -366,6 +392,7 @@ mod channel_tests {
         persist_exchange(
             tmp.path(),
             "qa",
+            None,
             "the question",
             Some("u-1"),
             "the answer",
@@ -385,8 +412,47 @@ mod channel_tests {
         assert_eq!(evs[1].payload["usage"]["route_reason"], "smart-background");
         assert!(evs[0].payload.get("usage").is_none());
         // A second exchange appends to the SAME channel, not a new one.
-        persist_exchange(tmp.path(), "qa", "q2", None, "a2", None, None);
+        persist_exchange(tmp.path(), "qa", None, "q2", None, "a2", None, None);
         assert_eq!(svc.list(10).unwrap().len(), 1);
         assert_eq!(svc.load_events(&id).unwrap().len(), 4);
+    }
+
+    #[test]
+    fn explicit_channel_id_wins_over_latest() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let old = svc.create_for_agent("qa").unwrap().id;
+        svc.append_message(
+            &old,
+            ChannelActor::local_human(),
+            EventKind::Message,
+            "old q",
+            None,
+        )
+        .unwrap();
+        let new = svc.create_for_agent("qa").unwrap().id;
+        svc.append_message(
+            &new,
+            ChannelActor::local_human(),
+            EventKind::Message,
+            "new q",
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            svc.latest_for_agent("qa").unwrap().as_deref(),
+            Some(new.as_str())
+        );
+
+        // Hydration: no id → latest; explicit id → that channel, even if older.
+        let latest = load_channel_events(tmp.path(), "qa", None).unwrap();
+        assert_eq!(latest[0].payload["text"], "new q");
+        let picked = load_channel_events(tmp.path(), "qa", Some(&old)).unwrap();
+        assert_eq!(picked[0].payload["text"], "old q");
+
+        // Persistence follows the same choice: the turn lands in the picked channel.
+        persist_exchange(tmp.path(), "qa", Some(&old), "q2", None, "a2", None, None);
+        assert_eq!(svc.load_events(&old).unwrap().len(), 3);
+        assert_eq!(svc.load_events(&new).unwrap().len(), 1);
     }
 }

--- a/mur-hub-gui/ui/src/components/ChatTab.tsx
+++ b/mur-hub-gui/ui/src/components/ChatTab.tsx
@@ -123,9 +123,11 @@ interface Props {
   displayName: string;
   /** Slot rendered between the message log and the composer (e.g. TaskPill). */
   aboveCompose?: React.ReactNode;
+  /** Channel picked in the chat window's rail; null/undefined = the agent's latest. */
+  channelId?: string | null;
 }
 
-export function ChatTab({ agentName, displayName, aboveCompose }: Props) {
+export function ChatTab({ agentName, displayName, aboveCompose, channelId }: Props) {
   const { t } = useT();
   const { drafts, clearDraft } = useConversations();
   const [messages, setMessages] = useState<ChatMsg[]>([]);
@@ -205,6 +207,7 @@ export function ChatTab({ agentName, displayName, aboveCompose }: Props) {
       try {
         const events = await invoke<ChannelEvent[]>("channel_load", {
           name: agentName,
+          channelId: channelId ?? null,
         });
         if (!alive) return;
         setMessages(channelEventsToMessages(events));
@@ -227,7 +230,10 @@ export function ChatTab({ agentName, displayName, aboveCompose }: Props) {
       alive = false;
       void unChannel.then((f) => f());
     };
-  }, [agentName]);
+    // ponytail: switching channel resets the agent context (taskIdRef) like an
+    // agent switch does; resuming the runtime conversation behind an older
+    // channel is the upgrade path.
+  }, [agentName, channelId]);
 
   // Subscribe to token deltas for this agent.
   useEffect(() => {
@@ -277,6 +283,7 @@ export function ChatTab({ agentName, displayName, aboveCompose }: Props) {
         text,
         taskId,
         contextTaskId: taskIdRef.current,
+        channelId: channelId ?? null,
       });
       taskIdRef.current = res.task_id || taskIdRef.current;
       // If Stop already committed the partial reply, don't append again.

--- a/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
+++ b/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
@@ -108,6 +108,7 @@ export function AgentChatWindow() {
           <ChatTab
             agentName={agentName}
             displayName={displayName}
+            channelId={activeChannelId}
             aboveCompose={<TaskPill agentName={agentName} />}
           />
         </div>

--- a/mur-hub-gui/ui/src/components/chat/ChatChannelRail.test.ts
+++ b/mur-hub-gui/ui/src/components/chat/ChatChannelRail.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { channelLabel } from "./ChatChannelRail";
+import type { ChannelSummary } from "../../work/types";
+
+const UUID = "019ed0af-5e38-7912-b554-dc335a8fc2db";
+const base: ChannelSummary = {
+  id: UUID, title: "", state: "working", goal: "", created_at: "", updated_at: "",
+  participants: [], agents: ["mur"], turns: 1, preview: "",
+};
+
+describe("channelLabel", () => {
+  it("shows the channel title, never the uuid", () => {
+    expect(channelLabel({ ...base, title: "install gitea for this mac" })).toBe("install gitea for this mac");
+  });
+  it("falls back to the preview line when the title is empty", () => {
+    expect(channelLabel({ ...base, preview: "find the bug" })).toBe("find the bug");
+  });
+  it("keeps the short fleet name for fleet channels without a title", () => {
+    expect(channelLabel({ ...base, id: "fleet-develop-rust" })).toBe("develop-rust");
+  });
+});

--- a/mur-hub-gui/ui/src/components/chat/ChatChannelRail.tsx
+++ b/mur-hub-gui/ui/src/components/chat/ChatChannelRail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { ChannelSummary } from "../../work/types";
+import { relativeTime } from "../../work/format";
 
 interface Props {
   agentName: string;
@@ -17,6 +18,12 @@ function agentChannels(channels: ChannelSummary[], agentName: string): ChannelSu
       c.id.startsWith(`${agentName}-`) ||
       c.id.startsWith(`fleet-`),
   );
+}
+
+/** What the rail prints for a channel: its title (the first message), else the
+ *  preview line, else the short id — a uuid tail is the last resort, not the label. */
+export function channelLabel(c: ChannelSummary): string {
+  return c.title || c.preview || shortName(c.id);
 }
 
 function shortName(id: string): string {
@@ -42,9 +49,13 @@ export function ChatChannelRail({ agentName, activeId, onSelect }: Props) {
 
   const fleetChs = channels.filter((c) => c.id.startsWith("fleet-"));
   const agentChs = channels.filter((c) => !c.id.startsWith("fleet-"));
+  // No pick yet = the agent's latest channel, which is what ChatTab hydrates;
+  // the list is newest-first, so highlight the first row rather than nothing.
+  const highlighted = activeId ?? agentChs[0]?.id ?? null;
+  const now = Date.now();
 
   function renderChannel(c: ChannelSummary) {
-    const isActive = c.id === activeId;
+    const isActive = c.id === highlighted;
     return (
       <button
         key={c.id}
@@ -53,7 +64,8 @@ export function ChatChannelRail({ agentName, activeId, onSelect }: Props) {
         title={c.title || c.id}
       >
         <span className="cw-rail__ch-hash">#</span>
-        <span className="cw-rail__ch-name">{shortName(c.id)}</span>
+        <span className="cw-rail__ch-name">{channelLabel(c)}</span>
+        <span className="cw-rail__ch-time">{relativeTime(c.updated_at, now)}</span>
         {c.turns > 0 && !isActive && (
           <span className="cw-rail__ch-badge">{c.turns > 99 ? "99+" : c.turns}</span>
         )}

--- a/mur-hub-gui/ui/src/styles/components/chat-window.css
+++ b/mur-hub-gui/ui/src/styles/components/chat-window.css
@@ -206,6 +206,12 @@
   text-overflow: ellipsis;
 }
 
+.cw-rail__ch-time {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
 .cw-rail__ch-badge {
   font-size: 10px;
   background: var(--color-brand);


### PR DESCRIPTION
## Summary
- **Clicking a rail channel did nothing**: the pick only reached the title bar; `ChatTab` always hydrated `latest_for_agent` and `agent_chat_send` persisted there too. Now `channel_load` / `agent_chat_send` take an optional `channel_id`, `ChatTab` accepts `channelId` and re-hydrates on change, `AgentChatWindow` threads the pick through. No pick = latest, so `ChatsPage` is unchanged.
- **Rail rows were uuid tails with no time**: `shortName("019ed0af-5e38-…")` → `5e38-7912-…`. Now `channelLabel` = title → preview → short id, plus `relativeTime(updated_at)` per row. Newest row is highlighted when nothing is picked (that is what ChatTab shows).

## Root cause
`ChatChannelRail.onSelect → setActiveChannelId` had a single consumer (title bar). Hydration and persistence both resolved the channel from the agent name alone.

## Tests
- Rust `chat::channel_tests::explicit_channel_id_wins_over_latest`: hydration and persistence both follow the explicit id over the latest.
- `ChatChannelRail.test.ts`: label never falls to the uuid when a title or preview exists.
- Local: `cargo fmt --check` 0, `cargo test --lib chat::` 4 passed, `cargo clippy --all-targets -D warnings` 0, `vitest run` 48 files / 304 passed, `tsc --noEmit` 0.
- **Not run**: the real Tauri window (no manual click-through). Please verify in the built Hub before release.

## Known ceiling
Switching channel resets the agent context (`taskIdRef`) the same way an agent switch does. Resuming the runtime conversation behind an older channel is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)