### PR TITLE
fix(murmur): approvals say which surface answered, and whether a human did

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1680,8 +1680,12 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
         // approval (#8) can offer a one-key re-run of the stranded request.
         let retry = app.last_sent.clone();
         let t = tx.clone();
+        // A keypress is the only branch a human actually answered; `auto` covers
+        // /auto, --auto-reads and session grants, which the audit trail must not
+        // report as a person sitting there.
+        let surface = if auto { "auto" } else { "cli" };
         tokio::spawn(async move {
-            if let Err(e) = respond_hitl(h, a, id, allow).await {
+            if let Err(e) = respond_hitl(h, a, id, allow, surface).await {
                 let msg = format!("{e:#}");
                 let out = match recover::classify_hitl_failure(&msg) {
                     // "approval expired" (new runtimes) / "task not found"
@@ -2723,19 +2727,22 @@ fn run_plain(
                     .get("tool_name")
                     .and_then(|v| v.as_str())
                     .unwrap_or("tool");
-                let allow = if auto {
+                // Second element is the audit attribution: only the interactive
+                // branch has a human at the keyboard, so every other branch says
+                // "auto" rather than claiming someone answered.
+                let (allow, surface) = if auto {
                     eprintln!("[non-interactive: auto-approving tool-approval request (--auto)]");
-                    true
+                    (true, "auto")
                 } else if auto_reads && bash_class::is_readonly_call(tool, hitl.get("tool_input")) {
                     // Same lane as the TUI, same classifier. This mode used to
                     // ignore `--auto-reads` outright, so the identical flag
                     // behaved differently depending on how the CLI was started
                     // — and plain mode is exactly where unattended runs live.
                     eprintln!("  [auto-approved read-only {tool} (--auto-reads)]");
-                    true
+                    (true, "auto")
                 } else if session_allow.borrow().contains(tool) {
                     eprintln!("  [auto-approved {tool} (session allow)]");
-                    true
+                    (true, "auto")
                 } else if interactive {
                     // Outer loop releases stdin lock between reads (Task 2), so
                     // we can safely acquire a fresh lock here to prompt the user.
@@ -2744,7 +2751,7 @@ fn run_plain(
                     let _ = o.flush();
                     let mut ans = String::new();
                     let _ = io::stdin().lock().read_line(&mut ans);
-                    match ans.trim().chars().next() {
+                    let allowed = match ans.trim().chars().next() {
                         // [a] now means what it says. It used to approve just
                         // this one call while the prompt promised "always".
                         Some('a' | 'A') => {
@@ -2753,18 +2760,19 @@ fn run_plain(
                         }
                         Some('y' | 'Y') => true,
                         _ => false,
-                    }
+                    };
+                    (allowed, "cli")
                 } else {
                     eprintln!(
                         "[non-interactive: auto-denying tool-approval request (use --auto to allow)]"
                     );
-                    false
+                    (false, "auto")
                 };
                 let _ = dial_method(
                     home,
                     agent,
                     "tool/hitl_respond",
-                    serde_json::json!({ "hitl_id": id, "allow": allow }),
+                    stream::hitl_respond_params(&id, allow, surface),
                     DialMode::RequireRunning,
                 );
             },

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -329,6 +329,22 @@ pub fn spawn_stream(
     });
 }
 
+/// Params for `tool/hitl_respond`.
+///
+/// `surface` is the audit attribution recorded on the signed `HitlResponse`
+/// (`mur_common::hitl::HitlResponse`): `"cli"` when a human answered the gate,
+/// `"auto"` when the session answered it for them (`--auto`, `--auto-reads`, a
+/// session-wide grant). Sending `"cli"` for a machine decision would claim a
+/// human was there, which is the class of lie spec §4.4 exists to prevent.
+///
+/// Omitting the field is not harmless either: the runtime defaults a missing
+/// surface to `"unknown"`, so the channel records that someone answered without
+/// recording who. Build the params here rather than inline so both CLI senders
+/// stay in step.
+pub(crate) fn hitl_respond_params(hitl_id: &str, allow: bool, surface: &str) -> serde_json::Value {
+    json!({ "hitl_id": hitl_id, "allow": allow, "surface": surface })
+}
+
 /// Answer a pending HITL request on a fresh connection. Does not block the
 /// streaming worker; the agent resumes once the runtime receives this.
 pub async fn respond_hitl(
@@ -336,13 +352,14 @@ pub async fn respond_hitl(
     agent: String,
     hitl_id: String,
     allow: bool,
+    surface: &'static str,
 ) -> Result<()> {
     tokio::task::spawn_blocking(move || {
         dial_method(
             &home,
             &agent,
             "tool/hitl_respond",
-            json!({ "hitl_id": hitl_id, "allow": allow }),
+            hitl_respond_params(&hitl_id, allow, surface),
             DialMode::RequireRunning,
         )
     })
@@ -440,6 +457,26 @@ fn extract_text(message: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hitl_respond_params_always_carry_a_surface() {
+        // The defect this guards: the CLI used to send only hitl_id and allow,
+        // so the runtime defaulted the surface to "unknown" and the signed
+        // channel could not say which surface answered.
+        for (allow, surface) in [(true, "cli"), (false, "cli"), (true, "auto")] {
+            let p = hitl_respond_params("h-1", allow, surface);
+            assert_eq!(p["hitl_id"], "h-1");
+            assert_eq!(p["allow"], allow);
+            assert_eq!(
+                p["surface"], surface,
+                "surface must be sent verbatim, never dropped"
+            );
+            assert!(
+                !p["surface"].is_null(),
+                "a missing surface is recorded as \"unknown\" by the runtime"
+            );
+        }
+    }
 
     #[test]
     fn build_params_threads_context() {


### PR DESCRIPTION
## Summary

Found while running the P3 chat-gate checklist on the real Hub (v2.74.0). Two approvals answered in the **murmur TUI** landed in the agent's chat-gate channel as **`surface: "unknown"`**, while every approval answered in the **Hub** carried `surface: "hub"`. Both were correctly signed — the channel just could not say who answered.

Cause: both CLI senders of `tool/hitl_respond` omitted the field, and the runtime defaults a missing surface to `"unknown"` (`mur-agent-runtime/src/hitl/batch.rs`). The Hub has passed `"hub"` since #1196; nothing passed one for the CLI. Design §4.4 exists precisely because the Hub used to sign as the CLI, so an unattributed decision is the same class of defect.

## What changed

- Both senders (`stream.rs`'s `respond_hitl` for the TUI, and the `--plain` path in `mod.rs`) now build their params through one `stream::hitl_respond_params`, so they cannot drift apart again.
- **`"cli"` only where a human answered.** The TUI already carried this as `decide_hitl_with_note`'s `auto` flag. The plain path's five branches now each return their own attribution: `--auto`, `--auto-reads`, a session-wide grant and the non-interactive auto-deny all report `"auto"`; only the interactive prompt reports `"cli"`. The field's documented vocabulary (`mur-common/src/hitl/mod.rs`) already allowed `"auto"`, and calling a machine decision `"cli"` would claim someone was at the keyboard.

## Test plan

- New unit test asserts the params always carry `surface`, verbatim.
- **Negative control:** removing `"surface"` from the builder fails it with `left: Null, right: "cli"`. Restoring it passes.
- `cargo nextest run -p mur-core` — 5778 passed.
- `cargo clippy -p mur-core --all-targets -- -D warnings` and `cargo fmt --check` clean.

Not covered by automated tests: the live channel write. Worth re-checking after merge that a murmur approval lands as `surface: "cli"` and an `/auto` one as `"auto"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)