### PR TITLE
test(hitl): defer-parks-immediately bound is 60 s, not 5 s — it guards the 300 s timeout, not latency

### DIFF
--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -832,8 +832,13 @@ mod tests {
         .unwrap();
 
         assert!(d.deferred && !d.allow, "parked, and never allowed");
+        // The bound separates "parked" from "sat out the 300 s timeout"; it is
+        // not a latency budget. 5 s tripped on a loaded Windows CI runner
+        // (8.04 s of keygen + file I/O under ~8k parallel tests) with the
+        // gate having parked correctly, so it is set well clear of that noise
+        // while still an order of magnitude under the timeout it guards.
         assert!(
-            t0.elapsed() < Duration::from_secs(5),
+            t0.elapsed() < Duration::from_secs(60),
             "must not wait out the gate timeout: {:?}",
             t0.elapsed()
         );


### PR DESCRIPTION
\`hitl::gate::tests::defer_parks_immediately_instead_of_waiting\` failed on #1207's Windows Test job: \`must not wait out the gate timeout: 8.04228s\`.

Not a regression: the first assertion (\`d.deferred && !d.allow\`) passed, and both \`Unanswered::Defer\` branches in \`gate()\` return before the poll loop's first \`sleep\` — there is no wait to have waited. 8 s was keygen + channel file I/O on a loaded runner running ~8k tests in parallel.

The bound's job is to distinguish "parked" from "sat out the 300 s timeout". 60 s does that with an order of magnitude to spare and stays clear of CI noise. Comment in the test records why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)