### PR TITLE
feat(hub): migrate macOS notifications to UNUserNotificationCenter

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -3595,9 +3595,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -6212,9 +6212,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom"
@@ -6299,6 +6299,24 @@ dependencies = [
  "objc2-foundation",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "mac-usernotifications"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08adbb1b9e11709f9ce628dd7471208e5dd3ad35a245dbc81e59a36dce3f3780"
+dependencies = [
+ "block2",
+ "futures-channel",
+ "futures-lite",
+ "futures-timer",
+ "log",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-user-notifications",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6834,6 +6852,7 @@ dependencies = [
  "mur-core",
  "mur-gui-core",
  "notify",
+ "notify-rust",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -7039,6 +7058,7 @@ dependencies = [
  "futures-lite",
  "log",
  "mac-notification-sys",
+ "mac-usernotifications",
  "serde",
  "tauri-winrt-notification",
  "zbus",
@@ -7237,7 +7257,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -7376,7 +7398,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
+ "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-core-location",
  "objc2-foundation",
 ]
 

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -33,6 +33,11 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-notification = "2"
+# Only pulled in by `macos-un-notifications`. tauri-plugin-notification does not
+# forward notify-rust's features, so the switch has to be made on the shared
+# dependency: Cargo unifies features across the graph, so enabling it here also
+# swaps the backend the plugin compiles against.
+notify-rust = { version = "4.18", optional = true, default-features = false }
 notify = "6"
 
 # Workspace siblings — reused from the root repo via relative path.
@@ -62,6 +67,15 @@ core-foundation = "0.10"
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+# Post macOS notifications through UNUserNotificationCenter instead of the
+# deprecated NSUserNotification (issue #1135). OFF by default and deliberately
+# so: upstream still labels this backend a preview, its `mac-usernotifications`
+# dependency is 0.3.x, and UN adds a failure mode NS does not have — the user
+# can deny authorization, or revoke it later in System Settings. Flipping the
+# default is a product decision, not a dependency chore; this flag exists so
+# the decision can be tried against a real build first.
+macos-un-notifications = ["dep:notify-rust", "notify-rust/preview-macos-un"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -65,16 +65,21 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signa
 core-foundation = "0.10"
 
 [features]
-default = ["custom-protocol"]
+default = ["custom-protocol", "macos-un-notifications"]
 custom-protocol = ["tauri/custom-protocol"]
 
 # Post macOS notifications through UNUserNotificationCenter instead of the
-# deprecated NSUserNotification (issue #1135). OFF by default and deliberately
-# so: upstream still labels this backend a preview, its `mac-usernotifications`
-# dependency is 0.3.x, and UN adds a failure mode NS does not have — the user
-# can deny authorization, or revoke it later in System Settings. Flipping the
-# default is a product decision, not a dependency chore; this flag exists so
-# the decision can be tried against a real build first.
+# deprecated NSUserNotification (issue #1135). ON by default.
+#
+# The cost this buys is real and is handled in `macos_un.rs`: UN will not post
+# until the user has been asked, and the answer can be no — at the prompt, or
+# later in System Settings. The Hub asks once per launch and names that state
+# when a post fails, which is also the detection point the issue wanted: on the
+# old backend nothing could tell us why a notification never arrived.
+#
+# Turn it OFF (`--no-default-features --features custom-protocol`) to fall back
+# to NSUserNotification. Upstream still labels the UN backend a preview and
+# `mac-usernotifications` is 0.3.x, so the way back should stay one flag away.
 macos-un-notifications = ["dep:notify-rust", "notify-rust/preview-macos-un"]
 
 [dev-dependencies]

--- a/mur-hub-gui/src-tauri/src/companion_notify.rs
+++ b/mur-hub-gui/src-tauri/src/companion_notify.rs
@@ -144,7 +144,19 @@ fn raise(app: &AppHandle, mur_home: &Path, e: &InboxEntry, missed: bool) {
                 tracing::warn!("notified {} but could not record it: {err:#}", e.id);
             }
         }
-        Err(err) => tracing::warn!("could not show notification for {}: {err:#}", e.id),
+        Err(err) => {
+            // A bare transport error is what issue #1135 called unhelpful: it
+            // says the call failed, never that the user revoked permission.
+            // Query the real authorization state and quote it when it explains
+            // the failure. Returns None on the old backend, which has no such
+            // API — the message then reads exactly as it did before.
+            match crate::macos_un::authorization_note() {
+                Some(note) => {
+                    tracing::warn!("could not show notification for {}: {err:#} — {note}", e.id)
+                }
+                None => tracing::warn!("could not show notification for {}: {err:#}", e.id),
+            }
+        }
     }
 }
 

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod geometry;
 pub mod hitl;
 pub mod import_muragent;
 mod install_inbox;
+pub mod macos_un;
 pub mod mcp_skills;
 pub mod memory;
 pub mod mlx_sidecar;
@@ -361,6 +362,12 @@ pub fn run() {
             // long-lived runtime. Mirrors the guard around `Supervisor::new` above.
             let rt_handle = tauri::async_runtime::handle();
             let _rt_guard = rt_handle.inner().enter();
+
+            // UN will not post until the user has been asked, and the answer can
+            // be no. Ask once per launch — macOS prompts the first time and
+            // replays the stored answer afterwards. No-op unless the UN backend
+            // is compiled in (issue #1135).
+            crate::macos_un::request_authorization_once();
 
             // Start agent discovery (filesystem scan).
             let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());

--- a/mur-hub-gui/src-tauri/src/macos_un.rs
+++ b/mur-hub-gui/src-tauri/src/macos_un.rs
@@ -1,0 +1,85 @@
+//! Authorization surface for the UNUserNotificationCenter backend (issue #1135).
+//!
+//! `NSUserNotification` needed none of this: it posted, and the app appeared in
+//! Notifications settings afterwards. UN will not post until the user has been
+//! asked, and the answer can be **no** — at the prompt, or later in System
+//! Settings. That is the failure mode the migration buys, so it has to be
+//! visible rather than presenting as notifications that quietly stop.
+//!
+//! Two entry points, both no-ops when the backend is not compiled in, so the
+//! call sites carry no `cfg`:
+//!
+//! - [`request_authorization_once`] at startup — macOS prompts the first time
+//!   and replays the stored answer afterwards, so this is safe to call on
+//!   every launch.
+//! - [`authorization_note`] when a send fails — turns "could not show
+//!   notification" into a line that names the permission, which is the whole
+//!   complaint behind the sibling MCP issue (#1161) in a different subsystem.
+
+#[cfg(all(target_os = "macos", feature = "macos-un-notifications"))]
+mod imp {
+    /// Ask macOS for permission to post, once per launch, off the main thread.
+    ///
+    /// Spawned rather than awaited: Tauri's `setup` runs on the thread that is
+    /// about to drive the UI, and the authorization completion handler fires on
+    /// an Apple-internal queue, so blocking here would stall the window for no
+    /// gain. Nothing downstream needs the answer synchronously — a send that
+    /// races the prompt fails and is retried on the next inbox sweep.
+    pub fn request_authorization_once() {
+        std::thread::spawn(|| match notify_rust::request_auth_blocking() {
+            Ok(true) => tracing::info!("macOS notification authorization granted"),
+            // Not an error: the user is allowed to say no. Say it once, at warn,
+            // so a later "notifications never arrive" report has a first line to
+            // search for.
+            Ok(false) => tracing::warn!(
+                "macOS notification authorization DENIED — the Hub cannot post \
+                 notifications until it is allowed in System Settings › \
+                 Notifications › MUR Hub"
+            ),
+            Err(e) => tracing::warn!("could not request macOS notification authorization: {e}"),
+        });
+    }
+
+    /// A human-readable reason a notification may not have been delivered, or
+    /// `None` when authorization is not the explanation.
+    ///
+    /// This is the detection point issue #1135 asked for. `show()` returning
+    /// `Ok` never meant "the user saw it", and on the old backend there was no
+    /// API that could tell us otherwise; UN reports the real state, so a failed
+    /// send can finally name a permission instead of a bare error.
+    pub fn authorization_note() -> Option<String> {
+        match notify_rust::get_notification_settings_blocking() {
+            Ok(s) => {
+                // Debug string rather than the enum: notify-rust re-exports the
+                // functions but not `AuthorizationStatus`, and mac-usernotifications
+                // is not a direct dependency, so the type cannot be named here.
+                let status = format!("{:?}", s.authorization_status);
+                // Only the two states that actually stop delivery. Provisional
+                // and Ephemeral both post — quoting them would blame the
+                // permission for a failure it did not cause.
+                let blocking = status.contains("Denied") || status.contains("NotDetermined");
+                blocking.then(|| {
+                    format!(
+                        "macOS notification authorization is {status} — allow MUR Hub in \
+                         System Settings › Notifications"
+                    )
+                })
+            }
+            Err(e) => Some(format!("could not read macOS notification settings: {e}")),
+        }
+    }
+}
+
+#[cfg(not(all(target_os = "macos", feature = "macos-un-notifications")))]
+mod imp {
+    /// No-op: the deprecated `NSUserNotification` backend has no authorization
+    /// step, and neither do Linux or Windows.
+    pub fn request_authorization_once() {}
+
+    /// No-op: without UN there is no API that can report why a post failed.
+    pub fn authorization_note() -> Option<String> {
+        None
+    }
+}
+
+pub use imp::{authorization_note, request_authorization_once};


### PR DESCRIPTION
Closes #1135.

## What the issue asked for first

> Whether a newer `notify-rust` / `mac-notification-sys` already migrated — crates.io was unreachable from this environment. **That is the first thing to check.**

Checked. **Upstream shipped it, in a version we already resolve to.** notify-rust PR hoodie/notify-rust#280 merged 2026-06-14 and landed in **4.18.0**. `src/macos/mod.rs` picks the backend with `#[cfg(feature = "preview-macos-un")]`, so the objc bindings, authorization flow and three-platform `cfg` split the issue costed out are not the work any more. It re-exports `request_auth` / `get_notification_settings` / `check_bundle` too, so the permission surface is not written from scratch either.

`mac-notification-sys` itself has **not** migrated: 0.6.15 is newest, still 27 references to `NSUserNotification` and zero to `UNUserNotificationCenter`, tracking issue open since 2019. The escape came from notify-rust adopting a different crate.

## What this does

Migrates, **on by default**, and handles what the issue correctly said the migration costs.

`macos_un.rs`:

- **Asks once per launch**, on a spawned thread. Tauri's `setup` runs on the thread about to drive the UI and the authorization callback fires on an Apple-internal queue, so blocking there would stall the window for nothing. macOS prompts the first time and replays the stored answer after.
- **A denial is logged once at warn**, so "notifications stopped arriving" has a first line to search for.
- **A failed post names the permission.** This is also the detection point the issue asked for — `show()` returning `Ok` never meant the user saw it, and NS had no API that could say otherwise. Only `Denied` and `NotDetermined` produce the note: `Provisional` and `Ephemeral` both deliver, and quoting them would blame the permission for a failure it did not cause.

**An unbundled run does not crash.** `check_bundle`'s own docs warn that UNUserNotificationCenter crashes without a bundle identifier, but `send_blocking` calls `check_bundle()?` first, so `tauri dev` gets an `Err` from `show()` — which `raise()` already handles without marking the entry seen.

**The way back is one flag.** `--no-default-features --features custom-protocol` restores NSUserNotification. Upstream still labels the UN backend a preview and `mac-usernotifications` is 0.3.x, so that exit should stay cheap.

## Mechanism

`tauri-plugin-notification` does not forward notify-rust's features (its only feature is `windows7-compat`), so the switch is made on the **shared dependency**: Cargo unifies features across the graph, so enabling it on our direct `notify-rust` swaps the backend the plugin itself compiles against.

## Lockfile

Two stale pins blocked resolution **even with the feature off**, since an optional dependency still resolves. `mac-usernotifications` needs `futures-timer ^3.0.4` (we held 3.0.3 via `governor`) and `log ^0.4.32` (we held 0.4.29). Both sat inside the existing requirements. Three packages move, 284 untouched.

## Test plan

- `cargo check` clean with the default (UN) **and** with `--no-default-features --features custom-protocol` (NS), so neither path rots.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- The compiler is the real check on the swap: `notify_rust::request_auth_blocking` exists only under `preview-macos-un`, so `macos_un.rs` cannot compile against the old backend.

**Not verified, and it needs a person.** Nothing here proves a notification reaches a screen. On a signed `.app` this should be run once: first launch prompts, granting posts a companion notification, then denying in System Settings should make the next attempt log the authorization line rather than a bare error. That is the one behaviour automated checks cannot reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)