### PR TITLE
feat(mcp): servers can declare the state paths they write, and get them

### DIFF
--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -348,6 +348,23 @@ pub struct McpServerEntry {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires_programs: Vec<ProgramDep>,
 
+    /// Paths this server writes state into at runtime, declared at install
+    /// time so the sandbox can be told about them (issue #1161).
+    ///
+    /// Distinct from everything above: `command`, `args` and `package`
+    /// describe how the server is *launched*, and #1158 already syncs what the
+    /// rewritten launch line needs. These are what the server touches once it
+    /// is running — a property of the server, not of the command MUR rewrote.
+    /// `@wonderwhy-er/desktop-commander` wants three of them under `$HOME` and
+    /// exits 1 before answering `initialize` without them.
+    ///
+    /// Granted read+write, and **created if missing** at install time. The
+    /// sandbox drops entitlement paths that do not exist when the profile is
+    /// sealed, so granting a directory the server has not created yet would be
+    /// accepted and still denied by the kernel — see `reject_dead_grant`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub state_paths: Vec<String>,
+
     /// Vendored package this entry launches, when MUR installed it itself.
     ///
     /// Present only for entries moved off a package runner by

--- a/mur-core/src/agent_admin/mcp.rs
+++ b/mur-core/src/agent_admin/mcp.rs
@@ -16,6 +16,7 @@ pub fn add(name: &str, server_id: &str, command: &str, args: &[String]) -> Resul
         server_id,
         command,
         args,
+        &[],
         agent::McpAddPin {
             force: true,
             ..Default::default()

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -951,6 +951,12 @@ pub enum AgentMcpAction {
         /// start with `-`/`--`, e.g. `--arg --engine` or `--arg=--engine`.
         #[arg(long = "arg", allow_hyphen_values = true)]
         args: Vec<String>,
+        /// A directory this server writes state into at runtime (repeatable).
+        /// Created if missing, then granted read+write. Many MCP servers put
+        /// config, logs or a device id under $HOME on first launch and exit
+        /// before answering `initialize` when the sandbox denies it.
+        #[arg(long = "state-path")]
+        state_paths: Vec<String>,
         /// Skip the y/N install confirmation prompt (B0 rule 6 / M9.2).
         /// Use for scripted / non-interactive installs.
         #[arg(long)]

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -346,6 +346,7 @@ mod tests {
                 url: None,
                 auth: None,
                 requires_programs: Vec::new(),
+                state_paths: Vec::new(),
                 package: None,
             });
         }

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -83,6 +83,7 @@ pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> 
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        state_paths: Vec::new(),
         package: None,
     });
     if !profile

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -63,6 +63,7 @@ pub fn cmd_mcp_add(
     server_id: &str,
     command: &str,
     args: &[String],
+    state_paths: &[String],
     pin: McpAddPin,
 ) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(name)?;
@@ -161,6 +162,7 @@ pub fn cmd_mcp_add(
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        state_paths: state_paths.to_vec(),
         package: None,
     });
     // Sync spawn allowlist so the supervisor is permitted to launch this MCP.
@@ -179,7 +181,46 @@ pub fn cmd_mcp_add(
             .allowed
             .push(command.to_string());
     }
+    grant_state_paths(name, &mut profile, state_paths)?;
     save_profile(&path, &mut profile)
+}
+
+/// Create each declared state path if missing, then grant read+write on it.
+///
+/// Creation is the point, not a convenience. `SandboxPolicy::from_entitlements`
+/// drops entitlement paths that do not exist when the profile is sealed, and
+/// the servers this exists for create their state on FIRST launch — which is
+/// the launch that gets denied. Granting a path that is not there yet would be
+/// accepted here and still return EPERM, which is the failure #1161 is about.
+///
+/// Grants go through the same guards as `mur agent perm allow-write`: the
+/// launch chain can never be granted, and neither can a home or volume root.
+/// A declared path is a claim by a server author, so it gets no more trust
+/// than a path the user typed.
+fn grant_state_paths(
+    agent: &str,
+    profile: &mut mur_common::AgentProfile,
+    state_paths: &[String],
+) -> Result<()> {
+    for raw in state_paths {
+        let expanded = mur_agent_runtime::sandbox::policy::expand_entitlement_path(raw);
+        crate::cmd::agent::perm::reject_ungrantable_path(agent, raw, true)?;
+        if !expanded.exists() {
+            std::fs::create_dir_all(&expanded)
+                .with_context(|| format!("create declared state path {}", expanded.display()))?;
+            println!("  created {}", expanded.display());
+        }
+        for list in [
+            &mut profile.entitlements.filesystem.read,
+            &mut profile.entitlements.filesystem.write,
+        ] {
+            if !list.iter().any(|p| p == raw) {
+                list.push(raw.clone());
+            }
+        }
+        println!("  granted read+write on {raw}");
+    }
+    Ok(())
 }
 
 pub fn cmd_mcp_remove(name: &str, server_id: &str) -> Result<()> {
@@ -445,6 +486,52 @@ pub fn cmd_mcp_add_remote(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A declared state path must be CREATED, not just listed. The sandbox
+    /// drops entitlement paths that are missing when the profile is sealed, so
+    /// a grant on a directory the server has not made yet is accepted here and
+    /// still returns EPERM — which is the failure #1161 is about, reintroduced
+    /// by the feature meant to fix it.
+    #[test]
+    fn a_declared_state_path_is_created_and_granted_read_and_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let want = tmp.path().join("dot-server-state");
+        assert!(!want.exists(), "fixture must start absent");
+        let raw = want.display().to_string();
+
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        grant_state_paths("agent", &mut profile, std::slice::from_ref(&raw)).unwrap();
+
+        assert!(
+            want.exists(),
+            "the path the sandbox will look for must exist"
+        );
+        assert!(
+            profile.entitlements.filesystem.read.contains(&raw),
+            "read grant missing"
+        );
+        assert!(
+            profile.entitlements.filesystem.write.contains(&raw),
+            "write grant missing"
+        );
+    }
+
+    /// A state path is a claim by a server author, so it gets no more trust
+    /// than a path the user typed: the same guard that stops
+    /// `perm allow-write ~` has to stop this too.
+    #[test]
+    fn a_declared_state_path_cannot_smuggle_in_an_overbroad_grant() {
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        let err = grant_state_paths("agent", &mut profile, &["~".to_string()]).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("too broad"),
+            "home directory must be refused, got: {err:#}"
+        );
+        assert!(
+            profile.entitlements.filesystem.write.is_empty(),
+            "a refused path must leave no grant behind"
+        );
+    }
     use std::sync::Mutex;
 
     /// Serialize tests that mutate the `MUR_HOME` env var to avoid races.
@@ -549,6 +636,7 @@ mod tests {
             "carol",
             "echo-srv",
             "true",
+            &[],
             &[],
             McpAddPin {
                 force: true,
@@ -672,6 +760,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            state_paths: vec![],
             package: None,
         };
         let output = render_server_line(&server);
@@ -700,6 +789,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            state_paths: vec![],
             package: None,
         };
         let output = render_server_line(&server);
@@ -728,6 +818,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            state_paths: vec![],
             package: None,
         };
         let output = render_server_line(&server);
@@ -751,6 +842,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            state_paths: vec![],
             package: None,
         };
         let output = render_server_line(&server);

--- a/mur-core/src/cmd/agent/mcp_registry.rs
+++ b/mur-core/src/cmd/agent/mcp_registry.rs
@@ -166,6 +166,7 @@ pub async fn cmd_mcp_registry_add(agent: &str, server_name: &str, force: bool) -
             &id,
             &command,
             &args,
+            &[],
             McpAddPin {
                 force,
                 publisher_name: Some("mcp-registry".to_string()),

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -251,6 +251,10 @@ fn reject_dead_grant(path_arg: &str) -> Result<()> {
 ///
 /// Distinct from `reject_dead_grant`, which refuses a path that does not exist
 /// yet. This one refuses paths that must never be granted at all.
+pub(crate) fn reject_ungrantable_path(name: &str, path_arg: &str, write: bool) -> Result<()> {
+    reject_ungrantable(name, path_arg, write)
+}
+
 fn reject_ungrantable(name: &str, path_arg: &str, write: bool) -> Result<()> {
     use mur_agent_runtime::sandbox::launch_chain::{LaunchChain, is_overbroad_grant_root};
 

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -203,6 +203,7 @@ pub fn build_pinned_entry(
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        state_paths: Vec::new(),
         package: None,
     }
 }

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -144,6 +144,7 @@ pub(crate) fn provision_one(
         GATEWAY_MCP_NAME,
         GATEWAY_MCP_COMMAND,
         &[],
+        &[],
         McpAddPin {
             force: true,
             ..Default::default()

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1652,6 +1652,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 command,
                 args,
                 force,
+                state_paths,
                 publisher_name,
                 publisher_homepage,
                 publisher_registry_id,
@@ -1660,6 +1661,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 &server_id,
                 &command,
                 &args,
+                &state_paths,
                 cmd::agent::McpAddPin {
                     force,
                     publisher_name,

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -76,6 +76,9 @@ pub fn agent_mcp_add(
         server_id,
         command,
         &args,
+        // No state paths: the Hub's add form has no field for them yet, and an
+        // empty list is exactly what every server that keeps no state wants.
+        &[],
         McpAddPin {
             force: true,
             ..Default::default()


### PR DESCRIPTION
Closes #1161 — the P2 the issue left optional. P0 shipped in #1162, P1 in #1212.

## Why P2 after all

The issue said P2 was *"only worth it if P0+P1 turn out not to be enough in practice; a good error message may be the whole fix."* P0 and P1 make the failure legible — the EACCES path is quoted, and `inspect --probe` now reproduces it under the agent's real sandbox. Neither grants anything. An operator still has to read the path out of an error and type an `allow-write` for it, every time, for every server that keeps state under `$HOME`.

## What this adds

`McpServerEntry.state_paths`, declared at install time with `mur agent mcp add --state-path <dir>` (repeatable).

**They are created if missing.** That is the load-bearing part, not a convenience: `SandboxPolicy::from_entitlements` drops entitlement paths that do not exist when the profile is sealed, and the servers this exists for create their state on *first* launch — the launch that gets denied. Granting a directory that is not there yet would be accepted and still return EPERM, which is the failure this issue is about, reintroduced by the feature meant to fix it. `reject_dead_grant` already documents this for hand-typed grants.

**They get no extra trust.** A declared path is a claim by a server author, not by the user, so it goes through the same guard as `perm allow-write`: the launch chain can never be granted, and neither can a home or volume root.

## Compatibility

`#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so existing profiles load and round-trip unchanged. Four exhaustive struct literals needed the new field; the rest use `..Default::default()`.

`mur-hub-gui` is workspace-excluded and holds four more literals that `cargo check --workspace` cannot see. Checked separately — it compiles, because its literals use `..Default::default()`.

## Test plan

- The declared path is created and granted read **and** write.
- `~` is refused and leaves no grant behind, so the feature cannot smuggle past the guard that stops `perm allow-write ~`.
- `cargo nextest run -p mur-core -p mur-common` — 6759 passed.
- `cargo check --workspace --all-targets` clean; Hub crate checked separately; clippy `-D warnings` and fmt clean.

Not done: `mcp vendor` does not re-apply state paths, and no built-in server declares any yet. Both want a real server that needs them, which is the evidence the issue asked for before building this at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)