### PR TITLE
chore(release): bump workspace version to 2.76.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.75.0"
+version = "2.76.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.75.0"
+version = "2.76.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Merging this **is** the release: `tag.yml` tags `v2.76.0` on the merge commit and dispatches `release.yml`, which publishes to crates.io. Review this PR as the release approval — there is no later gate.

Thirteen commits since v2.75.0.

**murmur (the chat TUI)**
- #1219 — every slash command completes, with arguments read from the agent: `/effort` offers the levels its model actually has, `/model` your registry aliases, `/secret` the keys it holds, `/forget` its own notes. Six commands reached the menu for the first time.
- #1216 — the welcome survives slash commands (the mascot no longer vanishes into a blank page), and a rule now marks only a change of speaker.
- #1210, #1208 — the approval gate cannot page over a row you never saw; approvals record which surface answered and whether a human did.

**Permissions, MCP, telemetry**
- #1215 — `perm list-paths` shows the launch-chain denies it was hiding.
- #1214 — MCP servers can declare the state paths they write, and get them.
- #1212 — `mcp inspect --probe` spawns under the agent's own sandbox.
- #1213 — tool calls report the time they actually took.

**Hub**
- #1211 — macOS notifications migrate to `UNUserNotificationCenter`.
- #1217 — the README hero screenshot is Hub 2.0.

Docs: #1218, #1220, and mur-server#80 (already live on app.mur.run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)