### PR TITLE
fix(hub-gui): Claude Subscription aliases are anthropic_, not chatgpt_

### DIFF
--- a/mur-hub-gui/ui/src/components/SubscriptionProviderPanel.tsx
+++ b/mur-hub-gui/ui/src/components/SubscriptionProviderPanel.tsx
@@ -21,7 +21,7 @@ import {
   type SubscriptionDescriptor,
 } from "./modelLibraryHelpers";
 import {
-  defaultChatGPTAlias,
+  defaultSubscriptionAlias,
   deriveSubscriptionState,
   gatewayProblem,
   type ChatGPTAccount,
@@ -246,6 +246,7 @@ export function SubscriptionProviderPanel({
           busy={busy}
           picks={picks}
           aliases={aliases}
+          aliasPrefix={descriptor.aliasPrefix}
           registrySet={registrySet}
           manualId={manualId}
           onToggle={(id) => setPicks(togglePick(picks, id))}
@@ -256,7 +257,7 @@ export function SubscriptionProviderPanel({
             addPicks(
               [...picks].map((id) => ({
                 model: id,
-                alias: aliases[id]?.trim() || defaultChatGPTAlias(id),
+                alias: aliases[id]?.trim() || defaultSubscriptionAlias(id, descriptor.aliasPrefix),
                 verified: true,
               })),
             )
@@ -265,7 +266,7 @@ export function SubscriptionProviderPanel({
             addPicks([
               {
                 model: manualId.trim(),
-                alias: defaultChatGPTAlias(manualId),
+                alias: defaultSubscriptionAlias(manualId, descriptor.aliasPrefix),
                 verified: false,
               },
             ])
@@ -468,6 +469,7 @@ function ModelSection({
   busy,
   picks,
   aliases,
+  aliasPrefix,
   registrySet,
   manualId,
   onToggle,
@@ -482,6 +484,7 @@ function ModelSection({
   busy: boolean;
   picks: Set<string>;
   aliases: Record<string, string>;
+  aliasPrefix: string;
   registrySet: Set<string>;
   manualId: string;
   onToggle: (id: string) => void;
@@ -538,7 +541,7 @@ function ModelSection({
         <ul className="ml-mlist" role="group" aria-label={t(copy.modelsTitle)}>
           {state.models.map((m) => {
             const sel = picks.has(m.id);
-            const alias = aliases[m.id] ?? defaultChatGPTAlias(m.id);
+            const alias = aliases[m.id] ?? defaultSubscriptionAlias(m.id, aliasPrefix);
             return (
               <li key={m.id} className={`ml-mrow${sel ? " ml-mrow--sel" : ""}`}>
                 <label className="ml-mrow__pick">

--- a/mur-hub-gui/ui/src/components/chatgptSubscription.test.ts
+++ b/mur-hub-gui/ui/src/components/chatgptSubscription.test.ts
@@ -3,7 +3,7 @@ import {
   CHATGPT_READINESS,
   CLAUDE_READINESS,
   billingLabel,
-  defaultChatGPTAlias,
+  defaultSubscriptionAlias,
   deriveChatGPTState,
   deriveSubscriptionState,
   gatewayProblem,
@@ -11,6 +11,7 @@ import {
   type ChatGPTStateInput,
   type GatewayStatus,
 } from "./chatgptSubscription";
+import { CHATGPT_SUBSCRIPTION, CLAUDE_SUBSCRIPTION } from "./modelLibraryHelpers";
 
 const chatgpt: ChatGPTAccount = {
   cli_present: true,
@@ -109,10 +110,18 @@ describe("billingLabel", () => {
   });
 });
 
-describe("defaultChatGPTAlias", () => {
-  it("slugs the model id under a chatgpt_ prefix", () => {
-    expect(defaultChatGPTAlias("gpt-5.6-sol")).toBe("chatgpt_gpt_5_6_sol");
-    expect(defaultChatGPTAlias("  GPT-5.6 Mini  ")).toBe("chatgpt_gpt_5_6_mini");
+describe("defaultSubscriptionAlias", () => {
+  it("slugs the model id under the chatgpt_ prefix by default", () => {
+    expect(defaultSubscriptionAlias("gpt-5.6-sol")).toBe("chatgpt_gpt_5_6_sol");
+    expect(defaultSubscriptionAlias("  GPT-5.6 Mini  ")).toBe("chatgpt_gpt_5_6_mini");
+  });
+
+  it("uses the descriptor prefix, so Claude models are never chatgpt_", () => {
+    expect(defaultSubscriptionAlias("claude-opus-4-6", CLAUDE_SUBSCRIPTION.aliasPrefix)).toBe(
+      "anthropic_claude_opus_4_6",
+    );
+    expect(CHATGPT_SUBSCRIPTION.aliasPrefix).toBe("chatgpt");
+    expect(CLAUDE_SUBSCRIPTION.aliasPrefix).toBe("anthropic");
   });
 });
 

--- a/mur-hub-gui/ui/src/components/chatgptSubscription.ts
+++ b/mur-hub-gui/ui/src/components/chatgptSubscription.ts
@@ -137,13 +137,17 @@ export function billingLabel(mode?: BillingMode | string | null): BillingLabel {
   }
 }
 
-/** The registry alias a picked model gets by default: `chatgpt_<slug>`. */
-export function defaultChatGPTAlias(modelId: string): string {
+/**
+ * The registry alias a picked model gets by default: `<prefix>_<slug>`.
+ * The prefix names the vendor behind the subscription — `chatgpt` for Codex,
+ * `anthropic` for Claude Code — so it comes from the descriptor, never hard-coded.
+ */
+export function defaultSubscriptionAlias(modelId: string, prefix = "chatgpt"): string {
   const slug = modelId
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
-  return `chatgpt_${slug}`;
+  return `${prefix}_${slug}`;
 }
 
 export type PaidFallbackWarning =

--- a/mur-hub-gui/ui/src/components/modelLibraryHelpers.ts
+++ b/mur-hub-gui/ui/src/components/modelLibraryHelpers.ts
@@ -139,6 +139,8 @@ export interface SubscriptionDescriptor {
   logo: string;
   color: string;
   readiness: GatewayReadiness;
+  /** Prefix for default registry aliases — the vendor, not the CLI. */
+  aliasPrefix: string;
   commands: {
     accountRead: string;
     modelsList: string;
@@ -159,6 +161,7 @@ export const CHATGPT_SUBSCRIPTION: SubscriptionDescriptor = {
   logo: "GPT",
   color: "#10A37F",
   readiness: CHATGPT_READINESS,
+  aliasPrefix: "chatgpt",
   commands: {
     accountRead: "chatgpt_account_read",
     modelsList: "chatgpt_models_list",
@@ -199,6 +202,7 @@ export const CLAUDE_SUBSCRIPTION: SubscriptionDescriptor = {
   logo: "CL",
   color: "#C5694A",
   readiness: CLAUDE_READINESS,
+  aliasPrefix: "anthropic",
   commands: {
     accountRead: "claude_account_read",
     modelsList: "claude_models_list",


### PR DESCRIPTION
Claude Subscription models were rendering with a `chatgpt_` alias prefix. The prefix now comes from the descriptor: `aliasPrefix: "anthropic"`, so the library shows `anthropic_claude_opus_4_6`.

**Not verified:** vitest could not run in this sandbox (`node_modules/.bin/vitest: /usr/bin/env: bad interpreter: Operation not permitted`). Please run the suite in CI before merging.

Existing registry entries named `chatgpt_claude_*` are not renamed by this change.