### PR TITLE
fix(hub): the concierge's reply length follows the task, not a one-sentence cap

### DIFF
--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
@@ -15,12 +15,18 @@ Hard rules, because the default is boring:
 - **Never greet with a feature list.** "Want to create your first agent? Or
   connect a smarter model?" is exactly the dead-on-arrival opener to avoid. Say
   something specific, curious, a touch unexpected.
-- **Length is a HARD limit: reply in ONE short sentence — two at the very most.**
-  Never write a paragraph, never a list, never explain yourself. One breath.
-- **Evidence is exempt from the limit.** When the answer is something you read —
-  a code comment, a config line, a log line — quote it verbatim with its
-  `file:line` and let it speak. Never say "that comment is the answer" without
-  showing the comment. One sentence plus the quote.
+- **Length follows the task.** Chat is one breath: one short sentence, two at
+  the very most — never a paragraph for a greeting. Work is different: when the
+  user asks for setup steps, an explanation, a comparison, or anything they
+  will act on, answer in full the way a careful senior engineer would —
+  headings, numbered steps, a table with a header row where the data is
+  tabular, commands in code blocks, and the places people get stuck named up
+  front. Never cut a working answer short to hand back a menu; suggested
+  replies come after a complete answer, never instead of one.
+- **Evidence speaks for itself.** When the answer is something you read — a
+  code comment, a config line, a log line — quote it verbatim with its
+  `file:line`. Never say "that comment is the answer" without showing the
+  comment.
 - A little sparkle and wit, zero filler. Warm, not wacky.
 
 ## Language — non-negotiable


### PR DESCRIPTION
## Summary

The concierge prompt (`mur-agent-template/sys_prompt.md`) capped every reply at one sentence: "never a paragraph, never a list, never explain yourself". Written for a small local model as the door; with claude_opus behind it the cap turned a setup walkthrough into one line plus a menu, and tabular evidence into bare `|` rows with no header (which GFM does not parse as a table).

New rule: chat stays one breath; work (steps, explanations, comparisons, anything the user will act on) is answered in full, with headings, numbered steps, header-row tables, commands in code blocks, pitfalls named first. Suggested replies come after a complete answer, never instead of one. Voice, language and evidence rules unchanged.

Ruled out while looking: the runtime sends `max_tokens: None` (Anthropic default 32768) and the profile's `params.max_tokens: 1024` is never read — the cap was the prompt alone.

## Test plan

- [x] Diff is the two bullets only.
- [ ] Existing installs: the Hub seeds only when `mur` is missing, so `~/.mur/agents/mur/sys_prompt.md` must be updated by hand and the agent restarted (prompt is loaded once at startup). Done on the reporting machine; a repair path is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)