### PR TITLE
feat(murmur): auto-approve is the session default; --ask opts back into ask-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,9 @@ Agent** wizard offers the same catalog as a source.
 
 - **Kernel sandbox** per OS — Landlock + seccomp (Linux), SBPL (macOS), Job
   Object (Windows) — plus a DNS-resolver guard that filters network egress.
-- **Human-in-the-loop** — tool calls pause for your approval in Hub and in
-  `mur agent cli` (opt out per session with `--auto`). While a gate is open the
+- **Human-in-the-loop** — tool calls pause for your approval in Hub. In
+  `mur agent cli` a session starts with auto-approve ON (the status bar's
+  `AUTO` badge says so); `--ask` or `/auto off` makes it ask first. While a gate is open the
   decision keys only count when you aren't mid-message, and a session-wide
   grant takes two presses — typing an ordinary sentence can't hand a tool
   blanket approval. An open gate always renders somewhere, `/auto off` revokes

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -187,9 +187,14 @@ pub enum AgentAction {
         /// Resume the most recent saved conversation for this agent
         #[arg(long)]
         resume: bool,
-        /// Auto-approve every tool call for this session (no HITL prompts)
-        #[arg(long)]
+        /// Auto-approve every tool call for this session. This is the default;
+        /// the flag stays so existing scripts keep working.
+        #[arg(long, conflicts_with = "ask")]
         auto: bool,
+        /// Ask before every tool call this session instead (`/auto` toggles
+        /// it back). The old default.
+        #[arg(long)]
+        ask: bool,
         /// Visual skin: dark (default) | light | mur
         #[arg(long)]
         skin: Option<String>,
@@ -1213,6 +1218,7 @@ mod tests {
             names,
             resume,
             auto,
+            ask: _,
             skin: _,
             plain: _,
             budget_usd: _,

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -430,8 +430,10 @@ pub struct App {
     pub chooser_grow: i16,
     pub spinner: usize,
     pub should_quit: bool,
-    /// Session-wide auto-approval of every tool call (`/auto` or `--auto`).
-    /// Never persisted: a new `mur agent cli` starts back at ask-first.
+    /// Session-wide auto-approval of every tool call. ON by default: a
+    /// session starts approving, `--ask` or `/auto off` makes it ask first.
+    /// Never persisted — the next `mur agent cli` starts from the default
+    /// again, not from where this one left off.
     pub auto_approve: bool,
     /// Tools the user marked "always allow" for THIS session via the HITL
     /// modal's `[a]` key. Same lifetime rules as `auto_approve`.
@@ -653,7 +655,7 @@ impl App {
             chooser_grow: 0,
             spinner: 0,
             should_quit: false,
-            auto_approve: false,
+            auto_approve: true,
             session_tool_allow: HashSet::new(),
             pending_shell: Vec::new(),
             persist_warned: false,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -441,9 +441,14 @@ async fn run_tui(
             "unknown skin '{skin_name}', using dark — valid: dark, light, mur"
         ));
     }
-    if auto {
-        app.auto_approve = true;
-        app.push_system("auto-approve is ON for this session (--auto) — every tool call will be allowed without asking");
+    // Auto-approve is the default and the status bar's AUTO badge says so;
+    // only the opt-out gets a notice, because a session that asks is the one
+    // whose operator has to know why it stopped.
+    app.auto_approve = auto;
+    if !auto {
+        app.push_system(
+            "ask-first is ON for this session (--ask) — every tool call waits for you; /auto to approve without asking",
+        );
     }
     app.budget_usd = budget_usd;
     if let Some(b) = budget_usd {
@@ -2741,7 +2746,9 @@ fn run_plain(
                 // branch has a human at the keyboard, so every other branch says
                 // "auto" rather than claiming someone answered.
                 let (allow, surface) = if auto {
-                    eprintln!("[non-interactive: auto-approving tool-approval request (--auto)]");
+                    eprintln!(
+                        "[non-interactive: auto-approving tool-approval request (default; --ask to deny)]"
+                    );
                     (true, "auto")
                 } else if auto_reads && bash_class::is_readonly_call(tool, hitl.get("tool_input")) {
                     // Same lane as the TUI, same classifier. This mode used to
@@ -2774,7 +2781,7 @@ fn run_plain(
                     (allowed, "cli")
                 } else {
                     eprintln!(
-                        "[non-interactive: auto-denying tool-approval request (use --auto to allow)]"
+                        "[non-interactive: auto-denying tool-approval request (--ask; drop it to allow)]"
                     );
                     (false, "auto")
                 };
@@ -2940,6 +2947,9 @@ mod hitl_key_tests {
     /// is where the flag used to be set. Calling `gate()` directly would skip
     /// the very line under test and pass either way.
     fn gate_via_stream(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+        // An ask-first session: with the default auto-approve the request
+        // would be answered on arrival and no gate would open to test.
+        app.auto_approve = false;
         let task_id = "t1".to_string();
         app.current_task_id = Some(task_id.clone());
         let req = stream::HitlRequest {
@@ -2997,6 +3007,8 @@ mod hitl_key_tests {
     async fn typing_a_message_never_decides_the_gate() {
         let (tx, _rx) = mpsc::channel(16);
         let mut app = App::test_fixture();
+        // Ask-first session (`--ask`): the gate is the operator's to decide.
+        app.auto_approve = false;
         gate(&mut app);
 
         type_str(&mut app, "add the test", &tx).await;

--- a/mur-core/src/cmd/agent/cli/multiplex.rs
+++ b/mur-core/src/cmd/agent/cli/multiplex.rs
@@ -265,8 +265,9 @@ fn pane_argv(exe: &str, name: &str, resume: bool, auto: bool) -> Vec<String> {
     if resume {
         v.push("--resume".into());
     }
-    if auto {
-        v.push("--auto".into());
+    // Auto-approve is the pane's default too; only the opt-out has to travel.
+    if !auto {
+        v.push("--ask".into());
     }
     v
 }
@@ -575,20 +576,18 @@ mod tests {
 
     #[test]
     fn pane_argv_includes_flags() {
+        // Auto-approve is the default, so it travels as nothing; ask-first is
+        // the flag that has to reach the pane.
         let v = pane_argv("/opt/homebrew/bin/mur", "a1", true, true);
         assert_eq!(
             v,
-            vec![
-                "/opt/homebrew/bin/mur",
-                "agent",
-                "cli",
-                "a1",
-                "--resume",
-                "--auto"
-            ]
+            vec!["/opt/homebrew/bin/mur", "agent", "cli", "a1", "--resume"]
         );
         let v = pane_argv("/opt/homebrew/bin/mur", "a1", false, false);
-        assert_eq!(v, vec!["/opt/homebrew/bin/mur", "agent", "cli", "a1"]);
+        assert_eq!(
+            v,
+            vec!["/opt/homebrew/bin/mur", "agent", "cli", "a1", "--ask"]
+        );
     }
 
     #[test]
@@ -636,7 +635,7 @@ mod tests {
     #[test]
     fn tmux_new_session_plan_shape() {
         let names = vec!["a1".to_string(), "a2".to_string(), "a3".to_string()];
-        let cmds = tmux_new_session("mur-chat", "/bin/mur", &names, false, false);
+        let cmds = tmux_new_session("mur-chat", "/bin/mur", &names, false, true);
         assert_eq!(
             cmds[0],
             vec![
@@ -715,7 +714,7 @@ mod tests {
     #[test]
     fn tmux_inside_plan_shape() {
         let names = vec!["a1".to_string(), "a2".to_string()];
-        let open = tmux_inside_open("/bin/mur", &names, false, false);
+        let open = tmux_inside_open("/bin/mur", &names, false, true);
         assert_eq!(
             open,
             vec![
@@ -727,7 +726,7 @@ mod tests {
                 "/bin/mur agent cli a1"
             ]
         );
-        let rest = tmux_inside_rest("@7", "/bin/mur", &names, false, false);
+        let rest = tmux_inside_rest("@7", "/bin/mur", &names, false, true);
         assert_eq!(
             rest[0],
             vec!["tmux", "split-window", "-t", "@7", "/bin/mur agent cli a2"]
@@ -739,7 +738,7 @@ mod tests {
     #[test]
     fn zellij_inside_plan_shape() {
         let names = vec!["a1".to_string(), "a2".to_string()];
-        let cmds = zellij_inside("/bin/mur", &names, false, true);
+        let cmds = zellij_inside("/bin/mur", &names, false, false);
         assert_eq!(
             cmds[0],
             vec!["zellij", "action", "new-tab", "--name", "mur-chat"]
@@ -747,13 +746,13 @@ mod tests {
         assert_eq!(
             cmds[1],
             vec![
-                "zellij", "run", "--", "/bin/mur", "agent", "cli", "a1", "--auto"
+                "zellij", "run", "--", "/bin/mur", "agent", "cli", "a1", "--ask"
             ]
         );
         assert_eq!(
             cmds[2],
             vec![
-                "zellij", "run", "--", "/bin/mur", "agent", "cli", "a2", "--auto"
+                "zellij", "run", "--", "/bin/mur", "agent", "cli", "a2", "--ask"
             ]
         );
         assert_eq!(cmds.len(), 3);
@@ -762,7 +761,7 @@ mod tests {
     #[test]
     fn zellij_kdl_layout_quotes_and_lists_all_agents() {
         let names = vec!["a1".to_string(), "a2".to_string()];
-        let kdl = zellij_kdl_layout("/My Drive/mur", &names, true, false);
+        let kdl = zellij_kdl_layout("/My Drive/mur", &names, true, true);
         let expected = concat!(
             "layout {\n",
             "    pane split_direction=\"vertical\" {\n",
@@ -777,7 +776,7 @@ mod tests {
     #[test]
     fn wezterm_plan_alternates_direction() {
         let names = vec!["a1".to_string(), "a2".to_string(), "a3".to_string()];
-        let cmds = wezterm_splits("/bin/mur", &names, false, false);
+        let cmds = wezterm_splits("/bin/mur", &names, false, true);
         assert_eq!(
             cmds[0],
             vec![
@@ -825,7 +824,7 @@ mod tests {
     #[test]
     fn kitty_plan_alternates_location() {
         let names = vec!["a1".to_string(), "a2".to_string()];
-        let cmds = kitty_launches("/bin/mur", &names, false, false);
+        let cmds = kitty_launches("/bin/mur", &names, false, true);
         assert_eq!(
             cmds[0],
             vec![

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1610,15 +1610,19 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Cli {
             names,
             resume,
-            auto,
+            auto: _,
+            ask,
             skin,
             plain,
             budget_usd,
             auto_reads,
             fleet,
         } => {
+            // Auto-approve is the default; `--ask` is the only way to start
+            // ask-first. `--auto` is accepted for old scripts and means what
+            // the default already means.
             cmd::agent::cmd_cli(
-                &names, resume, auto, skin, plain, budget_usd, auto_reads, fleet,
+                &names, resume, !ask, skin, plain, budget_usd, auto_reads, fleet,
             )
             .await?
         }


### PR DESCRIPTION
## Summary

Requested: murmur's `/auto` default flips to ON.

- `App.auto_approve` defaults to `true`; a `mur agent cli` session starts approving every tool call. The status bar's `AUTO` badge is the standing signal, so no startup notice.
- New `--ask` flag starts ask-first (the old default) and prints a one-line notice. `/auto off` still works mid-session.
- `--auto` is kept as an accepted no-op so existing scripts and shell aliases keep working (`conflicts_with = "ask"`).
- Multiplexer panes (tmux/zellij/wezterm/kitty) forward `--ask` instead of `--auto`.
- Plain mode's non-interactive messages name `--ask` as the reason for an auto-deny.
- README's human-in-the-loop paragraph updated. The docs site (mur-server) still describes `--auto` as the opt-in; that repo is a follow-up.

Unchanged: per-tool `[a]` session grants, `--auto-reads`, runtime entitlements, sandbox, HITL decision-by-hash.

Trade-off, stated once: a fresh session now runs `bash`/`write_file` without asking. That is the requested behaviour; `--ask` and `/auto off` are the way back.

## Test plan

- [x] `typing_a_message_never_decides_the_gate` and the HITL key tests run in an explicit ask-first session; `pane_argv_includes_flags` asserts `--ask` travels and `--auto` does not; the plan-shape tests use the default.
- [x] `cargo nextest run -p mur-core --lib cmd::agent::cli:: cli::agent dispatch` — 363 passed; clippy `-D warnings` and fmt clean.
- [ ] Live: `murmur mur` shows `AUTO` in the status bar and runs a tool without a modal; `murmur mur --ask` shows the notice and gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)