### PR TITLE
refactor(murmur): Theme is eleven semantic tokens; ansi names the terminal-following skin, dark is its alias

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -578,7 +578,7 @@ impl Default for CcProxyConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CliConfig {
     /// Default visual skin for `mur agent cli`. Overridable with --skin.
-    /// Valid values: "dark" (default), "light", "mur".
+    /// Valid values: "ansi" (default; "dark" is an alias), "light", "mur".
     pub skin: Option<String>,
 }
 

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -195,7 +195,7 @@ pub enum AgentAction {
         /// it back). The old default.
         #[arg(long)]
         ask: bool,
-        /// Visual skin: dark (default) | light | mur
+        /// Visual skin: ansi (default; `dark` is an alias) | light | mur
         #[arg(long)]
         skin: Option<String>,
         /// Plain line-based output (no full-screen TUI) — for screen readers,

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1616,10 +1616,10 @@ impl App {
             Block::default()
                 .borders(Borders::TOP | Borders::BOTTOM)
                 .border_type(theme.border_type)
-                .border_style(Style::default().fg(theme.border))
+                .border_style(theme.border)
                 .padding(Padding::horizontal(theme.inner_padding as u16))
                 .title(hint)
-                .title_style(Style::default().fg(theme.border_title))
+                .title_style(theme.muted)
         };
         self.input.set_block(block);
     }
@@ -1675,7 +1675,7 @@ impl App {
             home.path().to_path_buf(),
             "a".into(),
             session,
-            &super::theme::DARK,
+            &super::theme::ANSI,
         )
     }
 }
@@ -1692,7 +1692,7 @@ mod tests {
             home.path().to_path_buf(),
             "a".into(),
             session,
-            &super::super::theme::DARK,
+            &super::super::theme::ANSI,
         )
     }
 
@@ -1738,7 +1738,7 @@ mod tests {
             home.path().to_path_buf(),
             "a".into(),
             session,
-            &super::super::theme::DARK,
+            &super::super::theme::ANSI,
         )
     }
 
@@ -2756,7 +2756,7 @@ mod open_items_notice_tests {
             home.path().to_path_buf(),
             "a".into(),
             session,
-            &super::super::theme::DARK,
+            &super::super::theme::ANSI,
         )
     }
 

--- a/mur-core/src/cmd/agent/cli/complete.rs
+++ b/mur-core/src/cmd/agent/cli/complete.rs
@@ -125,7 +125,7 @@ pub enum Args {
 
 const ON_OFF: &[(&str, &str)] = &[("on", "enable"), ("off", "disable")];
 const SKINS: &[(&str, &str)] = &[
-    ("dark", "default"),
+    ("ansi", "default — follows your terminal"),
     ("light", "light terminals"),
     ("mur", "MUR brand"),
 ];

--- a/mur-core/src/cmd/agent/cli/diff.rs
+++ b/mur-core/src/cmd/agent/cli/diff.rs
@@ -26,9 +26,9 @@ fn str_field<'a>(args: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> 
 
 /// Append one bounded diff line; no-op once `pushed` reaches `DIFF_MAX_LINES`.
 /// The counter always increments so it reflects the true total line count.
-fn push(out: &mut Vec<Line<'static>>, pushed: &mut usize, s: String, color: Color, dim: bool) {
+fn push(out: &mut Vec<Line<'static>>, pushed: &mut usize, s: String, style: Style, dim: bool) {
     if *pushed < DIFF_MAX_LINES {
-        let mut st = Style::default().fg(color);
+        let mut st = style;
         if dim {
             st = st.add_modifier(Modifier::DIM);
         }
@@ -57,9 +57,7 @@ pub fn edit_diff_lines(
     if !path.is_empty() {
         out.push(Line::styled(
             format!(" {path}"),
-            Style::default()
-                .fg(theme.system)
-                .add_modifier(Modifier::BOLD),
+            theme.muted.add_modifier(Modifier::BOLD),
         ));
     }
 
@@ -71,25 +69,25 @@ pub fn edit_diff_lines(
             for hunk in diff::lines(old_str, new) {
                 match hunk {
                     diff::Result::Left(l) => {
-                        push(&mut out, &mut pushed, format!("  - {l}"), Color::Red, false);
+                        push(
+                            &mut out,
+                            &mut pushed,
+                            format!("  - {l}"),
+                            Style::default().fg(Color::Red),
+                            false,
+                        );
                     }
                     diff::Result::Right(r) => {
                         push(
                             &mut out,
                             &mut pushed,
                             format!("  + {r}"),
-                            Color::Green,
+                            Style::default().fg(Color::Green),
                             false,
                         );
                     }
                     diff::Result::Both(l, _) => {
-                        push(
-                            &mut out,
-                            &mut pushed,
-                            format!("    {l}"),
-                            theme.system,
-                            true,
-                        );
+                        push(&mut out, &mut pushed, format!("    {l}"), theme.muted, true);
                     }
                 }
             }
@@ -101,7 +99,7 @@ pub fn edit_diff_lines(
                     &mut out,
                     &mut pushed,
                     format!("  + {line}"),
-                    Color::Green,
+                    Style::default().fg(Color::Green),
                     false,
                 );
             }
@@ -112,9 +110,7 @@ pub fn edit_diff_lines(
     if pushed > DIFF_MAX_LINES {
         out.push(Line::styled(
             format!("  … +{} more diff line(s)", pushed - DIFF_MAX_LINES),
-            Style::default()
-                .fg(theme.system)
-                .add_modifier(Modifier::DIM),
+            theme.muted.add_modifier(Modifier::DIM),
         ));
     }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -396,12 +396,12 @@ async fn run_tui(
     auto_reads: bool,
     fleet: Option<String>,
 ) -> Result<()> {
-    // Resolve skin: CLI flag > config > "dark"
+    // Resolve skin: CLI flag > config > "ansi"
     let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
     let skin_name = skin
         .as_deref()
         .or(cfg.cli.skin.as_deref())
-        .unwrap_or("dark");
+        .unwrap_or("ansi");
     let unknown_skin = !theme::is_known_skin(skin_name);
     let active_theme = theme::resolve_skin(skin_name);
 
@@ -438,7 +438,8 @@ async fn run_tui(
     app.pricing_book = Some(book);
     if unknown_skin {
         app.push_system(format!(
-            "unknown skin '{skin_name}', using dark — valid: dark, light, mur"
+            "unknown skin '{skin_name}', using ansi — valid: {}",
+            theme::SKIN_NAMES
         ));
     }
     // Auto-approve is the default and the status bar's AUTO badge says so;
@@ -2251,11 +2252,17 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Skin(name_opt) => match name_opt {
             None => {
                 let current = theme::skin_name(app.theme);
-                app.push_system(format!("current skin: {current} — valid: dark, light, mur"));
+                app.push_system(format!(
+                    "current skin: {current} — valid: {}",
+                    theme::SKIN_NAMES
+                ));
             }
             Some(name) => {
                 if !theme::is_known_skin(&name) {
-                    app.push_system(format!("unknown skin '{name}' — valid: dark, light, mur"));
+                    app.push_system(format!(
+                        "unknown skin '{name}' — valid: {}",
+                        theme::SKIN_NAMES
+                    ));
                 } else {
                     app.theme = theme::resolve_skin(&name);
                     app.mascot_mode =

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -32,8 +32,8 @@ pub fn card_lines(
     let budget = hint_budget(width);
 
     let accent = match card.state {
-        StepState::Error => ratatui::style::Color::Red,
-        _ => theme.agent,
+        StepState::Error => Style::default().fg(ratatui::style::Color::Red),
+        _ => theme.accent,
     };
 
     // ── Header: glyph · name · arg-hint · duration ───────────────────────────
@@ -53,19 +53,11 @@ pub fn card_lines(
         None => format!("{} {} {}", card.glyph(), card.name, arg_hint(card, budget)),
     };
     let auto_tag = if card.auto_approved {
-        Span::styled(
-            " [auto]",
-            Style::default()
-                .fg(theme.system)
-                .add_modifier(Modifier::DIM),
-        )
+        Span::styled(" [auto]", theme.muted.add_modifier(Modifier::DIM))
     } else {
         Span::raw("")
     };
-    let mut header_spans = vec![Span::styled(
-        header,
-        Style::default().fg(accent).add_modifier(Modifier::BOLD),
-    )];
+    let mut header_spans = vec![Span::styled(header, accent.add_modifier(Modifier::BOLD))];
     // Without a subject the gist folds into the header, keeping the whole card
     // one scannable line. With one it belongs on the `⎿` row beside the command
     // it came from.
@@ -74,13 +66,10 @@ pub fn card_lines(
         && card.error.is_none()
         && let Some(gist) = result_gist(card, budget)
     {
-        header_spans.push(Span::styled(
-            format!("  → {gist}"),
-            Style::default().fg(theme.system),
-        ));
+        header_spans.push(Span::styled(format!("  → {gist}"), theme.muted));
     }
     if subject.is_none() {
-        header_spans.push(Span::styled(dur.clone(), Style::default().fg(theme.system)));
+        header_spans.push(Span::styled(dur.clone(), theme.muted));
     }
     header_spans.push(auto_tag);
     out.push(Line::from(header_spans));
@@ -89,17 +78,10 @@ pub fn card_lines(
     // land on, and this is the receipt underneath it.
     if subject.is_some() {
         let mut row = vec![
-            Span::styled(
-                "  ⎿ ",
-                Style::default()
-                    .fg(theme.system)
-                    .add_modifier(Modifier::DIM),
-            ),
+            Span::styled("  ⎿ ", theme.muted.add_modifier(Modifier::DIM)),
             Span::styled(
                 arg_hint(card, budget),
-                Style::default()
-                    .fg(theme.system)
-                    .add_modifier(Modifier::DIM),
+                theme.muted.add_modifier(Modifier::DIM),
             ),
         ];
         if !expanded
@@ -108,17 +90,10 @@ pub fn card_lines(
         {
             row.push(Span::styled(
                 format!("  → {gist}"),
-                Style::default()
-                    .fg(theme.system)
-                    .add_modifier(Modifier::DIM),
+                theme.muted.add_modifier(Modifier::DIM),
             ));
         }
-        row.push(Span::styled(
-            dur,
-            Style::default()
-                .fg(theme.system)
-                .add_modifier(Modifier::DIM),
-        ));
+        row.push(Span::styled(dur, theme.muted.add_modifier(Modifier::DIM)));
         out.push(Line::from(row));
     }
 
@@ -135,17 +110,12 @@ pub fn card_lines(
         let pretty = serde_json::to_string_pretty(&card.args).unwrap_or_default();
         let total_lines = pretty.lines().count();
         for l in pretty.lines().take(ARGS_MAX_LINES) {
-            out.push(Line::styled(
-                format!(" {l}"),
-                Style::default().fg(theme.system),
-            ));
+            out.push(Line::styled(format!(" {l}"), theme.muted));
         }
         if total_lines > ARGS_MAX_LINES {
             out.push(Line::styled(
                 format!(" … +{} more", total_lines - ARGS_MAX_LINES),
-                Style::default()
-                    .fg(theme.system)
-                    .add_modifier(Modifier::DIM),
+                theme.muted.add_modifier(Modifier::DIM),
             ));
         }
     }
@@ -158,10 +128,7 @@ pub fn card_lines(
     if !card.output.is_empty() {
         let output_line_count = card.output.lines().count();
         for l in card.output.lines().take(OUTPUT_MAX_LINES) {
-            out.push(Line::styled(
-                format!(" {l}"),
-                Style::default().fg(theme.agent_text),
-            ));
+            out.push(Line::styled(format!(" {l}"), theme.text));
         }
         let shown = output_line_count.min(OUTPUT_MAX_LINES);
         // Show "+N more" either when we clipped locally OR the runtime
@@ -174,9 +141,7 @@ pub fn card_lines(
         if card.truncated || output_line_count > OUTPUT_MAX_LINES {
             out.push(Line::styled(
                 format!(" … +{} more", total.saturating_sub(shown)),
-                Style::default()
-                    .fg(theme.system)
-                    .add_modifier(Modifier::DIM),
+                theme.muted.add_modifier(Modifier::DIM),
             ));
         }
     }
@@ -209,21 +174,21 @@ fn hitl_row(theme: &'static Theme) -> Line<'static> {
                 .fg(ratatui::style::Color::Green)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" approve  ", Style::default().fg(theme.system)),
+        Span::styled(" approve  ", theme.muted),
         Span::styled(
             "[a]",
             Style::default()
                 .fg(ratatui::style::Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" always  ", Style::default().fg(theme.system)),
+        Span::styled(" always  ", theme.muted),
         Span::styled(
             "[n]",
             Style::default()
                 .fg(ratatui::style::Color::Red)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" deny / Esc", Style::default().fg(theme.system)),
+        Span::styled(" deny / Esc", theme.muted),
     ])
 }
 
@@ -475,7 +440,7 @@ mod tests {
     }
 
     fn rows(card: &StepCard) -> Vec<String> {
-        super::card_lines(card, &theme::DARK, false, TEST_WIDTH)
+        super::card_lines(card, &theme::ANSI, false, TEST_WIDTH)
             .iter()
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect()

--- a/mur-core/src/cmd/agent/cli/settlement.rs
+++ b/mur-core/src/cmd/agent/cli/settlement.rs
@@ -46,13 +46,13 @@ const MIN_INDENT_WIDTH: u16 = 24;
 
 /// Colour for a row, chosen by its lead glyph.
 fn row_style(glyph: char, theme: &'static super::theme::Theme) -> Style {
-    let fg = match glyph {
-        '✔' => theme.success,
+    let style = match glyph {
+        '✔' => theme.ok,
         '✘' => theme.error,
         '⚠' => theme.warn,
-        _ => theme.agent_text,
+        _ => theme.text,
     };
-    Style::default().fg(fg).bg(theme.card_bg)
+    style.patch(theme.surface)
 }
 
 /// Break `s` into chunks no wider than `width` display columns.
@@ -111,7 +111,7 @@ fn pad(s: &str, width: usize) -> String {
 
 /// Draw the settlement card for `body` at `width` columns.
 ///
-/// Every row is padded to the full width and carries `theme.card_bg`, so the
+/// Every row is padded to the full width and carries `theme.surface`, so the
 /// block reads as one surface rather than ragged text. Nothing is elided: the
 /// runtime already stopped guessing what fits, and this is the layer that
 /// actually knows.
@@ -128,9 +128,9 @@ pub fn card_lines(
     };
     let mut out = vec![Line::from(Span::styled(
         pad(" SETTLEMENT", w),
-        Style::default()
-            .fg(theme.border_title)
-            .bg(theme.card_bg)
+        theme
+            .muted
+            .patch(theme.surface)
             .add_modifier(Modifier::BOLD),
     ))];
     for raw in body.lines() {
@@ -188,7 +188,7 @@ mod tests {
         assert!(card.is_none());
     }
 
-    use super::super::theme::DARK;
+    use super::super::theme::ANSI;
     use super::card_lines;
     use unicode_width::UnicodeWidthStr;
 
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn every_row_is_padded_to_the_pane_width() {
-        let out = card_lines("  ✔ bash · cargo test", &DARK, 40);
+        let out = card_lines("  ✔ bash · cargo test", &ANSI, 40);
         assert!(!out.is_empty());
         for row in plain(&out) {
             assert_eq!(row.width(), 40, "ragged row: {row:?}");
@@ -211,8 +211,8 @@ mod tests {
     #[test]
     fn long_detail_wraps_instead_of_being_cut() {
         let body = format!("  ✘ parallel_jobs · {}", "e".repeat(200));
-        let narrow = card_lines(&body, &DARK, 40);
-        let wide = card_lines(&body, &DARK, 100);
+        let narrow = card_lines(&body, &ANSI, 40);
+        let wide = card_lines(&body, &ANSI, 100);
         assert!(
             narrow.len() > wide.len(),
             "narrow={} wide={} — text must reflow, not truncate",
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn the_card_names_itself() {
-        let out = plain(&card_lines("  ✔ bash", &DARK, 40));
+        let out = plain(&card_lines("  ✔ bash", &ANSI, 40));
         assert!(out[0].contains("SETTLEMENT"), "{out:?}");
     }
 }

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -1,136 +1,143 @@
-//! Skin/theme definitions for the agent CLI TUI.
+//! Skin/theme definitions for the agent CLI TUI: one semantic token
+//! vocabulary, three palettes. Tokens are `Style`, not `Color`, because
+//! `ansi` says "muted" with `DIM` where `light` says it with a grey, and a
+//! paint site must not know which. See
+//! `docs/superpowers/specs/2026-09-09-murmur-skin-redesign-design.md`.
 
+// `emphasis` has no paint site until the redesign PR (markdown table
+// headers take it); the token is part of the vocabulary from the start.
 #![allow(dead_code)]
 
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::BorderType;
 
 pub struct Theme {
-    // ── labels (bold, identifies speaker) ────────────────────────────────────
-    pub user: Color,   // "› you" label
-    pub agent: Color,  // "● agent" label
-    pub accent: Color, // mascot / brand accent (always color-capable)
-    pub shell: Color,  // "$ cmd" label for !command output
-    // ── body text ─────────────────────────────────────────────────────────────
-    pub user_text: Color,  // continuation lines of a user turn
-    pub agent_text: Color, // continuation lines of an agent reply
-    pub thinking: Color,   // streaming thinking tokens (italic+dim)
-    // ── chrome ────────────────────────────────────────────────────────────────
-    pub system: Color,       // system hints, errors, slash-cmd output
-    pub warn: Color,         // amber: warnings / degraded notices
-    pub error: Color,        // red: failures
-    pub success: Color,      // green: completed actions
-    pub border: Color,       // transcript + input box borders
-    pub border_title: Color, // text inside the border title
-    pub separator: Color,    // inter-message separator line
-    pub card_bg: Color,      // settlement card background (one step off the pane)
-    // ── status bar ────────────────────────────────────────────────────────────
-    pub status_bg: Color, // status bar background
-    pub badge_fg: Color,  // agent-name badge foreground
-    pub badge_bg: Color,  // agent-name badge background
-    // ── layout ────────────────────────────────────────────────────────────────
-    pub border_type: BorderType, // Plain | Rounded | Double
-    pub inner_padding: u8,       // horizontal padding inside panes (0–2)
-    pub show_separator: bool,    // true = ─── line; false = blank line
-    pub compact_input: bool,     // shorten input box hint text
+    // ── text ──────────────────────────────────────────────────────────────
+    /// Body text: agent replies; user turns take this plus DIM.
+    pub text: Style,
+    /// Metadata: notices, thinking, hints, rule titles, timestamps.
+    pub muted: Style,
+    /// Headings and focused items.
+    pub emphasis: Style,
+    // ── identity ──────────────────────────────────────────────────────────
+    /// "● agent" label, mascot, brand, focused-panel borders.
+    pub accent: Style,
+    /// "you ›" label, "$ cmd" shell label.
+    pub accent_alt: Style,
+    // ── status ────────────────────────────────────────────────────────────
+    pub ok: Style,
+    pub warn: Style,
+    pub error: Style,
+    // ── chrome ────────────────────────────────────────────────────────────
+    /// Unfocused rules: composer top rule, table grid, fleet rail.
+    pub border: Style,
+    /// Status bar and card background (bg only).
+    pub surface: Style,
+    /// Agent-name / AUTO badge on the status bar.
+    pub badge: Style,
+    // ── layout ────────────────────────────────────────────────────────────
+    pub border_type: BorderType,
+    pub inner_padding: u8,
+    pub compact_input: bool,
 }
 
-pub const DARK: Theme = Theme {
-    user: Color::Green,
-    agent: Color::Cyan,
-    accent: Color::Cyan,
-    shell: Color::Green,
-    user_text: Color::Rgb(0xb8, 0xb8, 0xb8),
-    agent_text: Color::Rgb(0xea, 0xea, 0xea),
-    thinking: Color::Rgb(0x8a, 0x8a, 0x8a),
-    system: Color::Rgb(0x8a, 0x8a, 0x8a),
-    warn: Color::Rgb(0xe5, 0xa5, 0x3a),
-    error: Color::Rgb(0xe0, 0x6c, 0x6c),
-    success: Color::Rgb(0x6c, 0xc0, 0x7a),
-    border: Color::Rgb(0x55, 0x55, 0x55),
-    border_title: Color::Rgb(0x70, 0x70, 0x70),
-    separator: Color::Rgb(0x45, 0x45, 0x45),
-    card_bg: Color::Rgb(0x1e, 0x1e, 0x1e),
-    status_bg: Color::Reset,
-    badge_fg: Color::Black,
-    badge_bg: Color::Cyan,
+const fn fg(c: Color) -> Style {
+    Style::new().fg(c)
+}
+
+const fn rgb(r: u8, g: u8, b: u8) -> Style {
+    Style::new().fg(Color::Rgb(r, g, b))
+}
+
+/// Follows the terminal: ANSI slots only, so the user's own theme decides
+/// every colour. Alias `dark`. (The greys are still today's RGB values in
+/// this PR; the redesign PR replaces them with `Reset` + modifiers.)
+pub const ANSI: Theme = Theme {
+    text: rgb(0xea, 0xea, 0xea),
+    muted: rgb(0x8a, 0x8a, 0x8a),
+    emphasis: rgb(0xea, 0xea, 0xea).add_modifier(Modifier::BOLD),
+    accent: fg(Color::Cyan),
+    accent_alt: fg(Color::Green),
+    ok: rgb(0x6c, 0xc0, 0x7a),
+    warn: rgb(0xe5, 0xa5, 0x3a),
+    error: rgb(0xe0, 0x6c, 0x6c),
+    border: rgb(0x55, 0x55, 0x55),
+    surface: Style::new().bg(Color::Rgb(0x1e, 0x1e, 0x1e)),
+    badge: Style::new().fg(Color::Black).bg(Color::Cyan),
     border_type: BorderType::Plain,
     inner_padding: 1,
-    show_separator: false,
     compact_input: false,
 };
 
 pub const LIGHT: Theme = Theme {
-    user: Color::Rgb(0x16, 0x65, 0x34),
-    agent: Color::Rgb(0x0e, 0x6b, 0x8c),
-    accent: Color::Rgb(0x0e, 0x6b, 0x8c),
-    shell: Color::Rgb(0x16, 0x65, 0x34),
-    user_text: Color::Rgb(0x22, 0x22, 0x33),
-    agent_text: Color::Rgb(0x22, 0x22, 0x33),
-    thinking: Color::Rgb(0x88, 0x88, 0x99),
-    system: Color::Rgb(0x77, 0x77, 0x88),
-    warn: Color::Rgb(0xb5, 0x74, 0x00),
-    error: Color::Rgb(0xc0, 0x30, 0x30),
-    success: Color::Rgb(0x1c, 0x7a, 0x3a),
-    border: Color::Rgb(0xd0, 0xd0, 0xe0),
-    border_title: Color::Rgb(0x99, 0x99, 0x99),
-    separator: Color::Rgb(0xd8, 0xd8, 0xe8),
-    card_bg: Color::Rgb(0xf1, 0xf1, 0xf7),
-    status_bg: Color::Rgb(0xef, 0xef, 0xf5),
-    badge_fg: Color::Rgb(0x0e, 0x6b, 0x8c),
-    badge_bg: Color::Rgb(0xe0, 0xf0, 0xf8),
+    text: rgb(0x22, 0x22, 0x33),
+    muted: rgb(0x77, 0x77, 0x88),
+    emphasis: rgb(0x22, 0x22, 0x33).add_modifier(Modifier::BOLD),
+    accent: rgb(0x0e, 0x6b, 0x8c),
+    accent_alt: rgb(0x16, 0x65, 0x34),
+    ok: rgb(0x1c, 0x7a, 0x3a),
+    warn: rgb(0xb5, 0x74, 0x00),
+    error: rgb(0xc0, 0x30, 0x30),
+    border: rgb(0xd0, 0xd0, 0xe0),
+    surface: Style::new().bg(Color::Rgb(0xf1, 0xf1, 0xf7)),
+    badge: Style::new()
+        .fg(Color::Rgb(0x0e, 0x6b, 0x8c))
+        .bg(Color::Rgb(0xe0, 0xf0, 0xf8)),
     border_type: BorderType::Rounded,
     inner_padding: 1,
-    show_separator: true,
     compact_input: false,
 };
 
 pub const MUR: Theme = Theme {
-    user: Color::Rgb(0xa7, 0x8b, 0xfa),
-    agent: Color::Rgb(0xfb, 0xbf, 0x24),
-    accent: Color::Rgb(0xfb, 0xbf, 0x24),
-    shell: Color::Rgb(0x88, 0x88, 0xcc),
-    user_text: Color::Rgb(0xc8, 0xc8, 0xe8),
-    agent_text: Color::Rgb(0xe0, 0xe0, 0xf0),
-    thinking: Color::Rgb(0x86, 0x86, 0xc0),
-    system: Color::Rgb(0x77, 0x77, 0xaa),
-    warn: Color::Rgb(0xf0, 0xc0, 0x60),
-    error: Color::Rgb(0xf0, 0x80, 0x90),
-    success: Color::Rgb(0x80, 0xd0, 0x90),
-    border: Color::Rgb(0x50, 0x50, 0x90),
-    border_title: Color::Rgb(0x55, 0x55, 0x99),
-    separator: Color::Rgb(0x3a, 0x3a, 0x70),
-    card_bg: Color::Rgb(0x14, 0x14, 0x2c),
-    status_bg: Color::Rgb(0x09, 0x09, 0x1a),
-    badge_fg: Color::Rgb(0xfb, 0xbf, 0x24),
-    badge_bg: Color::Rgb(0x22, 0x1a, 0x06),
+    text: rgb(0xe0, 0xe0, 0xf0),
+    muted: rgb(0x77, 0x77, 0xaa),
+    emphasis: rgb(0xe0, 0xe0, 0xf0).add_modifier(Modifier::BOLD),
+    accent: rgb(0xfb, 0xbf, 0x24),
+    accent_alt: rgb(0xa7, 0x8b, 0xfa),
+    ok: rgb(0x80, 0xd0, 0x90),
+    warn: rgb(0xf0, 0xc0, 0x60),
+    error: rgb(0xf0, 0x80, 0x90),
+    border: rgb(0x50, 0x50, 0x90),
+    surface: Style::new().bg(Color::Rgb(0x14, 0x14, 0x2c)),
+    badge: Style::new()
+        .fg(Color::Rgb(0xfb, 0xbf, 0x24))
+        .bg(Color::Rgb(0x22, 0x1a, 0x06)),
     border_type: BorderType::Rounded,
     inner_padding: 1,
-    show_separator: true,
     compact_input: true,
 };
 
-const KNOWN: [(&str, &Theme); 3] = [("dark", &DARK), ("light", &LIGHT), ("mur", &MUR)];
+/// The names `/skin` and `--skin` accept, in the order they are listed.
+/// `dark` is an alias of `ansi` and is not listed.
+pub const SKIN_NAMES: &str = "ansi, light, mur";
 
-/// Resolve a skin name to a theme. Falls back to `&DARK` for unknown names.
+const KNOWN: [(&str, &Theme); 4] = [
+    ("ansi", &ANSI),
+    ("dark", &ANSI),
+    ("light", &LIGHT),
+    ("mur", &MUR),
+];
+
+/// Resolve a skin name to a theme. `dark` is an alias of `ansi`; unknown
+/// names fall back to `&ANSI`, the default.
 pub fn resolve_skin(name: &str) -> &'static Theme {
     KNOWN
         .iter()
         .find(|(n, _)| *n == name)
         .map(|(_, t)| *t)
-        .unwrap_or(&DARK)
+        .unwrap_or(&ANSI)
 }
 
-/// Return the canonical name of a theme instance, or "dark" as fallback.
+/// Canonical name of a theme instance — `"ansi"` for the alias too.
 pub fn skin_name(theme: &'static Theme) -> &'static str {
     KNOWN
         .iter()
         .find(|(_, t)| std::ptr::eq(*t, theme))
         .map(|(n, _)| *n)
-        .unwrap_or("dark")
+        .unwrap_or("ansi")
 }
 
-/// True if `name` is a valid skin name.
+/// True if `name` is a valid skin name (the alias included).
 pub fn is_known_skin(name: &str) -> bool {
     KNOWN.iter().any(|(n, _)| *n == name)
 }
@@ -140,31 +147,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_known_skins() {
-        assert!(std::ptr::eq(resolve_skin("dark"), &DARK));
-        assert!(std::ptr::eq(resolve_skin("light"), &LIGHT));
-        assert!(std::ptr::eq(resolve_skin("mur"), &MUR));
+    fn dark_is_an_alias_of_ansi() {
+        assert!(std::ptr::eq(resolve_skin("dark"), &ANSI));
+        assert!(std::ptr::eq(resolve_skin("ansi"), &ANSI));
+        assert_eq!(skin_name(&ANSI), "ansi");
+        assert!(is_known_skin("dark"), "saved config still says dark");
     }
 
     #[test]
-    fn resolve_unknown_falls_back_to_dark() {
-        assert!(std::ptr::eq(resolve_skin("neon"), &DARK));
-        assert!(std::ptr::eq(resolve_skin(""), &DARK));
-    }
-
-    #[test]
-    fn skin_name_round_trips() {
-        assert_eq!(skin_name(&DARK), "dark");
-        assert_eq!(skin_name(&LIGHT), "light");
-        assert_eq!(skin_name(&MUR), "mur");
-    }
-
-    #[test]
-    fn is_known_skin_validates_names() {
-        assert!(is_known_skin("dark"));
-        assert!(is_known_skin("light"));
-        assert!(is_known_skin("mur"));
+    fn unknown_skins_fall_back_to_ansi() {
+        assert!(std::ptr::eq(resolve_skin("neon"), &ANSI));
+        assert!(std::ptr::eq(resolve_skin(""), &ANSI));
         assert!(!is_known_skin("neon"));
         assert!(!is_known_skin("DARK"));
+    }
+
+    #[test]
+    fn light_and_mur_resolve_to_themselves() {
+        assert!(std::ptr::eq(resolve_skin("light"), &LIGHT));
+        assert!(std::ptr::eq(resolve_skin("mur"), &MUR));
+        assert_eq!(skin_name(&LIGHT), "light");
+        assert_eq!(skin_name(&MUR), "mur");
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -174,8 +174,8 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
                 // Numbered option: "N  label" + a dimmed, aligned description +
                 // a spacer. The number is a quiet affordance for digit-select.
                 let mut lines = vec![Line::from(vec![
-                    Span::styled(format!("{}  ", i + 1), Style::default().fg(theme.system)),
-                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                    Span::styled(format!("{}  ", i + 1), theme.muted),
+                    Span::styled(c.display.clone(), theme.text),
                 ])];
                 if !c.desc.is_empty() {
                     lines.push(Line::from(Span::styled(
@@ -186,10 +186,7 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
                 lines.push(Line::default()); // spacer between options
                 ListItem::new(lines)
             } else {
-                let mut spans = vec![Span::styled(
-                    c.display.clone(),
-                    Style::default().fg(theme.border_title),
-                )];
+                let mut spans = vec![Span::styled(c.display.clone(), theme.muted)];
                 if !c.desc.is_empty() {
                     spans.push(Span::raw(" "));
                     spans.push(Span::styled(
@@ -227,10 +224,10 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
     };
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border)
         .padding(Padding::horizontal(state.spaced as u16))
         .title(title)
-        .title_style(Style::default().fg(theme.border_title));
+        .title_style(theme.muted);
 
     let mut list_state = ListState::default();
     list_state.select(Some(state.selected));
@@ -239,12 +236,7 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
     // description too. Mark the selection with a caret + accent-bold label
     // instead. The slash menu keeps its compact reverse highlight.
     let (highlight_style, highlight_symbol) = if state.spaced {
-        (
-            Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
-            "❯ ",
-        )
+        (theme.accent.add_modifier(Modifier::BOLD), "❯ ")
     } else {
         (Style::default().add_modifier(Modifier::REVERSED), "")
     };

--- a/mur-core/src/cmd/agent/cli/ui/band.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band.rs
@@ -10,7 +10,7 @@ use super::rail::fleet_rail_height;
 use ratatui::Frame;
 use ratatui::backend::Backend;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Padding, Paragraph, Widget, Wrap};
 
@@ -388,9 +388,7 @@ pub fn flush_finished<B: Backend>(
             }
             lines.push(Line::from(Span::styled(
                 "● agent".to_string(),
-                Style::default()
-                    .fg(theme.agent)
-                    .add_modifier(Modifier::BOLD),
+                theme.accent.add_modifier(Modifier::BOLD),
             )));
         }
         lines.extend(agent_body_lines(
@@ -517,9 +515,6 @@ pub(super) fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
     f.render_widget(output.block(block).scroll((offset, 0)), area);
     if let Some(marker) = scroll_marker(max_scroll, app.scroll_back) {
         let row = Rect { height: 1, ..inner };
-        f.render_widget(
-            Line::styled(marker, Style::default().fg(theme.border_title)).right_aligned(),
-            row,
-        );
+        f.render_widget(Line::styled(marker, theme.muted).right_aligned(), row);
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui/band/tests.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band/tests.rs
@@ -191,7 +191,12 @@ mod welcome_surface_tests {
     fn consecutive_notices_draw_no_rule_and_turns_still_do() {
         let mut app = App::test_fixture();
         app.theme = &MUR;
-        const { assert!(MUR.show_separator, "test needs a ruled skin") };
+        const {
+            assert!(
+                matches!(MUR.border_type, ratatui::widgets::BorderType::Rounded),
+                "test needs a ruled skin"
+            )
+        };
         app.push_system("skin changed to light");
         app.push_system("skin changed to mur");
         app.messages.push(ChatMsg::for_test(Role::User, "hi"));
@@ -339,5 +344,57 @@ mod band_growth_tests {
         app.flushed_upto = 1;
         let d = dump(&mut app);
         assert!(!d.contains(MASCOT_REST[1]), "mascot painted twice:\n{d}");
+    }
+}
+
+/// PR-1 of the skin redesign is structure only: for the cells whose colour
+/// maps 1:1 (agent label and body, notices) the cell under each skin carries
+/// the token the old field held. Deleted in the redesign PR once the
+/// palettes move on purpose.
+#[cfg(test)]
+mod token_pin_tests {
+    use super::super::super::super::app::{App, ChatMsg, Role};
+    use super::super::super::super::theme::{ANSI, LIGHT, MUR};
+    use super::super::render_transcript;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+
+    #[test]
+    fn agent_turn_and_notice_paint_their_tokens_under_each_skin() {
+        for (name, theme) in [("ansi", &ANSI), ("light", &LIGHT), ("mur", &MUR)] {
+            let mut app = App::test_fixture();
+            app.theme = theme;
+            app.welcome_dismissed = true;
+            app.messages
+                .push(ChatMsg::for_test(Role::Agent, "hello there"));
+            app.push_system("skin changed");
+            let mut term = Terminal::new(TestBackend::new(60, 8)).unwrap();
+            term.draw(|f| render_transcript(f, &mut app, Rect::new(0, 0, 60, 8)))
+                .unwrap();
+            let buf = term.backend().buffer().clone();
+            let find = |needle: &str| -> (u16, u16) {
+                for y in 0..buf.area.height {
+                    let row: String = (0..buf.area.width)
+                        .map(|x| buf.cell((x, y)).unwrap().symbol())
+                        .collect();
+                    if let Some(i) = row.find(needle) {
+                        let x = row[..i].chars().count() as u16;
+                        return (x, y);
+                    }
+                }
+                panic!("{name}: {needle:?} not painted:\n{buf:?}");
+            };
+            let label = buf.cell(find("● agent")).unwrap();
+            let body = buf.cell(find("hello")).unwrap();
+            let notice = buf.cell(find("skin changed")).unwrap();
+            assert_eq!(label.fg, theme.accent.fg.unwrap(), "{name}: agent label");
+            // A finished reply's body comes through the markdown renderer,
+            // which paints prose in the terminal's own foreground — the old
+            // `agent_text` never reached it. Pinned as-is; the redesign PR
+            // decides whether `text` should.
+            assert_eq!(body.fg, ratatui::style::Color::Reset, "{name}: agent body");
+            assert_eq!(notice.fg, theme.muted.fg.unwrap(), "{name}: notice");
+        }
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui/chooser.rs
+++ b/mur-core/src/cmd/agent/cli/ui/chooser.rs
@@ -79,8 +79,8 @@ pub(super) fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
         .map(|(i, c)| {
             if compact {
                 let mut spans = vec![
-                    Span::styled(format!("{} ", i + 1), Style::default().fg(theme.system)),
-                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                    Span::styled(format!("{} ", i + 1), theme.muted),
+                    Span::styled(c.display.clone(), theme.text),
                 ];
                 if !c.desc.is_empty() {
                     spans.push(Span::styled(
@@ -91,8 +91,8 @@ pub(super) fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
                 ListItem::new(Line::from(spans))
             } else {
                 let mut lines = vec![Line::from(vec![
-                    Span::styled(format!("{} ", i + 1), Style::default().fg(theme.system)),
-                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                    Span::styled(format!("{} ", i + 1), theme.muted),
+                    Span::styled(c.display.clone(), theme.text),
                 ])];
                 if !c.desc.is_empty() {
                     lines.push(Line::from(Span::styled(
@@ -108,10 +108,10 @@ pub(super) fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.border))
+        .border_style(theme.border)
         .padding(Padding::horizontal(1))
         .title(" 1-9 pick · ↑↓ move · Enter accept · Esc close · Ctrl+↑↓ resize ")
-        .title_style(Style::default().fg(theme.border_title));
+        .title_style(theme.muted);
 
     let mut list_state = ListState::default();
     list_state.select(Some(state.selected));
@@ -119,11 +119,7 @@ pub(super) fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
     f.render_stateful_widget(
         List::new(rows)
             .block(block)
-            .highlight_style(
-                Style::default()
-                    .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD),
-            )
+            .highlight_style(theme.accent.add_modifier(Modifier::BOLD))
             .highlight_symbol("❯ "),
         area,
         &mut list_state,

--- a/mur-core/src/cmd/agent/cli/ui/message.rs
+++ b/mur-core/src/cmd/agent/cli/ui/message.rs
@@ -1,7 +1,8 @@
 //! One message's lines: role header, body, gap before it.
 
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
+use ratatui::widgets::BorderType;
 
 use super::super::app::{ChatMsg, Role, SPINNER, Severity};
 use super::super::markdown;
@@ -56,11 +57,11 @@ pub(super) fn gap_row(
     m: &crate::cmd::agent::cli::app::ChatMsg,
 ) -> Line<'static> {
     let spoken = |r: Role| r != Role::System;
-    if theme.show_separator && prev.is_none_or(|p| spoken(p.role)) && spoken(m.role) {
-        Line::styled(
-            "─".repeat(SEPARATOR_WIDTH),
-            Style::default().fg(theme.separator),
-        )
+    if matches!(theme.border_type, BorderType::Rounded)
+        && prev.is_none_or(|p| spoken(p.role))
+        && spoken(m.role)
+    {
+        Line::styled("─".repeat(SEPARATOR_WIDTH), theme.border)
     } else {
         Line::default()
     }
@@ -78,13 +79,11 @@ pub(super) fn push_agent_header(
 ) {
     let (bullet, header_style) = if m.streaming {
         let spin = SPINNER[spinner % SPINNER.len()];
-        (format!("{spin} agent"), Style::default().fg(theme.agent))
+        (format!("{spin} agent"), theme.accent)
     } else {
         (
             "● agent".to_string(),
-            Style::default()
-                .fg(theme.agent)
-                .add_modifier(Modifier::BOLD),
+            theme.accent.add_modifier(Modifier::BOLD),
         )
     };
     lines.push(Line::from(Span::styled(bullet, header_style)));
@@ -92,9 +91,7 @@ pub(super) fn push_agent_header(
         for l in m.thinking.lines() {
             lines.push(Line::styled(
                 format!("{MSG_INDENT}{l}"),
-                Style::default()
-                    .fg(theme.thinking)
-                    .add_modifier(Modifier::ITALIC | Modifier::DIM),
+                theme.muted.add_modifier(Modifier::ITALIC | Modifier::DIM),
             ));
         }
     }
@@ -122,14 +119,10 @@ pub(super) fn agent_body_lines(
         // Trailing spinner so the user sees liveness.
         let spin = SPINNER[spinner % SPINNER.len()];
         match body.last_mut() {
-            Some(last) => last.spans.push(Span::styled(
-                format!(" {spin}"),
-                Style::default().fg(theme.agent),
-            )),
-            None => body.push(Line::styled(
-                spin.to_string(),
-                Style::default().fg(theme.agent),
-            )),
+            Some(last) => last
+                .spans
+                .push(Span::styled(format!(" {spin}"), theme.accent)),
+            None => body.push(Line::styled(spin.to_string(), theme.accent)),
         }
         body
     } else if let Some(cached) = cached {
@@ -166,23 +159,23 @@ pub(super) fn push_message(
         Role::User => {
             lines.push(Line::from(Span::styled(
                 "you ›",
-                Style::default().fg(theme.user).add_modifier(Modifier::BOLD),
+                theme.accent_alt.add_modifier(Modifier::BOLD),
             )));
             for l in m.text.lines() {
                 lines.push(Line::styled(
                     format!("{MSG_INDENT}{l}"),
-                    Style::default().fg(theme.user_text),
+                    theme.text.add_modifier(Modifier::DIM),
                 ));
             }
         }
         Role::System => {
             // Severity paints the whole note and picks a lead glyph, so a
             // warning reads amber and a success reads green at a glance.
-            let (color, glyph) = match m.severity {
-                Severity::Info => (theme.system, "·"),
+            let (style, glyph) = match m.severity {
+                Severity::Info => (theme.muted, "·"),
                 Severity::Warn => (theme.warn, "▲"),
                 Severity::Error => (theme.error, "✖"),
-                Severity::Success => (theme.success, "✔"),
+                Severity::Success => (theme.ok, "✔"),
             };
             let bold = !matches!(m.severity, Severity::Info);
             for (i, l) in m.text.lines().enumerate() {
@@ -191,7 +184,7 @@ pub(super) fn push_message(
                 } else {
                     "  ".to_string()
                 };
-                let mut style = Style::default().fg(color);
+                let mut style = style;
                 if bold {
                     style = style.add_modifier(Modifier::BOLD);
                 }
@@ -204,16 +197,11 @@ pub(super) fn push_message(
             if let Some(first) = it.next() {
                 lines.push(Line::styled(
                     first.to_string(),
-                    Style::default()
-                        .fg(theme.shell)
-                        .add_modifier(Modifier::BOLD),
+                    theme.accent_alt.add_modifier(Modifier::BOLD),
                 ));
             }
             for l in it {
-                lines.push(Line::styled(
-                    l.to_string(),
-                    Style::default().fg(theme.system),
-                ));
+                lines.push(Line::styled(l.to_string(), theme.muted));
             }
         }
         Role::Agent => {
@@ -245,14 +233,14 @@ pub(super) fn push_message(
 mod settlement_paint_tests {
     use super::push_message;
     use crate::cmd::agent::cli::app::{ChatMsg, Role};
-    use crate::cmd::agent::cli::theme::DARK;
+    use crate::cmd::agent::cli::theme::ANSI;
 
     #[test]
     fn a_carried_settlement_is_painted_after_the_body() {
         let mut m = ChatMsg::for_test(Role::Agent, "did it");
         m.settlement = Some("  ✔ bash · cargo test".into());
         let mut lines = Vec::new();
-        push_message(&mut lines, &m, 0, &DARK, false, 60);
+        push_message(&mut lines, &m, 0, &ANSI, false, 60);
         let text: Vec<String> = lines
             .iter()
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
@@ -271,7 +259,7 @@ mod settlement_paint_tests {
     fn a_message_without_one_paints_nothing_extra() {
         let m = ChatMsg::for_test(Role::Agent, "did it");
         let mut lines = Vec::new();
-        push_message(&mut lines, &m, 0, &DARK, false, 60);
+        push_message(&mut lines, &m, 0, &ANSI, false, 60);
         let text: Vec<String> = lines
             .iter()
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
@@ -285,7 +273,7 @@ mod gap_tests {
     use super::{gap_row, wants_gap_before};
     use crate::cmd::agent::cli::app::{ChatMsg, Role};
     use crate::cmd::agent::cli::step::StepCard;
-    use crate::cmd::agent::cli::theme::{DARK, MUR};
+    use crate::cmd::agent::cli::theme::{ANSI, MUR};
 
     fn card_msg() -> ChatMsg {
         ChatMsg::tool_for_test(StepCard::new(
@@ -318,7 +306,7 @@ mod gap_tests {
             ChatMsg::for_test(Role::User, "hi"),
             ChatMsg::for_test(Role::Agent, "hello"),
         );
-        let blank: String = gap_row(&DARK, Some(&u), &a)
+        let blank: String = gap_row(&ANSI, Some(&u), &a)
             .spans
             .iter()
             .map(|s| s.content.as_ref())
@@ -333,7 +321,7 @@ mod gap_tests {
             .iter()
             .map(|s| s.content.as_ref())
             .collect();
-        if MUR.show_separator {
+        if matches!(MUR.border_type, ratatui::widgets::BorderType::Rounded) {
             assert!(ruled.contains('─'), "a ruled skin draws a rule: {ruled:?}");
         }
     }

--- a/mur-core/src/cmd/agent/cli/ui/rail.rs
+++ b/mur-core/src/cmd/agent/cli/ui/rail.rs
@@ -2,7 +2,7 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::Modifier;
 use ratatui::text::{Line, Text};
 use ratatui::widgets::Paragraph;
 
@@ -48,39 +48,31 @@ pub(super) fn rail_lines(
         Some(n) => format!("{}  {n}", view.jobs_line),
         None => view.jobs_line.clone(),
     };
-    lines.push(Line::styled(
-        head,
-        Style::default()
-            .fg(theme.border_title)
-            .add_modifier(Modifier::BOLD),
-    ));
+    lines.push(Line::styled(head, theme.muted.add_modifier(Modifier::BOLD)));
 
     if rail_height_for(view) > 1 {
         for m in view.members.iter().take(MAX_EXPANDED_ROWS) {
-            let (body, color) = match &m.state {
+            let (body, style) = match &m.state {
                 MemberState::Blocked { summary, .. } => (format!("blocked: {summary}"), theme.warn),
                 MemberState::Working { tool, since } => (
                     match tool {
                         Some(t) => format!("working ({}) · {t}", elapsed(*since)),
                         None => format!("working ({})", elapsed(*since)),
                     },
-                    theme.agent,
+                    theme.accent,
                 ),
-                MemberState::Done => ("done".to_string(), theme.success),
+                MemberState::Done => ("done".to_string(), theme.ok),
                 MemberState::Failed => ("failed".to_string(), theme.error),
             };
             let glyph = m.state.glyph();
             lines.push(Line::styled(
                 format!("  {:<10} {glyph} {body}", m.agent),
-                Style::default().fg(color),
+                style,
             ));
         }
         let extra = view.members.len().saturating_sub(MAX_EXPANDED_ROWS);
         if extra > 0 {
-            lines.push(Line::styled(
-                format!("  … {extra} more"),
-                Style::default().fg(theme.system),
-            ));
+            lines.push(Line::styled(format!("  … {extra} more"), theme.muted));
         }
     }
 

--- a/mur-core/src/cmd/agent/cli/ui/status.rs
+++ b/mur-core/src/cmd/agent/cli/ui/status.rs
@@ -22,7 +22,7 @@ pub(super) const AUTO_NAMES_MAX: usize = 24;
 
 pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
     let theme = app.theme;
-    let (msg, color) = if let Some(req) = &app.hitl {
+    let (msg, style) = if let Some(req) = &app.hitl {
         // Surface the auto-deny clock: the gate expires approvals after
         // DEFAULT_TIMEOUT (300s). Reuse `created_at` rather than tracking new
         // state; the status bar redraws on each blink deadline so it ticks.
@@ -34,7 +34,7 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
             .saturating_sub(req.created_at.elapsed().as_secs());
         (
             format!("⏳ approve {} · auto-deny in {remaining}s", req.tool_name),
-            Color::Yellow,
+            Style::default().fg(Color::Yellow),
         )
     } else if app.streaming {
         let spin = SPINNER[app.spinner % SPINNER.len()];
@@ -45,20 +45,17 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
         } else {
             format!("{spin} generating…")
         };
-        (msg, theme.agent)
+        (msg, theme.accent)
     } else {
         let ctx = if app.context_task_id.is_some() {
             " · context kept"
         } else {
             ""
         };
-        (format!("ready{ctx}"), theme.system)
+        (format!("ready{ctx}"), theme.muted)
     };
     let mut spans = vec![
-        Span::styled(
-            format!(" {} ", app.agent),
-            Style::default().fg(theme.badge_fg).bg(theme.badge_bg),
-        ),
+        Span::styled(format!(" {} ", app.agent), theme.badge),
         Span::raw("  "),
     ];
     // Auto-approval visibility (#8 / proposal 2). All three auto-approval
@@ -116,13 +113,10 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
         // `⏵ 019ff831:working   ready`. Two sources for one fact; the live one
         // wins and the stale one is gone (#940).
         let short: String = meta.id.chars().take(8).collect();
-        spans.push(Span::styled(
-            format!(" ⏵ {short} "),
-            Style::default().fg(theme.agent),
-        ));
+        spans.push(Span::styled(format!(" ⏵ {short} "), theme.accent));
         spans.push(Span::raw("  "));
     }
-    spans.push(Span::styled(msg, Style::default().fg(color)));
+    spans.push(Span::styled(msg, style));
 
     // Glass Box observability: tokens · cost · ctx · timer.
     //
@@ -153,19 +147,16 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
     );
     if !obs.is_empty() {
         spans.push(Span::raw(FOOTER_SEP));
-        spans.push(Span::styled(obs, Style::default().fg(theme.system)));
+        spans.push(Span::styled(obs, theme.muted));
     }
     if let Some(t) = timer {
-        spans.push(Span::styled(
-            format!("{FOOTER_SEP}{t}"),
-            Style::default().fg(theme.system),
-        ));
+        spans.push(Span::styled(format!("{FOOTER_SEP}{t}"), theme.muted));
     }
 
-    let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
+    let right_hint: Option<(String, Style)> = if app.scroll_back > 0 {
         Some((
             format!("↑ {} lines · ⬇ to bottom", app.scroll_back),
-            theme.system,
+            theme.muted,
         ))
     } else if app.esc_hint {
         let hint = if app.streaming {
@@ -173,14 +164,14 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
         } else {
             "ESC again to clear"
         };
-        Some((hint.to_string(), theme.system))
+        Some((hint.to_string(), theme.muted))
     } else if app.ctrl_c_hint {
-        Some(("Ctrl+C again to quit".to_string(), theme.system))
+        Some(("Ctrl+C again to quit".to_string(), theme.muted))
     } else {
         None
     };
 
-    if let Some((hint_text, hint_color)) = right_hint {
+    if let Some((hint_text, hint_style)) = right_hint {
         let hint_display = format!(" {} ", hint_text);
         let hint_width = hint_display.chars().count() as u16;
         let left_width: u16 = spans.iter().map(|s| s.content.chars().count() as u16).sum();
@@ -191,7 +182,7 @@ pub(super) fn render_status(f: &mut Frame, app: &App, area: Rect) {
             spans.push(Span::raw(" ".repeat(pad as usize)));
             spans.push(Span::styled(
                 hint_display,
-                Style::default().fg(hint_color).add_modifier(Modifier::DIM),
+                hint_style.add_modifier(Modifier::DIM),
             ));
         }
     }

--- a/mur-core/src/cmd/agent/cli/welcome.rs
+++ b/mur-core/src/cmd/agent/cli/welcome.rs
@@ -143,7 +143,7 @@ pub fn resolve_mascot_mode(theme: &Theme, is_tty: bool) -> MascotMode {
     if !is_tty || no_color_env() || term_is_dumb() {
         return MascotMode::Off;
     }
-    MascotMode::Accent(theme.accent)
+    MascotMode::Accent(theme.accent.fg.unwrap_or(Color::Reset))
 }
 
 fn no_color_env() -> bool {
@@ -200,7 +200,7 @@ pub fn welcome_lines(
 ) -> Vec<Line<'static>> {
     let mascot_style = match mode {
         MascotMode::Accent(c) => Style::default().fg(c),
-        MascotMode::Off => Style::default().fg(theme.system),
+        MascotMode::Off => theme.muted,
     };
     // In Off mode the eye is always open (truly static — no animation); otherwise
     // the eye frame follows the wall-clock blink phase passed by the caller.
@@ -227,24 +227,20 @@ pub fn welcome_lines(
     // relative paths were handed over that could not resolve and the failure
     // looked like a missing file (#940).
     lines.push(Line::from(vec![
-        Span::styled(
-            agent.to_string(),
-            Style::default()
-                .fg(theme.agent)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled("  ·  shell ", Style::default().fg(theme.separator)),
-        Span::styled(pretty_cwd(cwd), Style::default().fg(theme.system)),
+        Span::styled(agent.to_string(), theme.accent.add_modifier(Modifier::BOLD)),
+        Span::styled("  ·  shell ", theme.muted),
+        Span::styled(pretty_cwd(cwd), theme.muted),
     ]));
     lines.push(Line::default());
 
     // ONE example to seed the first message.
     lines.push(Line::from(vec![
-        Span::styled("Try  ", Style::default().fg(theme.system)),
+        Span::styled("Try  ", theme.muted),
         Span::styled(
             "\"explain this repo\"",
-            Style::default()
-                .fg(theme.user_text)
+            theme
+                .text
+                .add_modifier(Modifier::DIM)
                 .add_modifier(Modifier::ITALIC),
         ),
     ]));
@@ -252,17 +248,9 @@ pub fn welcome_lines(
     // Single discoverability hint — full reference lives behind /help. Surface
     // Ctrl+V image paste here too (it was previously undiscoverable).
     lines.push(Line::from(vec![
-        Span::styled("Type ", Style::default().fg(theme.system)),
-        Span::styled(
-            "/help",
-            Style::default()
-                .fg(theme.agent)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            " for commands · Ctrl+V pastes a screenshot",
-            Style::default().fg(theme.system),
-        ),
+        Span::styled("Type ", theme.muted),
+        Span::styled("/help", theme.accent.add_modifier(Modifier::BOLD)),
+        Span::styled(" for commands · Ctrl+V pastes a screenshot", theme.muted),
     ]));
 
     lines
@@ -347,7 +335,7 @@ mod tests {
 
     #[test]
     fn resolve_off_when_not_tty() {
-        let m = resolve_mascot_mode(&super::super::theme::DARK, false);
+        let m = resolve_mascot_mode(&super::super::theme::ANSI, false);
         assert_eq!(m, MascotMode::Off);
     }
 
@@ -371,7 +359,7 @@ mod tests {
     #[test]
     fn the_identity_line_labels_the_path_as_the_shell_cwd() {
         let lines = welcome_lines(
-            &super::super::theme::DARK,
+            &super::super::theme::ANSI,
             MascotMode::Off,
             "repomanager",
             Some(std::path::Path::new("/a/b/c")),
@@ -395,7 +383,7 @@ mod tests {
         // Off mode is truly static: even with eye_open=false, render the REST
         // (open-eye) frame — never the blink frame.
         let lines = welcome_lines(
-            &super::super::theme::DARK,
+            &super::super::theme::ANSI,
             MascotMode::Off,
             "a",
             None,


### PR DESCRIPTION
## Summary

PR-1 of the skin redesign (spec + plan: #1229). **Structure only — no visual change intended.**

- `Theme` collapses from 22 hand-filled `Color` fields to eleven `Style` tokens (`text`, `muted`, `emphasis`, `accent`, `accent_alt`, `ok`, `warn`, `error`, `border`, `surface`, `badge`) plus the three layout knobs. Every paint site in `cmd/agent/cli/` takes a token; none composes a colour and a modifier of its own.
- `ansi` is the new name of the terminal-following skin; `dark` stays as an alias (`resolve_skin`, `is_known_skin`, saved config). `/skin` notices, the completion menu and the startup fallback say `ansi, light, mur`.
- Palettes hold today's values. Where two old fields merged, the surviving value:

| token | ANSI (was DARK) | LIGHT | MUR |
|---|---|---|---|
| `text` | `agent_text` #eaeaea | #222233 | #e0e0f0 |
| `muted` | `system` #8a8a8a | `system` #777788 | `system` #7777aa |
| `accent` / `accent_alt` | Cyan / Green | #0e6b8c / #166534 | #fbbf24 / #a78bfa |
| `ok` / `warn` / `error` | unchanged | unchanged | unchanged |
| `border` / `surface` / `badge` | unchanged | unchanged | unchanged |

Moved by construction (merged roles): `user_text` → `text`+DIM; `thinking` and `border_title` → `muted`; the welcome's `separator`-coloured dot → `muted`.

Found while pinning: a finished reply's body never took `agent_text` — markdown-rendered prose carries the terminal's own foreground. Pinned as-is; PR-2 decides whether `text` should reach the renderer.

## Test plan

- [x] `theme` tests: `dark` resolves to `ANSI`, `skin_name` says `ansi`, unknown → `ansi`.
- [x] `token_pin_tests`: under each skin the agent label carries `accent`, the notice `muted`, the body the renderer's own foreground.
- [x] `cargo nextest run -p mur-core --lib` — 2722 passed; clippy `-D warnings`, fmt clean.
- [x] Live (tmux, this build installed): mascot and identity line are cyan under `dark`/`ansi`, #0e6b8c under `light`, gold under `mur`; grey notices and borders match the old values per skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)