### PR TITLE
chore(release): bump workspace version to 2.77.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.76.0"
+version = "2.77.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.76.0"
+version = "2.77.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Release 2.77.0

Merging this PR is the release: `tag.yml` tags `v2.77.0` and dispatches `release.yml`.

### murmur
- Live band grows upward: an open suggested-reply chooser no longer hides the reply; no rule above the transcript; the mascot stays until the band fills (#1223).
- Markdown tables render as a box, columns share the pane width (widest column squeezed first), cells wrap, CJK-aligned (#1226).
- `/model` hot-switches chain/routing agents too (swaps the primary, keeps the chain); murmur persists the pick because the sealed runtime cannot write its own profile (#1227).
- Auto-approve is the session default; `--ask` opts back into ask-first (#1228).
- Skins: `Theme` is eleven semantic tokens; `ansi` (default, follows the terminal; `dark` alias) / `light` / `mur` with WCAG contrast guards; no rule between turns; composer top rule only; accent on focused panels (#1230, #1231; spec #1229).
- `ui.rs` split into `ui/{band,message,chooser,rail,status,hitl}` (#1224).

### Hub
- Concierge prompt: reply length follows the task instead of a one-sentence cap (#1225).
- Claude Subscription aliases are `anthropic_`, not `chatgpt_` (#1222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)