### PR TITLE
fix(murmur): breathing room — composer padding, gaps before cards and settlement, padded tables

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1610,14 +1610,14 @@ impl App {
                 .borders(Borders::TOP)
                 .border_type(theme.border_type)
                 .border_style(theme.error)
-                .padding(Padding::horizontal(theme.inner_padding as u16))
+                .padding(composer_padding(theme))
                 .title(" ! shell command — output shared with agent ")
         } else {
             Block::default()
                 .borders(Borders::TOP)
                 .border_type(theme.border_type)
                 .border_style(theme.border)
-                .padding(Padding::horizontal(theme.inner_padding as u16))
+                .padding(composer_padding(theme))
                 .title(hint)
                 .title_style(theme.muted)
         };
@@ -1626,11 +1626,24 @@ impl App {
 }
 
 /// Build the styled multiline input widget.
+/// The composer's inner padding: the skin's horizontal padding, plus one
+/// blank row above and below the text so the input does not sit jammed
+/// between its rule and the status bar.
+fn composer_padding(theme: &Theme) -> Padding {
+    let h = u16::from(theme.inner_padding);
+    Padding::new(h, h, COMPOSER_PAD_ROWS, COMPOSER_PAD_ROWS)
+}
+
+/// Blank rows above and below the composer text. `ui::INPUT_H_MIN` counts
+/// them; change both together.
+pub(super) const COMPOSER_PAD_ROWS: u16 = 1;
+
 fn new_input() -> TextArea<'static> {
     let mut ta = TextArea::default();
     ta.set_block(
         Block::default()
             .borders(Borders::TOP)
+            .padding(Padding::new(0, 0, COMPOSER_PAD_ROWS, COMPOSER_PAD_ROWS))
             .title(ENTER_HINT_COMPACT),
     );
     ta.set_cursor_line_style(Style::default());

--- a/mur-core/src/cmd/agent/cli/markdown.rs
+++ b/mur-core/src/cmd/agent/cli/markdown.rs
@@ -29,6 +29,10 @@ const MIN_BODY_COLS: usize = 20;
 /// Narrowest a table column is ever squeezed to.
 const MIN_COL: usize = 4;
 
+/// Spaces between a cell's text and its borders, each side. One read as
+/// cramped, especially around CJK text.
+const CELL_PAD: usize = 2;
+
 /// Columns a message body may use inside a pane `pane_width` wide: the pane
 /// minus its horizontal padding on both sides and the body indent.
 pub(crate) fn body_cols(pane_width: u16, inner_padding: u8) -> usize {
@@ -136,10 +140,18 @@ impl Renderer {
             Event::End(tag) => self.end(tag),
             Event::Text(t) => {
                 if self.in_code_block {
-                    // Code text may contain newlines; render each as its own line.
-                    for (i, part) in t.split('\n').enumerate() {
+                    // Code text may contain newlines; render each as its own
+                    // line. A fenced block's text ends in one, and that final
+                    // empty part is not a line: pushing it painted a blank
+                    // that `blank_line` then doubled.
+                    let parts: Vec<&str> = t.split('\n').collect();
+                    let last = parts.len() - 1;
+                    for (i, part) in parts.into_iter().enumerate() {
                         if i > 0 {
                             self.flush_line();
+                        }
+                        if i == last && part.is_empty() {
+                            break;
                         }
                         self.cur
                             .push(Span::styled(part.to_string(), Style::default().fg(CODE)));
@@ -156,7 +168,18 @@ impl Renderer {
                     self.cur.push(span);
                 }
             }
-            Event::SoftBreak => self.cur.push(Span::raw(" ".to_string())),
+            // A line break the author typed is a line break on screen —
+            // models lay out "label:\n• item" with a bare newline and no
+            // list marker, and joining it into one line loses the shape.
+            // Inside a table cell there is nowhere to break to.
+            Event::SoftBreak => {
+                if self.in_table {
+                    self.table_cur_cell.push(Span::raw(" ".to_string()));
+                } else {
+                    self.flush_line();
+                    self.indent();
+                }
+            }
             Event::HardBreak => self.flush_line(),
             Event::Rule => {
                 self.flush_line();
@@ -321,15 +344,16 @@ impl Renderer {
                 natural[i] = natural[i].max(Line::from(cell.clone()).width());
             }
         }
-        // Every column costs its text plus one space each side and a border;
-        // the last border closes the row.
-        let room = self.width.saturating_sub(3 * ncols + 1);
+        // Every column costs its text plus its padding each side and a
+        // border; the last border closes the row.
+        let room = self.width.saturating_sub((2 * CELL_PAD + 1) * ncols + 1);
+        let pad = " ".repeat(CELL_PAD);
         let widths = fit_columns(&natural, room);
 
         let rule = |l: &str, m: &str, r: &str| -> Line<'static> {
             let bars = widths
                 .iter()
-                .map(|w| "─".repeat(w + 2))
+                .map(|w| "─".repeat(w + 2 * CELL_PAD))
                 .collect::<Vec<_>>()
                 .join(m);
             Line::styled(format!("{l}{bars}{r}"), Style::default().fg(QUOTE))
@@ -345,10 +369,10 @@ impl Renderer {
                 .collect();
             let height = cells.iter().map(Vec::len).max().unwrap_or(1);
             for k in 0..height {
-                let mut line: Vec<Span<'static>> = vec![Span::styled("│ ", border)];
+                let mut line: Vec<Span<'static>> = vec![Span::styled(format!("│{pad}"), border)];
                 for (ci, cell) in cells.iter().enumerate() {
                     if ci > 0 {
-                        line.push(Span::styled(" │ ", border));
+                        line.push(Span::styled(format!("{pad}│{pad}"), border));
                     }
                     let (text, used) = match cell.get(k) {
                         Some(l) => (l.spans.clone(), l.width()),
@@ -364,7 +388,7 @@ impl Renderer {
                     }
                     line.push(Span::raw(" ".repeat(widths[ci].saturating_sub(used))));
                 }
-                line.push(Span::styled(" │", border));
+                line.push(Span::styled(format!("{pad}│"), border));
                 self.lines.push(Line::from(line));
             }
             if ri == 0 {
@@ -664,6 +688,31 @@ mod tests {
     fn renders_code_block_contents() {
         let t = render("```\nlet x = 1;\n```");
         assert!(plain(&t).contains("let x = 1;"));
+    }
+
+    /// The fence's trailing newline used to paint a blank that `blank_line`
+    /// then doubled: two empty rows under every code block.
+    #[test]
+    fn a_code_block_is_followed_by_exactly_one_blank_row() {
+        let r = rows(&render("before\n\n```\nlet x = 1;\n```\n\nafter"));
+        assert_eq!(r, vec!["before", "", "let x = 1;", "", "after"]);
+    }
+
+    /// A newline the author typed inside a paragraph stays a newline.
+    #[test]
+    fn a_soft_break_starts_a_new_line() {
+        assert_eq!(
+            rows(&render("憑據：\n• x\n• y")),
+            vec!["憑據：", "• x", "• y"]
+        );
+    }
+
+    /// Two spaces between a cell's text and its border, each side.
+    #[test]
+    fn table_cells_are_padded() {
+        let r = rows(&render("| a | b |\n| --- | --- |\n| 1 | 2 |"));
+        assert_eq!(r[1], "│  a  │  b  │", "header: {r:?}");
+        assert_eq!(r[3], "│  1  │  2  │", "body: {r:?}");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -36,12 +36,16 @@ use super::complete;
 /// unhandled into the input box.
 const OVERLAY_HINT: &str = " press Enter or Esc to return · Ctrl+D quit ";
 
-/// Composer height when the input is empty (one text row plus its top rule;
-/// the status bar's own rule is the seam beneath). Typing grows it up to
-/// `INPUT_H_MAX`.
-pub(super) const INPUT_H_MIN: u16 = 2;
+/// Rows the composer spends on chrome: its top rule plus the blank row above
+/// and below the text (`app::COMPOSER_PAD_ROWS`).
+const INPUT_CHROME_ROWS: u16 = 1 + 2 * super::app::COMPOSER_PAD_ROWS;
 
-const INPUT_H_MAX: u16 = 8;
+/// Composer height when the input is empty (one text row plus the chrome;
+/// the status bar sits directly beneath). Typing grows it up to
+/// `INPUT_H_MAX`, which leaves seven text rows.
+pub(super) const INPUT_H_MIN: u16 = 1 + INPUT_CHROME_ROWS;
+
+const INPUT_H_MAX: u16 = 7 + INPUT_CHROME_ROWS;
 
 /// Draw the whole UI for one frame.
 pub fn render(f: &mut Frame, app: &mut App) {
@@ -53,7 +57,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
         return;
     }
     let input_lines = app.input.lines().len() as u16;
-    let input_height = (input_lines + 1).clamp(INPUT_H_MIN, INPUT_H_MAX);
+    let input_height = (input_lines + INPUT_CHROME_ROWS).clamp(INPUT_H_MIN, INPUT_H_MAX);
     // The agent chooser (suggested replies) renders as its own layout band
     // between transcript and composer — never a Clear-overlay popup — so it
     // can't cover the reply the user must read to choose. The slash-command

--- a/mur-core/src/cmd/agent/cli/ui/band.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band.rs
@@ -399,6 +399,10 @@ pub fn flush_finished<B: Backend>(
             None,
             width,
         ));
+        // The block ended at a blank line and the renderer trims its own
+        // trailing blank; put the separator back, or every paragraph a
+        // streaming reply spilled sat flush against the next.
+        lines.push(Line::default());
         emit(terminal, lines, pad, width)?;
         skip += block_end;
         app.flushed_bytes = skip;

--- a/mur-core/src/cmd/agent/cli/ui/band.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band.rs
@@ -167,7 +167,7 @@ pub(super) fn message_block(
     let mut lines: Vec<Line<'static>> = Vec::new();
     // Never before a continuation: `skip > 0` resumes a message whose head is
     // already committed above.
-    if idx > 0 && skip == 0 && wants_gap_before(m) {
+    if idx > 0 && skip == 0 && wants_gap_before(app.messages.get(idx - 1), m) {
         lines.push(gap_row(app.theme, app.messages.get(idx - 1), m));
     }
     if measured {

--- a/mur-core/src/cmd/agent/cli/ui/band/tests.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band/tests.rs
@@ -393,20 +393,22 @@ mod layout_guard_tests {
         let d = term.backend().to_string();
         let rows: Vec<&str> = d.lines().map(|l| l.trim_matches('"')).collect();
         let status = rows[rows.len() - 1];
-        let input = rows[rows.len() - 2];
-        let rule = rows[rows.len() - 3];
+        let pad_below = rows[rows.len() - 2];
+        let input = rows[rows.len() - 3];
+        let pad_above = rows[rows.len() - 4];
+        let rule = rows[rows.len() - 5];
         assert!(status.contains("ready"), "status bar not last:\n{d}");
         assert!(
+            pad_below.trim().is_empty() && pad_above.trim().is_empty(),
+            "the input text must have a blank row above and below:\n{d}"
+        );
+        assert!(
             input.contains("Type a message"),
-            "input row not above the status bar:\n{d}"
+            "input row not two above the status bar:\n{d}"
         );
         assert!(
             rule.contains("message —"),
-            "composer rule not above the input row:\n{d}"
-        );
-        assert!(
-            !input.contains('─'),
-            "a rule between input and status bar:\n{d}"
+            "composer rule not above the padded input:\n{d}"
         );
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui/band/tests.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band/tests.rs
@@ -412,3 +412,93 @@ mod layout_guard_tests {
         );
     }
 }
+
+/// Paragraph spacing survives both paint paths: a blank line is one row in
+/// the band and one row in scrollback.
+#[cfg(test)]
+mod paragraph_spacing_tests {
+    use super::super::super::super::app::{App, ChatMsg, RenderMode, Role};
+    use super::super::super::render;
+    use super::super::{flush_finished, render_transcript};
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use ratatui::{Terminal, TerminalOptions, Viewport};
+
+    fn rows(term: &Terminal<TestBackend>) -> Vec<String> {
+        let buf = term.backend().buffer();
+        (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf.cell((x, y)).unwrap().symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    fn blanks_between(rows: &[String], a: &str, b: &str) -> usize {
+        let ia = rows
+            .iter()
+            .position(|r| r.contains(a))
+            .unwrap_or_else(|| panic!("{a}: {rows:?}"));
+        let ib = rows
+            .iter()
+            .position(|r| r.contains(b))
+            .unwrap_or_else(|| panic!("{b}: {rows:?}"));
+        rows[ia + 1..ib].iter().filter(|r| r.is_empty()).count()
+    }
+
+    /// The band: a finished reply's blank line used to paint as two rows,
+    /// because the indent turned it into a whitespace-only line and
+    /// `Wrap { trim: false }` gives those two rows.
+    #[test]
+    fn a_blank_line_is_one_row_in_the_band() {
+        let mut app = App::test_fixture();
+        app.welcome_dismissed = true;
+        app.messages
+            .push(ChatMsg::for_test(Role::Agent, "first\n\nsecond"));
+        let mut term = Terminal::new(TestBackend::new(60, 12)).unwrap();
+        term.draw(|f| render_transcript(f, &mut app, Rect::new(0, 0, 60, 12)))
+            .unwrap();
+        let r = rows(&term);
+        assert_eq!(blanks_between(&r, "first", "second"), 1, "{r:?}");
+    }
+
+    /// Scrollback: paragraphs a streaming reply spilled block by block kept
+    /// no blank between them (each chunk's trailing blank was trimmed), while
+    /// the live tail double-spaced them. One row, both places.
+    #[test]
+    fn spilled_paragraphs_keep_one_blank_between_them() {
+        let mut app = App::test_fixture();
+        app.render_mode = RenderMode::Inline;
+        app.welcome_dismissed = true;
+        app.width = 80;
+        app.messages.push(ChatMsg::for_test(Role::User, "hi"));
+        app.streaming = true;
+        let mut term = Terminal::with_options(
+            TestBackend::new(80, 40),
+            TerminalOptions {
+                viewport: Viewport::Inline(12),
+            },
+        )
+        .unwrap();
+        for p in [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        ] {
+            app.append_delta(&format!("{p}\n\n"), false);
+            flush_finished(&mut term, &mut app, 12).unwrap();
+            term.draw(|f| render(f, &mut app)).unwrap();
+        }
+        let r = rows(&term);
+        // Spilled into scrollback by the block-at-a-time path.
+        assert_eq!(blanks_between(&r, "alpha", "bravo"), 1, "scrollback: {r:?}");
+        assert_eq!(
+            blanks_between(&r, "bravo", "charlie"),
+            1,
+            "scrollback: {r:?}"
+        );
+        // Still in the live band.
+        assert_eq!(blanks_between(&r, "golf", "hotel"), 1, "band: {r:?}");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/ui/message.rs
+++ b/mur-core/src/cmd/agent/cli/ui/message.rs
@@ -12,6 +12,12 @@ pub(super) const MSG_INDENT: &str = markdown::BODY_INDENT;
 
 /// Prepend the body indent to an already-styled line (e.g. cached markdown).
 pub(super) fn indent_line(mut line: Line<'static>) -> Line<'static> {
+    // A blank stays a blank. Indenting it makes a whitespace-only line, and
+    // ratatui's `Wrap { trim: false }` paints one of those as TWO rows — every
+    // paragraph break in a reply showed up double-spaced.
+    if line.width() == 0 {
+        return line;
+    }
     line.spans.insert(0, Span::raw(MSG_INDENT));
     line
 }
@@ -103,7 +109,13 @@ pub(super) fn agent_body_lines(
     if streaming {
         let mut body: Vec<Line<'static>> = text
             .lines()
-            .map(|l| Line::raw(format!("{MSG_INDENT}{l}")))
+            .map(|l| {
+                if l.is_empty() {
+                    Line::default()
+                } else {
+                    Line::raw(format!("{MSG_INDENT}{l}"))
+                }
+            })
             .collect();
         // Trailing spinner so the user sees liveness.
         let spin = SPINNER[spinner % SPINNER.len()];

--- a/mur-core/src/cmd/agent/cli/ui/message.rs
+++ b/mur-core/src/cmd/agent/cli/ui/message.rs
@@ -33,9 +33,14 @@ pub(super) fn indent_line(mut line: Line<'static>) -> Line<'static> {
 /// read as ten unrelated events — twenty rows of scrollback for ten facts.
 /// Suppressing the gap there is what turns vertical rhythm into grouping
 /// instead of uniform repetition: every remaining gap now marks a real
-/// boundary.
-pub(super) fn wants_gap_before(m: &crate::cmd::agent::cli::app::ChatMsg) -> bool {
-    m.step.is_none()
+/// boundary — including the one where a run of cards begins: the first card
+/// after a spoken turn opens a gap, so the block of work is set off from the
+/// message that asked for it instead of hanging off its last line.
+pub(super) fn wants_gap_before(
+    prev: Option<&crate::cmd::agent::cli::app::ChatMsg>,
+    m: &crate::cmd::agent::cli::app::ChatMsg,
+) -> bool {
+    m.step.is_none() || prev.is_none_or(|p| p.step.is_none())
 }
 
 /// The gap before a message: a blank line in every skin. The role label is
@@ -204,6 +209,10 @@ pub(super) fn push_message(
             // that knows the pane width, and it runs every frame, so the card
             // reflows on resize for free.
             if let Some(body) = &m.settlement {
+                // A blank row between the reply and its settlement card: the
+                // card is a surface of its own and read as part of the last
+                // paragraph when it sat flush against it.
+                lines.push(Line::default());
                 let inner = width.saturating_sub(u16::from(theme.inner_padding) * 2);
                 lines.extend(crate::cmd::agent::cli::settlement::card_lines(
                     body, theme, inner,
@@ -237,6 +246,11 @@ mod settlement_paint_tests {
             text.iter().any(|l| l.contains("cargo test")),
             "card body missing: {text:?}"
         );
+        let head = text.iter().position(|l| l.contains("SETTLEMENT")).unwrap();
+        assert!(
+            head > 0 && text[head - 1].trim().is_empty(),
+            "no blank row between the reply and its card: {text:?}"
+        );
     }
 
     #[test]
@@ -268,18 +282,34 @@ mod gap_tests {
     }
 
     /// The whole point: a run of tool calls is one block of work, not N
-    /// separate events. Ten calls used to cost ten gap rows.
+    /// separate events. Ten calls used to cost ten gap rows — but the run
+    /// itself is set off from the turn that asked for it.
     #[test]
-    fn a_tool_call_does_not_open_a_gap() {
-        assert!(!wants_gap_before(&card_msg()));
+    fn a_run_of_tool_calls_opens_one_gap() {
+        let user = ChatMsg::for_test(Role::User, "hi");
+        assert!(wants_gap_before(Some(&user), &card_msg()), "first card");
+        assert!(
+            !wants_gap_before(Some(&card_msg()), &card_msg()),
+            "card after card"
+        );
     }
 
     /// Control — if this ever flips, gaps stop marking anything at all.
     #[test]
     fn a_spoken_turn_still_opens_a_gap() {
-        assert!(wants_gap_before(&ChatMsg::for_test(Role::User, "hi")));
-        assert!(wants_gap_before(&ChatMsg::for_test(Role::Agent, "hello")));
-        assert!(wants_gap_before(&ChatMsg::for_test(Role::System, "note")));
+        let card = card_msg();
+        assert!(wants_gap_before(
+            Some(&card),
+            &ChatMsg::for_test(Role::User, "hi")
+        ));
+        assert!(wants_gap_before(
+            Some(&card),
+            &ChatMsg::for_test(Role::Agent, "hello")
+        ));
+        assert!(wants_gap_before(
+            None,
+            &ChatMsg::for_test(Role::System, "note")
+        ));
     }
 
     /// One builder for the row, so the two emit paths cannot drift into
@@ -341,12 +371,24 @@ mod block_tests {
         );
     }
 
-    /// A tool call is a step inside the turn before it.
+    /// A tool call is a step inside the turn before it: the first card of a
+    /// run is set off from the message that asked, the cards after it are not.
     #[test]
-    fn a_step_card_opens_no_gap() {
-        let app = App::test_fixture();
-        let lines = text(&message_block(&app, 3, &card(), 0, false));
-        assert!(!lines.first().is_some_and(|l| is_gap(l)), "{lines:?}");
+    fn a_run_of_step_cards_opens_one_gap() {
+        let mut app = App::test_fixture();
+        app.messages.push(ChatMsg::for_test(Role::User, "hi"));
+        app.messages.push(card());
+        app.messages.push(card());
+        let first = text(&message_block(&app, 1, &app.messages[1], 0, false));
+        assert!(
+            first.first().is_some_and(|l| is_gap(l)),
+            "first card: {first:?}"
+        );
+        let second = text(&message_block(&app, 2, &app.messages[2], 0, false));
+        assert!(
+            !second.first().is_some_and(|l| is_gap(l)),
+            "second card: {second:?}"
+        );
     }
 
     /// Control — if this flips, gaps stop marking anything.


### PR DESCRIPTION
## Summary

Spacing pass on murmur after the skin redesign, from two screenshots — and one pre-existing bug the screenshots exposed.

- **Composer**: one blank row above and below the input text (`COMPOSER_PAD_ROWS`); `INPUT_H_MIN`/`INPUT_H_MAX` derive from it, so the band budget and chooser floor follow.
- **Settlement card**: a blank row between the reply and the card.
- **Tool cards**: the first card after a spoken turn opens a gap; cards after it still group (`wants_gap_before(prev, m)`).
- **Markdown**: a fenced block is followed by exactly one blank row (the fence's trailing newline painted a phantom row); a soft break inside a paragraph is a line break on screen, so `label:\n• item` keeps its shape; table cells have two spaces of padding each side.
- **Every paragraph break painted double-spaced** (visible in the very first report screenshot, before any of this week's changes): `indent_line` prefixed blank lines with the body indent, making them whitespace-only, and ratatui's `Wrap { trim: false }` paints those as two rows. Blanks now stay blank in both the cached and the streaming path. The opposite defect hid behind it in scrollback — a streaming reply spilled block by block had *no* blank between paragraphs, because the renderer trims each chunk's trailing blank — so stage 2 puts the block separator back.

## Test plan

- [x] New/updated: `composer_has_one_rule_and_the_status_bar_sits_under_the_input` (blank rows around the input), `a_run_of_step_cards_opens_one_gap`, `a_carried_settlement_is_painted_after_the_body` (blank before the card), `a_code_block_is_followed_by_exactly_one_blank_row`, `a_soft_break_starts_a_new_line`, `table_cells_are_padded`, `a_blank_line_is_one_row_in_the_band`, `spilled_paragraphs_keep_one_blank_between_them` (drives `flush_finished` through a TestBackend inline viewport).
- [x] `cargo nextest run -p mur-core --lib cmd::agent::cli::` — 370 passed; clippy `-D warnings`, fmt clean.
- [ ] Live in tmux: paragraphs single-spaced in band and scrollback, composer padded, settlement set off, first card gapped, table cells padded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)