### PR TITLE
chore(release): bump workspace version to 2.77.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.77.0"
+version = "2.77.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.0"
+version = "2.77.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## Release 2.77.1

Merging this PR is the release: `tag.yml` tags `v2.77.1` and dispatches `release.yml`.

### murmur
- Breathing room: composer padding, a gap before tool cards and the settlement card, one blank after code blocks, padded table cells — and every paragraph break used to paint double-spaced (whitespace-only lines under `Wrap { trim: false }`), while block-by-block spilled paragraphs had none (#1233).
- One viewport height: the first message no longer purges and re-anchors the transcript to the floor of a tall terminal; the viewport starts on the prompt's row and grows down (#1234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)