### PR TITLE
fix(anthropic): warn when a loopback bridge will ignore an sk-ant-oat key

### DIFF
--- a/docs/superpowers/plans/2026-09-10-deep-research-slash-handoff.md
+++ b/docs/superpowers/plans/2026-09-10-deep-research-slash-handoff.md
@@ -1,0 +1,84 @@
+# Handoff — `/deep-research` slash command + agent-visible progress
+
+> **For fleet `develop-rust`.** Execute with `mur-executing-plans`, task by task, in the order below. Delegate Rust to `rustsmith`, tests to `qa`, commits to `repomanager`; `pm` ticks the checkboxes in the plan file. Stop after each task for review.
+
+**Plan:** `docs/superpowers/plans/2026-09-10-deep-research-slash-plan.md` (5 tasks, checkbox-tracked — tick there, not in memory)
+**Spec:** `docs/superpowers/specs/2026-09-10-deep-research-slash-design.md`
+**Repo:** `/Volumes/Firecuda4tb/Projects/mur`
+**Base:** `main` @ `0b2e25b7` (spec + plan committed; no code touched)
+**Branch:** create `feat/deep-research-slash` from `main` before Task 1
+**Status:** nothing executed yet — zero of five tasks done
+
+## Goal in one breath
+
+A murmur `/deep-research` command, a `mur-deep-research` skill that documents the real flag surface, and a `fleet_run` tool that returns a `run_id` an agent can poll via `mur_job_status` — so a deep-research run is never a blind wait.
+
+## Task order and crate ownership
+
+| # | Task | Crates | Reviewer gate |
+|---|---|---|---|
+| 1 | `progress::load_view` + `render_progress(&ProgressView)` refactor | mur-core | 3 existing panel fixtures byte-identical |
+| 2 | Loop honours `MUR_RUN_ID`, self-registers in `run_status`, heartbeats per iteration, maps 9 outcomes → state | mur-core | one test per outcome variant |
+| 3 | `runs/` sandbox carve-in; `fleet_run` mints/returns `run_id`, `wait:false`; `mur_job_status` appends `progress:` | mur-agent-runtime, mur-mcp-server | default `fleet_run` output unchanged except leading `run_id:` line |
+| 4 | `/deep-research` + `/research` in murmur — argv subprocess, 5 s ticker, non-blocking | mur-core | help/complete parity tests pass |
+| 5 | Skill bump to 0.2.0 — written last, describes what shipped | mur-core | — |
+
+Tasks 1 → 2 → 3 are sequential (each builds on the previous). Task 4 depends on 1 only; Task 5 on everything. Still: **one cargo build at a time — never fan out cargo**.
+
+## Build / test env (non-negotiable)
+
+```
+PATH=$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH
+ORT_STRATEGY=download
+MUR_WEB_DIST=$HOME/Projects/mur-web/dist
+```
+
+- Test: `cargo nextest run -p <crate> <filter>`
+- Before every commit: `cargo fmt` then `cargo clippy -p <crate> -- -D warnings`
+- Commit per task, conventional prefix (`feat(fleet):`, `feat(murmur):`, `feat(mcp):`, `docs(skill):`)
+
+## Decisions already made — do not relitigate
+
+1. **Child-side registration.** `mur-agent-runtime` has no `mur-core` dep. The loop registers itself in `run_status` using the `MUR_RUN_ID` it is handed; `fleet_run` only mints the id and passes it in env. Accept the sub-second "no run recorded" window — the `wait:false` output states it.
+2. **Outcome vocabulary is 9, not 7.** `loop_run.rs:334` `outcome_label` has `converged`, `max-iterations`, `deadline`, `budget`, `queue-drained` → `Done`; `stopped`, `commander-killed` → `Stopped`; `awaiting-approval` → `Blocked`; `stuck` → `Failed`.
+3. **Slash command runs with the human's privileges** — a `mur` subprocess like `!cmd`, never the agent's `fleet_run` tool.
+4. **Progress file is the contract.** No new event channel. `~/.mur/fleets/deep-research/.run_progress.json` is read by all three surfaces through `load_view`.
+5. **`progress::load()` returns `SystemTime`, not `u64`** — `load_view` converts to age-seconds. The spec had this wrong.
+
+## Known traps (found at plan time, already accounted for in the plan)
+
+- No `temp_env` dev-dep — Task 2 factors a pure `resolve_run_id_from(env_value: Option<&str>)` so the test needs no env mutation.
+- tokio is 1.52 — `Command::process_group` is a direct method, no `tokio::process::CommandExt` gymnastics.
+- `mur_core::cmd::fleet::progress` is already `pub` — no re-export needed.
+- `fleet_run.rs:170-186` spawns with `.kill_on_drop(true)`; `wait:false` must **not** drop the child — detach it (Task 3 spells this out).
+- Sandbox carve-in loop at `policy.rs:358` is `["fleets", "commander", "conversations", "artifacts"]`; add `"runs"` and extend the guard test at `policy.rs:1150-1178` — do not add a second loop.
+
+## Anchors (so nobody re-explores)
+
+| What | Where |
+|---|---|
+| progress reader | `mur-core/src/cmd/fleet/progress.rs:158` `load()` |
+| panel renderer + fixtures | `mur-core/src/cmd/fleet/panel.rs:46`, fixtures `:213-258` |
+| loop mints id / terminal write / per-iter save | `mur-core/src/cmd/fleet/loop_run.rs:420`, `:719-725`, `:673-680` |
+| `RunState` / store save / update | `run_status/mod.rs:123-145`, `store.rs:25`, `store.rs:92` |
+| reference run-record construction | `executor/dag.rs:1055-1067` |
+| `fleet_run` spawn / timeout error | `mur-agent-runtime/src/tools/fleet_run.rs:170-186`, `:188-201` |
+| sandbox carve-in + guard test | `policy.rs:358`, `:1150-1178` |
+| `mur_job_status` renderer + tests | `mur-mcp-server/src/tools.rs:808-843`, tests `:1002-1052`, helper `call_tool_in :981` |
+| `SlashCmd` / `parse_slash` / dispatch / `HELP` | `app.rs:158`, `:212-271`, `cli/mod.rs:2222-2271`, `:196` |
+| help/complete parity tests | `cli/mod.rs:3130-3197` |
+| completion table | `complete.rs:164-200` |
+| `!cmd` shell path to mirror | `cli/mod.rs:1781` → `StreamMsg::ShellDone` → `app.push_shell` `app.rs:1467`; `app.push_system` `app.rs:925` |
+| skill | `mur-core/src/skills/mur_deep_research.yaml` |
+
+## Definition of done
+
+- [ ] All five tasks ticked in the plan file, one commit each on `feat/deep-research-slash`
+- [ ] `cargo nextest run -p mur-core -p mur-agent-runtime -p mur-mcp-server` green
+- [ ] Manual: `mur fleet run deep-research --goal "x"` from a terminal shows `run_id:`; `mur_job_status <id>` answers with a `progress:` line mid-run
+- [ ] Manual: `/deep-research status` in murmur renders the same numbers as `mur deep-research` panel
+- [ ] PR opened against `main`, body links spec + plan, lists any corrections found during execution (add a "Corrections" section to this file, as `2026-09-07-murmur-secret-handoff.md` does)
+
+## Report back
+
+Per task: commit hash, test filter run + pass count, anything the plan got wrong. At the end: PR URL and the corrections list.

--- a/docs/superpowers/plans/2026-09-10-deep-research-slash-plan.md
+++ b/docs/superpowers/plans/2026-09-10-deep-research-slash-plan.md
@@ -1,0 +1,310 @@
+# `/deep-research` Slash Command + Agent-Visible Progress — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `mur-executing-plans` (or `mur-delegate-dev` when a running coder agent is available) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking — tick them in this file, not in memory.
+
+**Goal:** A built-in murmur `/deep-research` slash command, a `mur-deep-research` skill that documents the real flag surface, and a `fleet_run` tool that returns a `run_id` an agent can poll with `mur_job_status` — so a deep-research run is never a blind wait.
+
+**Architecture:** One shared reader (`progress::load_view`) feeds three surfaces: the CLI panel (already there), the murmur slash card, and `mur_job_status`. The loop learns its `run_id` from `MUR_RUN_ID` and registers itself in `run_status`; `fleet_run` mints that id and hands it back. No new event channel — the progress file is the contract.
+
+**Tech Stack:** Rust (edition 2024), tokio, serde_json, uuid v7, existing `run_status` store, existing atomic progress writer.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-deep-research-slash-design.md`
+
+## Global Constraints
+
+- Every progress / run-record write stays best-effort (`tracing::debug!` on error, continue). A bookkeeping failure must never fail, slow, or change the loop.
+- Existing loop stdout lines stay byte-identical; additions only.
+- `render_progress`'s three existing fixtures (`panel.rs:213-258`) must produce identical output after the `&ProgressView` refactor.
+- `fleet_run` default behaviour (`wait` omitted) stays byte-for-byte except for the leading `run_id:` line.
+- The slash command runs with the **human's** privileges (a `mur` subprocess, like `!cmd`) — it never calls the agent's `fleet_run` tool.
+- Build env: PATH `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin`, `ORT_STRATEGY=download`, `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`. Test via `cargo nextest run -p <crate> <filter>`; `cargo fmt` + `cargo clippy -p <crate> -- -D warnings` before every commit. **One** build at a time — never fan out cargo.
+
+## Decision made at plan time: who registers the run
+
+`fleet_run` lives in `mur-agent-runtime/src/tools/fleet_run.rs`, and `mur-agent-runtime` depends on `mur-common` only — **no `mur-core`**, so it cannot call `run_status::store::save`. Rather than moving `RunState` into `mur-common`, the **child loop registers itself** using the `MUR_RUN_ID` it was handed (Task 2). `fleet_run` only mints the id, passes it in the env, and reports it (Task 3). Consequence: for a few hundred ms after spawn, `mur_job_status <id>` may answer "no run recorded"; the `wait:false` output says so explicitly. The `runs/` sandbox carve-in (Task 3, Step 1) is what lets the child write the record.
+
+## Outcome vocabulary (corrected from the spec's 7 to the real 9)
+
+`loop_run.rs:334` `outcome_label`:
+
+| `outcome` | `run_status::State` |
+|---|---|
+| `converged`, `max-iterations`, `deadline`, `budget`, `queue-drained` | `Done` |
+| `stopped`, `commander-killed` | `Stopped` |
+| `awaiting-approval` | `Blocked` |
+| `stuck` | `Failed` |
+
+---
+
+### Task 1: D0 — `progress::load_view` + panel refactor
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/progress.rs` (`load` at `:158` returns `Option<(RunProgress, SystemTime)>` — note `SystemTime`, not `u64` as the spec says)
+- Modify: `mur-core/src/cmd/deep_research/panel.rs` (`render_progress(p: &RunProgress, mtime_age_secs: u64)` at `:46`; fixtures `:213-258`)
+
+**Interfaces:**
+- Consumes: `RunProgress`, `STALE_AFTER_SECS`, `load` (existing).
+- Produces (used by Tasks 3, 4):
+  - `pub struct ProgressView { pub progress: RunProgress, pub age_secs: u64, pub stale: bool, pub live: bool }`
+  - `pub fn view_from(progress: RunProgress, age_secs: u64) -> ProgressView` — pure; `stale = finished_at.is_none() && age_secs > STALE_AFTER_SECS`, `live = finished_at.is_none() && !stale`.
+  - `pub fn load_view(mur_home: &Path, fleet: &str) -> Option<ProgressView>` — `load()` + mtime→`age_secs` (saturating, `0` if the clock is behind) + `view_from`.
+  - `panel::render_progress(v: &ProgressView) -> String` (signature change; body unchanged apart from reading `v.progress` / `v.age_secs`).
+
+- [ ] **Step 1: Write the failing tests** (in `progress.rs` `mod tests`)
+
+```rust
+#[test]
+fn view_truth_table() {
+    let mut p = sample(); // existing fixture helper
+    p.finished_at = None;
+    let v = view_from(p.clone(), 5);
+    assert!(v.live && !v.stale);
+    let v = view_from(p.clone(), STALE_AFTER_SECS + 1);
+    assert!(!v.live && v.stale);
+    p.finished_at = Some("2026-09-10T00:00:00Z".into());
+    let v = view_from(p, STALE_AFTER_SECS + 1);
+    assert!(!v.live && !v.stale, "finished runs are neither live nor stale");
+}
+
+#[test]
+fn load_view_missing_file_is_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(load_view(tmp.path(), "nope").is_none());
+}
+
+#[test]
+fn load_view_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    sample().save(tmp.path(), "f");
+    let v = load_view(tmp.path(), "f").expect("view");
+    assert_eq!(v.progress.run_id, "r1");
+    assert!(v.age_secs < 5);
+    assert!(v.live);
+}
+```
+
+- [ ] **Step 2: Run** `cargo nextest run -p mur-core progress::tests` — expect compile failure (`view_from` missing).
+- [ ] **Step 3: Implement** `ProgressView`, `view_from`, `load_view` in `progress.rs`. Keep `load` public and untouched.
+- [ ] **Step 4: Refactor** `panel.rs::render_progress` to `&ProgressView`; update its sole caller in `panel.rs` to go through `load_view`. Update the three fixtures to build a `ProgressView` via `view_from(p, age)` with the same `age` values they passed before — **assertions unchanged**.
+- [ ] **Step 5: Run** `cargo nextest run -p mur-core progress panel` — all green, including the three untouched panel assertions.
+- [ ] **Step 6:** `cargo fmt && cargo clippy -p mur-core -- -D warnings`; commit `feat(progress): load_view shared reader; panel renders ProgressView`.
+
+---
+
+### Task 2: D3(a) — `MUR_RUN_ID` + loop self-registration in `run_status`
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/loop_run.rs` (id minted `:420`; per-iteration save block `:673-680`; terminal write `:719-725`; `outcome_label` `:334`)
+- Reference only: `mur-core/src/executor/dag.rs:1055-1067` (canonical `RunState` construction), `run_status/store.rs:25` `save`, `:92` `update`, `run_status/heartbeat.rs:27` `beat_once`
+
+**Interfaces:**
+- Consumes: `run_status::{RunState, RunKind::Fleet, State, RUN_SCHEMA}`, `store::{save, update}`, `heartbeat::beat_once`.
+- Produces:
+  - `pub const RUN_ID_ENV: &str = "MUR_RUN_ID";` (in `loop_run.rs`, `pub` so Task 3's tool and Task 4 can name it without a string literal — tool crate re-declares it since it lacks `mur-core`; keep the two in sync via the test in Task 3 Step 5).
+  - `fn resolve_run_id_from(env: Option<&str>) -> (String, bool)` — `(value, true)` when `Some` and non-empty, else `(uuid v7, false)`. Pure; the caller passes `std::env::var(RUN_ID_ENV).ok().as_deref()`. (`temp_env` is not a dep — don't add one for this.)
+  - `fn state_for_outcome(stop: LoopStop) -> State` — the table above.
+  - Env contract: when `MUR_RUN_ID` is set, the loop (i) uses it as `RunProgress.run_id`, (ii) writes a `RunKind::Fleet` `RunState` (label = fleet name, pid = self, `state: Running`, heartbeat = now) via `store::save` before the first iteration, (iii) calls `heartbeat::beat_once` in the per-iteration save block, (iv) on exit `store::update`s `state` to `state_for_outcome(stop)`. When unset: behaviour identical to today (no run record).
+
+- [ ] **Step 1: Write the failing tests** (in `loop_run.rs` `mod tests`)
+
+```rust
+#[test]
+fn resolve_run_id_prefers_env() {
+    assert_eq!(resolve_run_id_from(Some("0192f-test")), ("0192f-test".to_string(), true));
+    let (id, from_env) = resolve_run_id_from(None);
+    assert!(!from_env);
+    assert!(uuid::Uuid::parse_str(&id).is_ok());
+    let (_, from_env) = resolve_run_id_from(Some(""));
+    assert!(!from_env, "empty env value is treated as unset");
+}
+
+#[test]
+fn outcome_state_mapping_covers_every_variant() {
+    use crate::run_status::State::*;
+    assert_eq!(state_for_outcome(LoopStop::Converged), Done);
+    assert_eq!(state_for_outcome(LoopStop::MaxIterations), Done);
+    assert_eq!(state_for_outcome(LoopStop::Deadline), Done);
+    assert_eq!(state_for_outcome(LoopStop::Budget), Done);
+    assert_eq!(state_for_outcome(LoopStop::QueueDrained), Done);
+    assert_eq!(state_for_outcome(LoopStop::Stopped), Stopped);
+    assert_eq!(state_for_outcome(LoopStop::CommanderKilled), Stopped);
+    assert_eq!(state_for_outcome(LoopStop::AwaitingApproval), Blocked);
+    assert_eq!(state_for_outcome(LoopStop::Stuck), Failed);
+}
+```
+
+- [ ] **Step 2: Run** `cargo nextest run -p mur-core loop_run::tests` — expect compile failure.
+- [ ] **Step 3: Implement** `resolve_run_id_from`, `state_for_outcome`; replace the literal `uuid::Uuid::now_v7()` at `:420` with `resolve_run_id_from(std::env::var(RUN_ID_ENV).ok().as_deref())`. Keep `from_env` in a local.
+- [ ] **Step 4: Register.** Immediately after the `RunProgress` is built, `if from_env { save RunState }` — copy the construction at `dag.rs:1055-1067`, `kind: RunKind::Fleet`, `label: name.to_string()`, `channel_id: Some(fleet.channel_id.clone())`. Wrap in the same "bookkeeping must never take down real work" `if let Err(e) … debug!` pattern.
+- [ ] **Step 5: Heartbeat + terminal.** In the per-iteration block (`:673-680`) add `if from_env { let _ = heartbeat::beat_once(mur_home, &run_id, Utc::now()); }`. In the terminal block (`:719-725`) add `if from_env { let _ = store::update(mur_home, &run_id, |r| r.state = state_for_outcome(stop)); }`.
+- [ ] **Step 6: Integration test** — find the existing loop test that drives `run_loop_inner` with a stub fleet (search `fn .*loop.*converge` in `loop_run.rs` tests). Clone it, set `MUR_RUN_ID` (or pass through the factored helper), run to `Converged`, then assert `store::load(home, id)?.unwrap().state == State::Done` and that `.run_progress.json`'s `run_id` equals the env value.
+- [ ] **Step 7: Run** `cargo nextest run -p mur-core loop_run run_status` — green.
+- [ ] **Step 8:** fmt + clippy; commit `feat(fleet): loop honours MUR_RUN_ID and self-registers in run_status`.
+
+---
+
+### Task 3: D3(b)(c) — `fleet_run` returns `run_id`, `wait:false`, richer `mur_job_status`
+
+**Files:**
+- Modify: `mur-agent-runtime/src/sandbox/policy.rs` (`:358` carve-in list `["fleets", "commander", "conversations", "artifacts"]`; guard test `:1150-1178`, list at `:1166`)
+- Modify: `mur-agent-runtime/src/tools/fleet_run.rs` (schema `~:80-100`, `execute` `:104`, spawn `:170-186`, timeout error `:188-201`)
+- Modify: `mur-mcp-server/src/tools.rs` (`mur_job_status` `:808-843`; tests `:1002-1052`, helper `call_tool_in` `:981`)
+
+**Interfaces:**
+- Consumes: Task 1 `load_view`; Task 2 env contract.
+- Produces:
+  - `fleet_run` input gains `"wait": { "type": "boolean" }` (default `true`).
+  - `pub(crate) const RUN_ID_ENV: &str = "MUR_RUN_ID";` in `fleet_run.rs`.
+  - `fn run_id_header(run_id: &str, fleet: &str, mur_home: &Path) -> String` — the two-line block from the spec (`run_id: … fleet: … progress: …` / `poll: … stop: …`).
+  - Output contract: `wait:true` → `run_id_header` + `"\n"` + today's tail; timeout error text becomes ``fleet run `{run_id}` timed out after {n}s and was killed; … check `mur_job_status```. `wait:false` → `run_id_header` + one line `note: the record appears once the loop starts (~1s); "no run recorded" before that is not a failure.` Refuses with `Execution("a deep-research run is already live: run_id …")` when `.run_progress.json` for the fleet is live (see Step 3 for how the runtime crate reads it without `mur-core`).
+  - `mur_job_status` output: existing four lines, then — only when `run.kind == RunKind::Fleet` and `load_view(mur_home, &run.label)` returns a view whose `progress.run_id == run_id` — `"\nprogress: {iteration_summary_line}"` and one `"  running: {desc}"` line per `StepState::Running` step.
+
+- [ ] **Step 1: Sandbox carve-in.** Add `"runs"` to the list at `policy.rs:358` and to the guard test's list at `:1166`. Run `cargo nextest run -p mur-agent-runtime policy` — green. Commit `feat(sandbox): fleet_run carve-in covers ~/.mur/runs`.
+
+- [ ] **Step 2: Write failing tests** in `fleet_run.rs` `mod tests` (`:209`; check whether it already drives a fake `MUR_BIN` — if it only tests `allowed()`/`resolve_timeout_secs`, add a fake `mur` shell script in a tempdir and point `MUR_BIN` at it, and factor `fn build_command(&self, args, run_id) -> tokio::process::Command` so the env assertion needs no spawn):
+
+```rust
+#[tokio::test]
+async fn wait_false_returns_header_immediately() {
+    // harness: fake `mur` that sleeps 5s
+    let out = tool.execute(json!({"fleet":"deep-research","goal":"q","wait":false})).await.unwrap();
+    let text = out.to_string();
+    assert!(text.starts_with("run_id: "));
+    assert!(text.contains("poll: mur_job_status"));
+    // must have returned well before the child exits
+}
+
+#[tokio::test]
+async fn wait_true_output_is_prefixed_with_run_id() {
+    let out = tool.execute(json!({"fleet":"deep-research","goal":"q"})).await.unwrap();
+    assert!(out.to_string().starts_with("run_id: "));
+}
+
+#[tokio::test]
+async fn wait_false_refuses_when_live() {
+    // write a .run_progress.json with finished_at: null and fresh mtime
+    let err = tool.execute(json!({"fleet":"deep-research","goal":"q","wait":false})).await.unwrap_err();
+    assert!(err.to_string().contains("already live"));
+}
+
+#[test]
+fn child_env_carries_run_id() {
+    // assert the Command built by the tool sets MUR_RUN_ID (factor `build_command` if needed)
+}
+```
+
+- [ ] **Step 3: Implement in `fleet_run.rs`.** Mint `uuid::Uuid::now_v7()`; `.env(RUN_ID_ENV, &run_id)` on the child. Liveness check without `mur-core`: read `mur_home/fleets/<fleet>/.run_progress.json` as `serde_json::Value`, `finished_at.is_null()` and mtime age `<= 600` ⇒ live (mirror `STALE_AFTER_SECS`; add a comment pointing at `progress.rs` so the two stay in step). For `wait:false`: `.kill_on_drop(false)`, stdout/stderr → `Stdio::null()`, and on unix `.process_group(0)` (tokio is 1.52 in `Cargo.lock`; `tokio::process::Command::process_group` is available directly, no `CommandExt` detour). Spawn, drop the handle, return the header.
+- [ ] **Step 4: Schema.** Add `wait` to the JSON schema in the tool's `input_schema`; description verbatim from the spec.
+- [ ] **Step 5: Env-name parity test.** In `mur-core` `loop_run.rs` tests, `assert_eq!(RUN_ID_ENV, "MUR_RUN_ID")`; in `fleet_run.rs` tests the same literal. Two literals, one test each — a drift breaks a test, not a run.
+- [ ] **Step 6: Run** `cargo nextest run -p mur-agent-runtime fleet_run` — green.
+- [ ] **Step 7: `mur_job_status` failing test** in `mur-mcp-server/src/tools.rs` tests (use `call_tool_in` at `:981`):
+
+```rust
+#[tokio::test]
+async fn job_status_appends_fleet_progress() {
+    let home = tempdir();
+    // save a RunState { kind: Fleet, label: "deep-research", run_id: "r1", state: Running, .. }
+    // save a RunProgress { run_id: "r1", iteration: 2, steps: [one Running "verify s2"] } under fleets/deep-research
+    let out = call_tool_in(&home, "mur_job_status", json!({"run_id":"r1"})).await.unwrap();
+    let s = out.as_str().unwrap();
+    assert!(s.contains("progress: iteration 2"));
+    assert!(s.contains("running: verify s2"));
+}
+
+#[tokio::test]
+async fn job_status_ignores_progress_with_other_run_id() { /* run_id mismatch → no `progress:` line */ }
+```
+
+- [ ] **Step 8: Implement** the append in the `"mur_job_status"` arm after the existing `format!` — build the base string, then `if status.run.kind == RunKind::Fleet { if let Some(v) = mur_core::cmd::fleet::progress::load_view(&mur_home, &status.run.label) { if v.progress.run_id == run_id { … } } }`. Path is already public end to end: `lib.rs:26 pub mod cmd` → `cmd/mod.rs:37 pub mod fleet` → `cmd/fleet/mod.rs:19 pub mod progress`. No re-export needed.
+- [ ] **Step 9: Run** `cargo nextest run -p mur-mcp-server job_status` — green.
+- [ ] **Step 10:** fmt + clippy on all three crates; commit `feat(fleet_run): return run_id, wait:false, job_status shows fleet progress`.
+
+---
+
+### Task 4: D1 — `/deep-research` in murmur
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` (`SlashCmd` `:158`; `parse_slash` `:212-271`; `push_system` `:925`; `push_shell` `:1467`)
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (`HELP` `:196`; dispatch `:2222-2271`, `Panel` arm at `:2270`; `!cmd` shell path `:1781`; parity tests `help_name` / `one_of_each` `:3130-3197`)
+- Modify: `mur-core/src/cmd/agent/cli/complete.rs` (`COMMANDS` `:164-200`)
+- Create: `mur-core/src/cmd/agent/cli/deep_research.rs` (handler, sibling of `panel.rs`)
+
+**Interfaces:**
+- Consumes: Task 1 `load_view`, `iteration_summary_line`; `DEFAULT_FLEET_NAME`; `StreamMsg::ShellDone` (the `!cmd` result path).
+- Produces:
+  - `SlashCmd::DeepResearch(Vec<String>)`; parse words `"deep-research" | "research"`.
+  - `pub enum DeepResearchAction { Status, Stop, Setup, Ask(String) }` + `pub fn classify(args: &[String]) -> DeepResearchAction` — `status|stop|setup` only when it is the **sole** word; otherwise `Ask(args.join(" "))`; empty → `Status`.
+  - `pub fn handle(app: &mut App, args: &[String])` — dispatch table:
+    - `Status` → spawn `mur deep-research` (bare) through the same `!cmd` machinery, result lands as a shell card.
+    - `Stop` → spawn `mur fleet stop deep-research`; `push_system("kill-switch written — the loop exits at its next guard check")`.
+    - `Setup` → `push_system("run `mur deep-research setup` in a terminal — it asks for egress consent")`. No subprocess.
+    - `Ask(q)` → spawn `mur deep-research <q>` (argv, never shell) with `MUR_RUN_ID` set to a fresh uuid v7 (so the human's run is pollable too); start a tokio task that every 5 s reads `load_view(home, DEFAULT_FLEET_NAME)` and, while `live` and the iteration changed, `push_system(iteration_summary_line)`; when the process ends, its output arrives as the shell card via `ShellDone`. Non-blocking: input stays enabled.
+  - `COMMANDS` row: `("deep-research", "run the research fleet, or show its status", Args::Fixed(DEEP_RESEARCH_SUBS))` with `const DEEP_RESEARCH_SUBS: &[(&str,&str)] = &[("status","show the fleet panel"),("stop","write the kill-switch"),("setup","how to run the wizard")]`. `research` alias is parser-only (like `theme`/`todo`), not a second row.
+
+- [ ] **Step 1: Write failing tests**
+
+In `app.rs` tests:
+```rust
+#[test]
+fn parse_deep_research() {
+    assert!(matches!(parse_slash("/deep-research"), Some(SlashCmd::DeepResearch(v)) if v.is_empty()));
+    assert!(matches!(parse_slash("/research what is X"), Some(SlashCmd::DeepResearch(v)) if v == ["what","is","X"]));
+}
+```
+In `deep_research.rs` tests:
+```rust
+#[test]
+fn classify_reserved_words_only_when_sole() {
+    use DeepResearchAction::*;
+    assert!(matches!(classify(&[]), Status));
+    assert!(matches!(classify(&s(&["status"])), Status));
+    assert!(matches!(classify(&s(&["stop"])), Stop));
+    assert!(matches!(classify(&s(&["setup"])), Setup));
+    assert!(matches!(classify(&s(&["status","of","X"])), Ask(q) if q == "status of X"));
+}
+```
+In `mod.rs`: add `SlashCmd::DeepResearch(vec![])` to `one_of_each` and `"deep-research"` to `help_name` — the existing structural test then enforces `HELP` and `COMMANDS` parity.
+
+- [ ] **Step 2: Run** `cargo nextest run -p mur-core cli::app cli::deep_research every_command_is_parsed` — expect compile failures.
+- [ ] **Step 3: Parser + enum + HELP + COMMANDS.** Add the variant, the two parse words, a `HELP` line (`/deep-research [question|status|stop|setup]  run the research fleet (/research)`), and the `COMMANDS` row. Run the parity test — green before touching the handler.
+- [ ] **Step 4: Handler.** Create `deep_research.rs` with `classify` + `handle`. For the subprocess, extract the spawn half of the `!cmd` path at `mod.rs:1781` into a reusable `fn spawn_shell_card(app, program: &str, args: &[String], env: &[(&str,&str)])` if it is not already argv-shaped — **do not** route through `sh -c` (the question is user text). Wire `SlashCmd::DeepResearch(args) => deep_research::handle(app, &args)` next to the `Panel` arm.
+- [ ] **Step 5: Progress ticker.** In `Ask`, spawn the 5 s poller on the app's existing tokio handle; it sends system lines through whatever channel `push_system` is reachable from off-thread (look at how `StreamMsg` is delivered from the streaming task and reuse that variant, or add `StreamMsg::System(String)` if none exists). Stop when `!live` or the process has exited. Dedupe on `iteration` so a slow loop doesn't repeat lines.
+- [ ] **Step 6: Manual check** (record in the commit message): `mur agent chat` → `/deep-research` renders the panel card; `/research status of X` starts a run; `/deep-research stop` ends it with `outcome = stopped`; typing while it runs still works.
+- [ ] **Step 7: Run** `cargo nextest run -p mur-core cli::` — green. fmt + clippy; commit `feat(murmur): /deep-research slash command with live progress lines`.
+
+---
+
+### Task 5: D2 — `mur-deep-research` skill v0.2.0
+
+**Files:**
+- Modify: `mur-core/src/skills/mur_deep_research.yaml` (`version: 0.1.0` → `0.2.0`; replace `content.context`)
+
+**Interfaces:**
+- Consumes: everything shipped in Tasks 1–4 (write it last so it describes reality).
+- Produces: the skill text. Sections, in order:
+  1. The five-invocation table from the spec ("CLI surface").
+  2. `provision` and `run` flag tables (verbatim from the spec — they come from `actions.rs:770-836`).
+  3. **If you are an agent, not a human** — use `fleet_run {fleet:"deep-research", goal:"<q>"}`; `wait:false` + `mur_job_status <run_id>` for long runs; a `fleet_run denied` error is a config fact (`fleet_run.agents` / `fleet_run.fleets` in `~/.mur/config.yaml`) to report, never to route around; never shell out to `mur deep-research`.
+  4. **Reading progress** — `~/.mur/fleets/deep-research/.run_progress.json`, the 9-value `outcome` list, stale after 600 s, `mur_job_status` shows `progress:` for fleet runs.
+  5. **From murmur** — `/deep-research …` / `/research …` grammar, one line each.
+  6. Kill-switch: `mur fleet stop deep-research`.
+
+- [ ] **Step 1: Failing test.** Find the built-in-skill seed test (`grep -rn "mur_deep_research" mur-core/src --include=*.rs`) and add an assertion that the seeded skill's `version == "0.2.0"` and its context contains `fleet_run` and `MUR_RUN_ID`-free wording (agents never set the env themselves — assert the text does **not** mention `MUR_RUN_ID`).
+- [ ] **Step 2:** Edit the YAML. Keep `trigger`/`abstract`/`description` as-is (the abstract still holds).
+- [ ] **Step 3: Run** the seed test + `cargo nextest run -p mur-core skills` — green. Confirm the re-seed path replaces a 0.1.0 copy (there is an existing version-bump test for another built-in; mirror it).
+- [ ] **Step 4:** commit `docs(skill): mur-deep-research 0.2.0 — flag table, agent path, progress`.
+
+---
+
+## Verification (before claiming done)
+
+- [ ] `cargo nextest run -p mur-core -p mur-agent-runtime -p mur-mcp-server` — all green, one run.
+- [ ] `cargo clippy --workspace -- -D warnings` clean.
+- [ ] End-to-end from an allowlisted agent: `fleet_run {fleet:"deep-research", goal:"…", wait:false}` → returns `run_id`; `mur_job_status` within 10 s says `running · alive` with a `progress:` line; after `mur fleet stop deep-research`, says `stopped`.
+- [ ] Spec test-plan table, row by row, each mapped to a test name in this plan — no row left without one.
+
+## Out of scope (from the spec, restated so nobody "helpfully" adds them)
+
+- Streaming events from loop to agent.
+- Concurrent deep-research runs (refused with the live run's id).
+- Any change to preflight / egress consent.

--- a/docs/superpowers/specs/2026-09-10-deep-research-slash-design.md
+++ b/docs/superpowers/specs/2026-09-10-deep-research-slash-design.md
@@ -1,0 +1,265 @@
+# `/deep-research`: a slash command, a skill, and progress an agent can see
+
+**Status**: designed, not started.
+**Decisions taken in brainstorming**: (C) ship BOTH a built-in murmur slash
+command AND keep/upgrade the `mur-deep-research` skill; ALSO expose run
+progress to agents through `fleet_run`, not only to humans.
+
+## Problem
+
+Deep research exists and works — `mur deep-research "question"` runs a
+guarded fleet loop, writes a progress file, and the bare command renders a
+panel. But three surfaces cannot reach it well:
+
+1. **murmur has no `/deep-research`.** From the TUI the user must drop to
+   `!mur deep-research "…"`, which runs in the shell-card and blocks the
+   turn with no panel, no progress, no kill-switch hint.
+2. **The skill is prose only.** `mur-deep-research` (in
+   `mur-core/src/skills/mur_deep_research.yaml`) tells the model *that* the
+   command exists, but not the flag surface, nor how to read progress, nor
+   that `fleet_run` is the sanctioned way for an agent to trigger it.
+3. **An agent that calls `fleet_run` is blind for up to an hour.** The tool
+   spawns `mur deep-research "<q>"`, waits (default 1800 s, max 3600 s), and
+   returns the output tail. There is no run id to poll, so `mur_job_status`
+   — whose own description says "a timeout means MUR stopped waiting, NOT
+   that the work failed — ask here instead of re-dispatching" — has nothing
+   to be asked about. Every timeout is a coin-flip re-dispatch.
+
+## What already exists (the ground this stands on)
+
+### CLI surface — `mur deep-research`
+
+Parsed in `mur-core/src/cli/mod.rs:456-463` with
+`args_conflicts_with_subcommands = true`, so a bare question and a
+subcommand are mutually exclusive:
+
+| Invocation | What it does | Source |
+|---|---|---|
+| `mur deep-research` | Read-only status panel: model, fleet, each worker's running/egress state, last-run progress | `cmd/deep_research/panel.rs` |
+| `mur deep-research "<question>"` | Preflight (workers exist, egress granted, fleet exists) → safe auto-repair (start workers, re-pin gateway) → guarded loop | `cmd/deep_research/ask.rs` |
+| `mur deep-research setup` | Interactive wizard: model, worker count, budget, egress consent, browser consent | `cmd/deep_research/setup.rs` |
+| `mur deep-research provision` | Scripted worker creation, flags below | `cmd/deep_research/provision.rs` |
+| `mur deep-research run <fleet>` | Thin wrapper over `mur fleet run --loop` with overrides | `cmd/deep_research/run.rs` |
+
+`provision` flags (`mur-core/src/cli/actions.rs:770-815`):
+`--count N`, `--prefix <p>` (workers become `<p>_1..N`), `--model <alias>`
+(models.yaml alias; default `claude_haiku`), `--grant-egress` (BroadAudited,
+prompts `[y/N]` per worker), `--grant-browser`, `--deny-host <h>`
+(repeatable), `--yes`, `--render-engine agent-browser|obscura`.
+
+`run` flags (`actions.rs:823-836`): `--max-iterations N`, `--deadline 30s|5m|2h`,
+`--budget-usd F`. These override `fleet.yaml`'s `loop.*` for one run.
+
+Kill-switch: `mur fleet stop deep-research` (writes `.stopped`).
+Canonical fleet name: `DEFAULT_FLEET_NAME = "deep-research"`
+(`cmd/deep_research/status.rs:11`).
+
+### Progress — already written, just not read from the right places
+
+`mur-core/src/cmd/fleet/progress.rs` is the single-source model:
+
+```rust
+pub const PROGRESS_FILE: &str = ".run_progress.json";   // ~/.mur/fleets/<name>/
+pub const STALE_AFTER_SECS: u64 = 600;
+pub struct RunProgress { schema_version, run_id, question, started_at,
+    finished_at, outcome, iteration, model, budget_usd, spend_usd, steps }
+pub struct StepProgress { id, worker, phase, desc, state, cost_usd, started_at, ended_at }
+```
+
+The loop (`cmd/fleet/loop_run.rs:415-435`) creates it with a fresh
+`uuid::Uuid::now_v7()` run id, saves before the first iteration, on every
+step observation (`:556-563`), after every iteration (`:673-680`), and once
+more with `outcome` at exit (`:719-725`). Saves are atomic
+(tmp + rename, `progress.rs:121-137`) and never fail the run.
+
+`outcome` ∈ `converged | max-iterations | deadline | budget | stopped |
+stuck | failed`. `iteration_summary_line` (`progress.rs:152`) is the one
+human line: `iteration 3 done: 4✓ 0✗ 1 pending · spend $0.42/$5.00 · model claude_haiku`.
+
+So: **the answer to "can the fleet report progress?" is yes, it already
+does — to a file.** Nothing needs to be invented on the writer side. What is
+missing is readers.
+
+### Run status — has a hole exactly where fleet_run needs it
+
+`mur_job_status` reads `mur_core::run_status::status_of(mur_home, run_id)`
+(`mur-mcp-server/src/tools.rs:808-822`). The loop records
+`RunKind::Fleet` per **iteration** under
+`loop-<name>-<uuid>-<iter>` (`loop_run.rs:631-632`). The **top-level**
+`RunProgress.run_id` is never recorded in the run store, and `fleet_run`
+never returns any id. Hence the blindness.
+
+### murmur slash commands — three lists to touch
+
+Per the earlier `2026-09-08-murmur-slash-arg-completion-design.md`, a
+command lives in three places that nothing ties together:
+`parse_slash` (`cmd/agent/cli/app.rs:219-271`), `COMMANDS` in
+`complete.rs`, and `HELP` in `cli/mod.rs:196`. That spec's
+`help_lists_every_command_the_parser_accepts` guard exists; this command
+must land in its `one_of_each()` list too.
+
+## Design
+
+Three deliverables, each small, sharing one primitive.
+
+### D0 — shared primitive: `progress::load_view`
+
+One pure reader every surface calls, so no two renderings disagree:
+
+```rust
+// mur-core/src/cmd/fleet/progress.rs
+pub struct ProgressView { pub progress: RunProgress, pub age_secs: u64, pub stale: bool, pub live: bool }
+pub fn load_view(mur_home: &Path, fleet: &str) -> Option<ProgressView>
+```
+
+`live = finished_at.is_none() && !stale`; `stale = finished_at.is_none() &&
+age_secs > STALE_AFTER_SECS`. `render_progress` in `panel.rs` is refactored
+to take a `&ProgressView` (behaviour unchanged). `load` (already public,
+returns `(RunProgress, u64)`) stays for compatibility.
+
+### D1 — built-in `/deep-research` in murmur
+
+Grammar (mirrors the CLI so nothing new to learn):
+
+```
+/deep-research                      status panel (same text as bare CLI)
+/deep-research <question…>          run; question is the rest of the line
+/deep-research status               alias of bare, for people who type it
+/deep-research stop                 kill-switch → mur fleet stop deep-research
+/deep-research setup                prints "run `mur deep-research setup` in a
+                                    terminal — it asks for egress consent"
+/research …                         alias
+```
+
+`SlashCmd::DeepResearch(Vec<String>)` — same shape as `Panel`/`Skill`,
+sub-dispatch inside the handler. Words `status|stop|setup` are reserved
+only as the **sole** first word; `"status of the Rust 2027 edition"` is a
+question.
+
+**Run semantics.** The handler does NOT call the model. It runs the same
+code path as `mur deep-research "<q>"` (`ask::cmd_ask`) in a background
+task, surfaces the panel as a card, and streams `iteration_summary_line`
+into the chat as system lines while `load_view().live`. The turn is not
+blocked — the user can keep chatting. On exit the card shows `outcome` and
+the report location (whatever `cmd_ask` prints last). `/deep-research
+stop` writes the kill-switch; the loop's own guard turns it into
+`outcome = stopped`.
+
+**Why not hand the question to the agent and let it call `fleet_run`?**
+Because the murmur-side agent is not necessarily on the `fleet_run.agents`
+allowlist, and a slash command that silently fails on a config gate is
+worse than none. The slash command is the *human's* door — it uses the
+human's privileges (a `mur` subprocess, exactly like `!mur …`), not the
+agent's.
+
+**Preflight failure** (no workers / no egress / no fleet) surfaces
+`plan_preflight`'s `bail!` text verbatim as the card body — those messages
+already say "run `mur deep-research setup`".
+
+**Completion menu** (`complete.rs`): row `("deep-research", "run the
+research fleet, or show its status", &["status", "stop", "setup"])`. Per the
+09-08 spec, an argument provider for the free-text question is
+deliberately *not* offered.
+
+### D2 — skill upgrade: `mur-deep-research` v0.2.0
+
+Same file, `mur-core/src/skills/mur_deep_research.yaml`. Keep the
+trigger/abstract; replace `context` with a table of the flag surface above,
+plus two new sections:
+
+- **"If you are an agent, not a human"**: never shell out to
+  `mur deep-research` — use the `fleet_run` tool with
+  `fleet: "deep-research"`, `goal: "<question>"`. Explain the deny-by-default
+  gate (`fleet_run.agents` / `fleet_run.fleets` in `~/.mur/config.yaml`)
+  and that a refusal is a config fact to report, not a thing to work around.
+- **"Reading progress"**: the file path, the `outcome` vocabulary, staleness
+  = 600 s, and — once D3 lands — "use `mur_job_status` with the `run_id`
+  `fleet_run` returned".
+
+Version bump so the built-in-skill re-seed logic replaces the stale copy.
+
+### D3 — `fleet_run` reports progress to the calling agent
+
+Two additions to the tool, both backward compatible.
+
+**(a) Register the run, return the id.** `fleet_run` cannot know the loop's
+uuid before spawning, so the loop learns it from the environment instead:
+
+```
+MUR_RUN_ID=<uuid>     # if set, loop_run uses it as RunProgress.run_id
+```
+
+`fleet_run` mints `uuid::Uuid::now_v7()`, passes it in the child env,
+records a `RunKind::Fleet` run under that id *before* spawn (state
+`running`, heartbeat = now), and the loop's existing per-iteration and exit
+writes stamp heartbeat and terminal state on it. `mur_job_status <id>` now
+answers `running · alive` mid-run and `done · converged` after. The
+loop's exit also writes to `run_status`, so a timed-out `fleet_run` and a
+finished loop reconcile the same way `status_of` already reconciles
+cache vs channel (`run_status/mod.rs:229-260`).
+
+**(b) A `wait: false` mode.** New optional input:
+
+```json
+"wait": { "type": "boolean", "description": "false → return immediately with run_id; poll with mur_job_status" }
+```
+
+Default `true` keeps today's behaviour byte-for-byte. With `false` the tool
+returns:
+
+```
+run_id: 0192f…   fleet: deep-research   progress: ~/.mur/fleets/deep-research/.run_progress.json
+poll: mur_job_status {"run_id":"0192f…"}    stop: mur fleet stop deep-research
+```
+
+The child is detached (`kill_on_drop(false)`, own process group) so the
+tool returning does not kill the research. In `wait: true` mode the
+returned tail is **prefixed** with the same `run_id:` line, so a caller
+that hits the 3600 s ceiling still has the id in the timeout error:
+
+> fleet run `0192f…` timed out after 3600s and was killed; … check
+> `mur_job_status`.
+
+**(c) Progress in `mur_job_status`.** When the record's `run_kind` is
+`Fleet` and a `.run_progress.json` exists with the same `run_id`, append
+`iteration_summary_line` and the running steps' `desc` to the status
+text. Read-only, via D0's `load_view`. Nothing here parses the loop's
+stdout.
+
+### Sandbox note
+
+`fleet_run`'s carve-ins are computed at seal time from the same allowlist
+(`fleet_run.rs:5-9`). Setting an env var and detaching a child needs no new
+grant; recording the run needs write access to `~/.mur/runs/` — add it to
+the carve-in set beside `fleets/`, `commander/`, `conversations/`, gated the
+same way.
+
+## Out of scope
+
+- A streaming/event channel from the loop to the agent. The file is the
+  contract; polling it is enough at research timescales (minutes).
+- Multiple concurrent deep-research runs. Today one progress file per fleet
+  means one run at a time; `fleet_run` in `wait: false` mode must refuse
+  with the existing run's id if `load_view().live`.
+- Any change to the preflight/consent model. Egress consent stays human.
+
+## Test plan
+
+| Area | Test |
+|---|---|
+| parse | `/deep-research`, `/research what is X`, `/deep-research status`, `/deep-research status of X` (question), `/deep-research stop` |
+| help/complete | `one_of_each()` gains `DeepResearch`; the existing structural test then covers `HELP` |
+| progress | `load_view` stale/live/finished truth table with a synthetic file and injected age |
+| loop | `MUR_RUN_ID` set → `RunProgress.run_id` equals it; unset → uuid v7 as today |
+| fleet_run | `wait:false` returns within 1 s with a `run_id:` line; refuses when a live run exists; `wait:true` output starts with `run_id:` |
+| job_status | Fleet run with matching progress file → status text contains `iteration N done:` |
+| panel | `render_progress` output unchanged for the existing fixtures |
+
+## Sequence
+
+1. D0 (`load_view`, panel refactor) — no behaviour change, lands alone.
+2. D3(a) `MUR_RUN_ID` + run registration — unlocks polling even before
+   the tool changes.
+3. D3(b)(c) `wait` + job_status enrichment.
+4. D1 slash command.
+5. D2 skill bump (last, so it describes what actually shipped).

--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -54,27 +54,92 @@ const LLM_CONNECT_TIMEOUT_SECS: u64 = 10;
 /// Must stay in sync with `mur-core/src/cmd/agent.rs::SECRET_SERVICE`.
 const MUR_AGENT_KEYCHAIN_SERVICE: &str = "mur-agent";
 
-/// Warn once per process if the resolved API key looks like a Claude
-/// subscription OAuth token (`sk-ant-oat*`) but the configured base URL
-/// still points at api.anthropic.com — Anthropic will reject the call.
+/// What is wrong with an `sk-ant-oat*` key at a given base URL, if anything.
+///
+/// Split out of `warn_if_oauth_key_misconfigured` so the rule is unit-testable
+/// without a tracing subscriber and without the process-global "warn once"
+/// latch, which makes the warning observable exactly once per test binary.
+#[derive(Debug, PartialEq, Eq)]
+enum OauthKeyMisuse {
+    /// Sent straight at Anthropic, which does not accept subscription tokens.
+    RejectedUpstream,
+    /// Sent at a loopback bridge. `mur-model-gateway` keys its mode on the
+    /// *shape* of the inbound credential: an `sk-ant-oat*` value in `x-api-key`
+    /// is read as "this client wants OAuth", and the bridge answers by
+    /// attaching its own, fresher Claude Code token and dropping the one that
+    /// arrived. The configured secret is therefore never sent anywhere, and a
+    /// model entry that looks like an independent credential path silently
+    /// shares whatever credential the bridge holds — so switching to it does
+    /// not escape an outage on that credential.
+    IgnoredByBridge,
+}
+
+/// `None` when the key is not a subscription token, or when the base URL is
+/// some other remote host whose credential policy we cannot know.
+///
+/// ponytail: loopback detection is a small host allowlist, not the whole of
+/// 127.0.0.0/8. Widen it if someone actually binds a bridge to 127.0.0.2.
+fn classify_oauth_key(api_key: &str, base_url: &str) -> Option<OauthKeyMisuse> {
+    if !api_key.contains("sk-ant-oat") {
+        return None;
+    }
+    if base_url.starts_with("https://api.anthropic.com") {
+        return Some(OauthKeyMisuse::RejectedUpstream);
+    }
+    let host = reqwest::Url::parse(base_url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned));
+    match host.as_deref() {
+        Some("127.0.0.1" | "localhost" | "::1" | "[::1]") => Some(OauthKeyMisuse::IgnoredByBridge),
+        _ => None,
+    }
+}
+
+/// Warn once per process, per kind, if the resolved API key is a Claude
+/// subscription OAuth token in a place that cannot use it.
+///
+/// The loopback arm exists because the other arm's advice used to end the
+/// story: it told the reader to point the base URL at a local OAuth bridge,
+/// and doing exactly that produced no warning at all — while the bridge went
+/// on ignoring the key. A real config kept an `sk-ant-oat*` token in
+/// `~/.mur/secrets/anthropic.key` for months believing it was a second,
+/// independent credential; it was the same credential the whole time, which
+/// only surfaced when switching models during an outage changed nothing.
+///
+/// The two kinds latch separately. One shared flag would let whichever route
+/// ran first silence the other, and they are different diagnoses with
+/// different fixes.
 fn warn_if_oauth_key_misconfigured(api_key: &str, base_url: &str) {
     use std::sync::atomic::{AtomicBool, Ordering};
-    static WARNED: AtomicBool = AtomicBool::new(false);
-    if !api_key.contains("sk-ant-oat") {
-        return;
+    match classify_oauth_key(api_key, base_url) {
+        Some(OauthKeyMisuse::RejectedUpstream) => {
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            if WARNED.swap(true, Ordering::Relaxed) {
+                return;
+            }
+            tracing::warn!(
+                base_url = %base_url,
+                "ANTHROPIC_API_KEY looks like an OAuth subscription token (sk-ant-oat*), \
+                 but base URL is api.anthropic.com — Anthropic will reject the request. \
+                 Point ANTHROPIC_BASE_URL at a local OAuth bridge, which supplies its \
+                 own credential and does not need this key."
+            );
+        }
+        Some(OauthKeyMisuse::IgnoredByBridge) => {
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            if WARNED.swap(true, Ordering::Relaxed) {
+                return;
+            }
+            tracing::warn!(
+                base_url = %base_url,
+                "ANTHROPIC_API_KEY is an OAuth subscription token (sk-ant-oat*) pointed at \
+                 a loopback bridge. The bridge attaches its own Claude Code credential and \
+                 drops this one, so this key is never sent and this model entry is not an \
+                 independent credential path. Use an sk-ant-api03 key if it was meant to be."
+            );
+        }
+        None => {}
     }
-    if !base_url.starts_with("https://api.anthropic.com") {
-        return;
-    }
-    if WARNED.swap(true, Ordering::Relaxed) {
-        return;
-    }
-    tracing::warn!(
-        base_url = %base_url,
-        "ANTHROPIC_API_KEY looks like an OAuth subscription token (sk-ant-oat*), \
-         but base URL is api.anthropic.com — Anthropic will reject the request. \
-         Point ANTHROPIC_BASE_URL at a local OAuth bridge."
-    );
 }
 
 /// How a request authenticates. Explicit so an authless route is a
@@ -1285,5 +1350,51 @@ mod tests {
             AnthropicClient::new(server.base_url(), "test-key".into(), "claude-opus-5".into());
         client.generate(hello()).await.unwrap();
         m.assert_async().await;
+    }
+
+    /// The gap this closes: a subscription token pointed at the loopback
+    /// bridge used to be classified as fine, because the only check was
+    /// "is the base URL api.anthropic.com". The bridge drops the key and
+    /// attaches its own, so nothing about that config does what it looks
+    /// like it does.
+    #[test]
+    fn an_oauth_key_at_a_loopback_bridge_is_flagged_as_ignored() {
+        for base in [
+            "http://127.0.0.1:8088",
+            "http://localhost:8088/v1",
+            "http://[::1]:8088",
+        ] {
+            assert_eq!(
+                classify_oauth_key("sk-ant-oat01-abc", base),
+                Some(OauthKeyMisuse::IgnoredByBridge),
+                "{base}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_oauth_key_at_anthropic_is_still_flagged_as_rejected() {
+        assert_eq!(
+            classify_oauth_key("sk-ant-oat01-abc", "https://api.anthropic.com"),
+            Some(OauthKeyMisuse::RejectedUpstream)
+        );
+    }
+
+    /// A real API key is fine everywhere, and a remote bridge we know nothing
+    /// about must not be second-guessed — it may well forward the token.
+    #[test]
+    fn a_real_key_and_an_unknown_remote_are_left_alone() {
+        assert_eq!(
+            classify_oauth_key("sk-ant-api03-abc", "https://api.anthropic.com"),
+            None
+        );
+        assert_eq!(
+            classify_oauth_key("sk-ant-api03-abc", "http://127.0.0.1:8088"),
+            None
+        );
+        assert_eq!(
+            classify_oauth_key("sk-ant-oat01-abc", "https://bridge.example.com"),
+            None
+        );
     }
 }


### PR DESCRIPTION
## The gap

`warn_if_oauth_key_misconfigured` warned only when the base URL was `api.anthropic.com`:

```rust
if !base_url.starts_with("https://api.anthropic.com") {
    return;
}
```

Its own remedy was *"Point ANTHROPIC_BASE_URL at a local OAuth bridge"* — and following that advice turned the warning off, without making the configuration correct.

`mur-model-gateway` picks its mode from the **shape** of the inbound credential. An `sk-ant-oat*` value arriving in `x-api-key` reads as "this client wants OAuth", so the gateway attaches its own (fresher) Claude Code token and drops the one that arrived. The configured secret is never sent anywhere.

The consequence is not cosmetic: a model entry backed by `file:~/.mur/secrets/anthropic.key` looks like a second, independent credential, but shares whatever credential the gateway holds. That stays invisible until an outage on that credential, when switching to the other model changes nothing — which is exactly how it was found.

## The change

- `classify_oauth_key` — the rule as a pure function returning `Option<OauthKeyMisuse>`, so it is testable without a tracing subscriber and without the process-global warn-once latch (which makes the warning observable exactly once per test binary).
- A `IgnoredByBridge` arm for loopback hosts, saying the key is dropped and the entry is not an independent credential path.
- The two kinds latch separately. One shared flag would let whichever route ran first silence the other, and they have different fixes.

Unknown remote bridges are still left alone — one may legitimately forward the token, and second-guessing it would be noise.

## Verification

`cargo test -p mur-agent-runtime --lib` — 687 passed / 0 failed. `cargo fmt --check` and `cargo clippy -p mur-agent-runtime --lib` clean. Three new tests cover loopback (`127.0.0.1`, `localhost`, `[::1]`), the unchanged Anthropic arm, and the cases that must stay silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)