### PR TITLE
chore(release): bump workspace version to 2.77.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.77.2"
+version = "2.77.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.2"
+version = "2.77.3"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Releases the two commits sitting on `main` since v2.77.2.

| PR | What |
|---|---|
| #1239 | Agent-triggered fleet runs work, and their failures are legible — the spawn allowlist and the exec resolve the same `mur`, `runs/` is carved into the sandbox, the delegate fan-out is bounded, terminal steps record why they failed, dropped spawn grants are recorded, a fleet cannot delegate back to its trigger, an agent with no working model says so instead of echoing, and a sealed child can sign the channel events it writes |
| #1238 | Warn when a loopback bridge will ignore an `sk-ant-oat` key |

**Merging this IS the release.** `tag.yml` tags `v2.77.3` on the merge commit and
dispatches `release.yml`, which publishes to crates.io — irreversible, yank-only.
This PR is the approval gate; there is no later one.

Both lock files moved with the version (the root one and
`mur-hub-gui/src-tauri/Cargo.lock`, which carries its own copy of every workspace
crate's version and breaks the Hub's release build when it disagrees).

### Note for after the release

The in-sandbox channel signing added in #1239 has **not** been verified live. Its
acceptance criterion is a real `fleet_run` producing an `events.jsonl` with zero
unsigned events; the unit tests cover the payload round-trip, not the wiring
reaching the process that actually writes fleet events. Baseline before the fix:
13 signed / 27 unsigned in `fleet-develop-rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)