### PR TITLE
fix(runtime): a keyless local model server no longer demands OPENAI_API_KEY

### DIFF
--- a/mur-agent-runtime/src/llm/client_builder.rs
+++ b/mur-agent-runtime/src/llm/client_builder.rs
@@ -246,6 +246,28 @@ fn build_bare_client(
                     entry.base_url.clone(),
                     guarded_http,
                 )))
+            } else if entry
+                .base_url
+                .as_deref()
+                .is_some_and(crate::llm::loopback::is_loopback_base_url)
+            {
+                // A local OpenAI-compatible runtime (oMLX, LM Studio, vLLM)
+                // does not authenticate, but `mur model connect` and the Hub
+                // both write `provider: openai` for it — that is the wire
+                // protocol, not the vendor. Without this arm the entry fell
+                // through to keychain/`OPENAI_API_KEY` and demanded a
+                // credential the server ignores and the user cannot obtain.
+                // Same placeholder the `local` provider sends, for the same
+                // reason.
+                let key = secrecy::SecretString::from(
+                    crate::supervisor_runner::LOCAL_LLM_PLACEHOLDER_KEY.to_string(),
+                );
+                Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
+                    &key,
+                    entry.model.clone(),
+                    entry.base_url.clone(),
+                    guarded_http,
+                )))
             } else {
                 block_on(OpenAiClient::from_agent_credentials_with_http(
                     &profile.inner.name,
@@ -283,6 +305,45 @@ fn block_on<F: std::future::Future>(fut: F) -> F::Output {
             .build()
             .expect("failed to build scratch runtime")
             .block_on(fut),
+    }
+}
+
+#[cfg(test)]
+mod local_openai_endpoint_tests {
+    use super::*;
+    use mur_common::agent::AgentProfile;
+
+    fn profile() -> Profile {
+        Profile {
+            inner: AgentProfile::default_for_tests(),
+            agent_home: std::path::PathBuf::from("/tmp/does-not-need-to-exist"),
+            digest: String::new(),
+            raw_yaml: String::new(),
+            system_prompt: None,
+        }
+    }
+
+    /// A local inference server is reached over the OpenAI wire protocol, so
+    /// `mur model connect` and the Hub Model Library both write
+    /// `provider: openai` for it. Without this, that entry fell through to the
+    /// keychain/`OPENAI_API_KEY` chain and failed with "OPENAI_API_KEY not
+    /// set" — demanding a credential from a server that does not authenticate,
+    /// and one the user cannot obtain.
+    #[test]
+    fn a_keyless_local_server_builds_without_any_credential() {
+        let entry = ModelEntry {
+            provider: "openai".into(),
+            model: "Qwen3.5-4B-MLX-4bit".into(),
+            base_url: Some("http://127.0.0.1:8000/v1".into()),
+            secret: None,
+            ..Default::default()
+        };
+        let built = build_bare_client(&entry, &profile(), std::path::Path::new("/tmp"));
+        assert!(
+            built.is_ok(),
+            "keyless loopback entry must build: {:?}",
+            built.err()
+        );
     }
 }
 

--- a/mur-agent-runtime/src/llm/loopback.rs
+++ b/mur-agent-runtime/src/llm/loopback.rs
@@ -7,6 +7,28 @@
 
 use super::LlmError;
 
+/// True when `url`'s host is this machine. Split out of
+/// [`validate_loopback_base_url`] because two callers need the host test
+/// without the rest: that validator also pins scheme, port and an exact route
+/// path, which is right for a subscription gateway and wrong for an arbitrary
+/// local inference server.
+fn host_is_loopback(url: &reqwest::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    }
+}
+
+/// True when `raw` points at an OpenAI-compatible server on this machine.
+/// Unlike [`validate_loopback_base_url`] this asks only "is this host me?" —
+/// a local runtime picks its own port and route, so pinning either would just
+/// reject working endpoints.
+pub fn is_loopback_base_url(raw: &str) -> bool {
+    reqwest::Url::parse(raw).is_ok_and(|u| host_is_loopback(&u))
+}
+
 pub fn validate_loopback_base_url(
     raw: &str,
     required_path: &str,
@@ -19,13 +41,7 @@ pub fn validate_loopback_base_url(
     if !url.username().is_empty() || url.password().is_some() {
         return Err(bad("credentials in the URL are not allowed"));
     }
-    let loopback = match url.host() {
-        Some(url::Host::Domain(d)) => d.eq_ignore_ascii_case("localhost"),
-        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-        None => false,
-    };
-    if !loopback {
+    if !host_is_loopback(&url) {
         return Err(bad("host must be localhost or a loopback IP"));
     }
     if url.port().is_none() {
@@ -43,6 +59,36 @@ pub fn validate_loopback_base_url(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A local inference server (oMLX, LM Studio, vLLM) is reached at
+    /// whatever port and path it chose, so only the host may be judged here.
+    #[test]
+    fn any_port_and_path_on_this_machine_counts_as_local() {
+        for ok in [
+            "http://127.0.0.1:8000/v1",
+            "http://localhost:1234/v1",
+            "http://127.0.0.1:11434/v1/",
+            "https://127.0.0.1:8000/v1",
+            "http://[::1]:8000/v1",
+        ] {
+            assert!(is_loopback_base_url(ok), "{ok}");
+        }
+    }
+
+    /// The whole point of the check: a remote host must not be treated as a
+    /// keyless local server. `localhost.evil.test` is the near-miss that a
+    /// `starts_with`/`contains` test would wave through.
+    #[test]
+    fn a_remote_host_is_never_local_however_it_is_spelled() {
+        for bad in [
+            "https://api.openai.com/v1",
+            "http://localhost.evil.test:8000/v1",
+            "http://192.168.1.10:8000/v1",
+            "not a url",
+        ] {
+            assert!(!is_loopback_base_url(bad), "{bad}");
+        }
+    }
 
     #[test]
     fn the_required_path_is_the_only_thing_that_differs_between_providers() {


### PR DESCRIPTION
## Problem

Adding a local model (oMLX, LM Studio, vLLM) through the Hub Model Library or `mur model connect` produces an entry the runtime cannot build:

```
invalid params: model_ref "mlx_qwen3_5_4b_mlx_4bit": invalid response: OPENAI_API_KEY not set
```

…against a server with **API key verification explicitly disabled**.

## Root cause

`wire_protocol_for()` (`model_discovery.rs:87`) maps every vendor except `anthropic`/`ollama`/`local` onto `"openai"` — correct, that *is* the wire protocol. But the `"openai"` arm of `build_bare_client` is the one provider branch with no authless route:

```rust
"openai" => {
    if let Some(key) = secret_value { …from_secret_string… }
    else { from_agent_credentials_with_http(…) }  // keychain → OPENAI_API_KEY → error
}
```

`OpenAiAuth::None` is `pub(crate)` and reserved for the Codex loopback gateway, so a local runtime had no path through. The user's only workaround was hand-editing `provider:` to `local`, or pointing `secret:` at a file whose contents the server ignores.

## Fix

An `openai` entry with **no secret** and a **loopback `base_url`** gets the same `local-no-key` placeholder the `local` provider already sends (`supervisor_runner.rs:36`), instead of resolving credentials. Verified against a live oMLX: both a bare request and `Authorization: Bearer local-no-key` return `200`.

Only the previously-failing case changes — an entry with a secret still uses it, a remote endpoint still resolves credentials as before.

`is_loopback_base_url` is split out of `validate_loopback_base_url`, which also pins scheme, port and an exact route path: right for a subscription gateway, wrong for a local server that picks its own.

## Tests

- `a_keyless_local_server_builds_without_any_credential` — fails on `main` with the exact user-visible error string.
- `any_port_and_path_on_this_machine_counts_as_local` / `a_remote_host_is_never_local_however_it_is_spelled` — the host check, including the `localhost.evil.test` near-miss a `contains()` would wave through.

694 tests pass; clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)