### PR TITLE
chore(release): bump workspace version to 2.77.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6626,7 +6626,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.77.3"
+version = "2.77.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.3"
+version = "2.77.4"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Patch release. Merging this PR **is** the release: `tag.yml` tags `v2.77.4` on the merge commit and dispatches `release.yml` (crates.io publish is irreversible), so this PR is the release approval.

## Contents since v2.77.3

- #1241 — a keyless local model server no longer demands `OPENAI_API_KEY`. Adding a local model (oMLX, LM Studio, vLLM) through the Hub Model Library or `mur model connect` wrote `provider: openai` — the wire protocol — and that branch had no authless route, so the entry failed to build with `OPENAI_API_KEY not set` against a server with API key verification explicitly disabled. An `openai` entry with no secret and a loopback `base_url` now gets the same `local-no-key` placeholder the `local` provider already sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)