### PR TITLE
fix(channel): sign state transitions like every other event

### DIFF
--- a/docs/superpowers/specs/2026-09-09-in-sandbox-channel-signing-design.md
+++ b/docs/superpowers/specs/2026-09-09-in-sandbox-channel-signing-design.md
@@ -141,9 +141,21 @@ Shipped: test 1's core (the payload survives `read_line` as one line and
 rebuilds a bit-identical key) as `a_signing_handoff_round_trips_to_the_same_key_on_one_line`,
 and test 2 by construction — `signing: None` leaves the old path untouched.
 
-**Test 5 has NOT been run.** It matters most: every other test can pass while
-the wiring never reaches the process that actually writes fleet events. Run it
-against a real `~/.mur` before believing this works.
+**Test 5 was run on 2026-09-10, and it found what the others could not.**
+
+The handoff works: the sandboxed child's `delegation` event came back SIGNED,
+which is the thing this design exists to make true.
+
+It also showed the acceptance criterion above was **unachievable as written**.
+"Zero unsigned events" can never hold, because `StateChange` events never went
+through `append_as_writer` at all — `ChannelService::transition` appended them
+directly and signed nothing, from sandboxed and unsandboxed processes alike (33
+of 33 on the live channel). That is a separate, pre-existing hole, fixed
+separately; it was invisible until a real run put a signed and an unsigned event
+side by side in the same second.
+
+The criterion should read: **every `delegation` and `message` event written from
+inside the sandbox is signed** — and, once transitions sign too, every event.
 
 ## Open questions
 

--- a/mur-channel/src/service.rs
+++ b/mur-channel/src/service.rs
@@ -329,12 +329,33 @@ impl ChannelService {
     /// Emit a `StateChange` event and persist the new state on the manifest.
     /// `run_id` stamps the run-status run boundary on the payload; pass `None`
     /// for transitions that are not part of a recorded run.
+    /// Unsigned state transition. Prefer `transition_signed` from anywhere a
+    /// writer identity is available — see that method for why.
     pub fn transition(
         &self,
         channel_id: &str,
         new_state: ChannelState,
         actor: ChannelActor,
         run_id: Option<&str>,
+    ) -> Result<ChannelEvent> {
+        self.transition_signed(channel_id, new_state, actor, run_id, None)
+    }
+
+    /// A state transition SIGNED by the channel's writer, when one is given.
+    ///
+    /// `transition` used to be the only entry point and never signed, so every
+    /// `StateChange` on every channel was unsigned regardless of who wrote it
+    /// — 33 of 33 on one live fleet channel, from sandboxed and unsandboxed
+    /// processes alike. `Message` and `Delegation` events went through the
+    /// signing path and these did not, which makes "the run started" and "the
+    /// run failed" the two events in a channel that nothing can attribute.
+    pub fn transition_signed(
+        &self,
+        channel_id: &str,
+        new_state: ChannelState,
+        actor: ChannelActor,
+        run_id: Option<&str>,
+        signer: Option<(&mur_common::identity::AgentIdentity, u32)>,
     ) -> Result<ChannelEvent> {
         let old_state = self
             .store
@@ -348,14 +369,30 @@ impl ChannelService {
         if let Some(run_id) = run_id {
             payload["run_id"] = serde_json::json!(run_id);
         }
+        // Same canonical sign-input as `append_signed`: no idempotency key
+        // participates here because a transition never carries one.
+        let (sig, kv) = match signer {
+            Some((id, kv)) => (
+                Some(crate::sign::sign_event(
+                    id,
+                    channel_id,
+                    &actor,
+                    EventKind::StateChange,
+                    &payload,
+                    None,
+                )),
+                Some(kv),
+            ),
+            None => (None, None),
+        };
         let ev = self.store.append_event(
             channel_id,
             actor,
             EventKind::StateChange,
             payload,
             None,
-            None,
-            None,
+            sig,
+            kv,
         )?;
         if let Ok(mut ch) = self.store.load_manifest(channel_id) {
             ch.state = new_state;
@@ -874,6 +911,49 @@ mod tests {
             trans.payload.get("run_id").is_none(),
             "non-run transitions must not fabricate a run_id"
         );
+    }
+
+    /// A state transition signs like every other event, and stays verifiable.
+    ///
+    /// The regression it pins: `transition` was the only write path that never
+    /// signed, so "the run started" and "the run failed" were the two events in
+    /// a channel nothing could attribute, while the messages between them were
+    /// signed. 33 of 33 StateChanges on one live fleet channel were unsigned.
+    #[test]
+    fn transition_signed_stores_verifiable_sig() {
+        let tmp = TempDir::new().unwrap();
+        let id = mur_common::identity::AgentIdentity::generate();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("signed-transition").unwrap();
+
+        let ev = svc
+            .transition_signed(
+                &ch.id,
+                ChannelState::Failed,
+                ChannelActor::System,
+                Some("run-7"),
+                Some((&id, 3)),
+            )
+            .unwrap();
+        assert_eq!(ev.key_version, Some(3));
+        let sig = ev.sig.as_ref().expect("a signed transition carries a sig");
+        assert!(crate::sign::verify_event_sig(
+            &ch.id,
+            &ev.actor,
+            ev.kind,
+            &ev.payload,
+            ev.idempotency_key.as_deref(),
+            sig,
+            &id.verifying_key_bytes()
+        ));
+
+        // No signer → unchanged behaviour, so the migration-safe path and every
+        // existing caller of `transition` keep working.
+        let plain = svc
+            .transition(&ch.id, ChannelState::Completed, ChannelActor::System, None)
+            .unwrap();
+        assert!(plain.sig.is_none());
+        assert!(plain.key_version.is_none());
     }
 
     #[test]

--- a/mur-core/src/channel_writer.rs
+++ b/mur-core/src/channel_writer.rs
@@ -77,6 +77,83 @@ fn handoff_for(router_agent: &str) -> Option<(&'static mur_common::identity::Age
     (agent == router_agent).then_some((id, *kv))
 }
 
+/// How this process signs as `router_agent`, resolved once for every kind of
+/// write.
+///
+/// `Ok(Some(..))` — sign. `Ok(None)` — no key exists at all, which is the
+/// legitimate bootstrap case (a fresh home, a test, a workflow channel with
+/// no agent behind it); unsigned is correct there. `Err` — the key is present
+/// and unreadable while `MUR_CHANNEL_REQUIRE_SIG` is set.
+///
+/// One derivation on purpose: an append and a state transition on the same
+/// channel must not disagree about whether that channel is protected.
+fn writer_key(
+    home: &Path,
+    router_agent: &str,
+) -> anyhow::Result<Option<(mur_common::identity::AgentIdentity, u32)>> {
+    // A process sealed inside an agent's sandbox cannot read `keys/` — that
+    // subtree is denied on purpose. Its parent loaded the key before sealing
+    // and handed it over stdin, so prefer that when it is for THIS writer.
+    // Checked before the disk read because the disk read is the thing that
+    // cannot work here, not a faster path we are skipping.
+    if let Some((id, kv)) = handoff_for(router_agent) {
+        return Ok(Some((id.clone(), kv)));
+    }
+    let agent_home = home.join("agents").join(router_agent);
+    match mur_common::identity::AgentIdentity::load(&agent_home) {
+        Ok(id) => Ok(Some((id, read_key_version(&agent_home)))),
+        Err(mur_common::identity::IdentityError::NotFound) => Ok(None),
+        // The key is THERE and we may not read it — a sandbox deny (a spawned
+        // `mur` cannot read a sibling's signing key since #975). Falling back
+        // to unsigned here is a silent security downgrade: the event was meant
+        // to be signed, and with `require_sig` off the reader accepts it, so
+        // the whole v3d signing guarantee lapses with nothing to show for it.
+        // The mirror of the read-side fix in `channel_verify::verify_event`.
+        Err(e) => {
+            if crate::channel_verify::require_sig_from_env() {
+                // The reader would reject an unsigned event anyway; fail here,
+                // where the cause is still legible, instead of at verification.
+                anyhow::bail!(
+                    "refusing to write an unsigned event as '{router_agent}': the writer key \
+                     is unreadable ({e}), and MUR_CHANNEL_REQUIRE_SIG is set"
+                );
+            }
+            tracing::warn!(
+                router_agent,
+                error = %e,
+                "writer signing key is present but unreadable — writing UNSIGNED. \
+                 Signature verification is not protecting this channel while that holds."
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Move `channel_id` to `new_state`, SIGNED by `router_agent` when possible.
+///
+/// The signed counterpart of `ChannelService::transition`. A run's start and
+/// end are the two events every surface reads to decide whether work is in
+/// flight; leaving them unattributable while the messages between them are
+/// signed is the wrong way round.
+pub fn transition_as_writer(
+    svc: &ChannelService,
+    home: &Path,
+    channel_id: &str,
+    router_agent: &str,
+    new_state: mur_common::channel::ChannelState,
+    actor: ChannelActor,
+    run_id: Option<&str>,
+) -> anyhow::Result<ChannelEvent> {
+    let key = writer_key(home, router_agent)?;
+    svc.transition_signed(
+        channel_id,
+        new_state,
+        actor,
+        run_id,
+        key.as_ref().map(|(id, kv)| (id, *kv)),
+    )
+}
+
 /// Append `actor`/`kind`/`payload` to `channel_id`, SIGNED by `router_agent`'s
 /// identity when it is available, else unsigned (migration-safe).
 ///
@@ -94,51 +171,9 @@ pub fn append_as_writer(
     payload: serde_json::Value,
     idem: Option<String>,
 ) -> anyhow::Result<ChannelEvent> {
-    // A process sealed inside an agent's sandbox cannot read `keys/` — that
-    // subtree is denied on purpose. Its parent loaded the key before sealing
-    // and handed it over stdin, so prefer that when it is for THIS writer.
-    // Checked before the disk read because the disk read is the thing that
-    // cannot work here, not a faster path we are skipping.
-    if let Some((id, kv)) = handoff_for(router_agent) {
-        return svc.append_signed(channel_id, id, kv, actor, kind, payload, idem);
-    }
-    let agent_home = home.join("agents").join(router_agent);
-    match mur_common::identity::AgentIdentity::load(&agent_home) {
-        Ok(id) => {
-            let kv = read_key_version(&agent_home);
-            svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem)
-        }
-        // No key at all: the legitimate bootstrap case (a fresh home, a test,
-        // a workflow channel with no agent behind it). Unsigned is correct.
-        Err(mur_common::identity::IdentityError::NotFound) => {
-            svc.append(channel_id, actor, kind, payload, idem)
-        }
-        // The key is THERE and we may not read it — a sandbox deny (a spawned
-        // `mur` cannot read a sibling's signing key since #975). Falling back
-        // to unsigned here is a silent security downgrade: the event was meant
-        // to be signed, and with `require_sig` off the reader accepts it, so
-        // the whole v3d signing guarantee lapses with nothing to show for it.
-        // The mirror of the read-side fix in `channel_verify::verify_event`.
-        Err(e) => {
-            if crate::channel_verify::require_sig_from_env() {
-                // The reader would reject an unsigned event anyway; fail here,
-                // where the cause is still legible, instead of at verification.
-                anyhow::bail!(
-                    "refusing to write an unsigned event to '{channel_id}': the \
-                     writer key for '{router_agent}' is unreadable ({e}), and \
-                     MUR_CHANNEL_REQUIRE_SIG is set"
-                );
-            }
-            tracing::warn!(
-                channel_id,
-                router_agent,
-                error = %e,
-                "writer signing key is present but unreadable — writing this \
-                 event UNSIGNED. Signature verification is not protecting this \
-                 channel while that holds."
-            );
-            svc.append(channel_id, actor, kind, payload, idem)
-        }
+    match writer_key(home, router_agent)? {
+        Some((id, kv)) => svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem),
+        None => svc.append(channel_id, actor, kind, payload, idem),
     }
 }
 

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -1070,8 +1070,13 @@ pub async fn execute_dag(
             Ok(events) => Some(events.last().map(|e| e.seq + 1).unwrap_or(0)),
             Err(_) => None,
         };
-        let _ = svc.transition(
+        // Signed like every other event this run writes — see
+        // `channel_writer::transition_as_writer`.
+        let _ = crate::channel_writer::transition_as_writer(
+            &svc,
+            mur_home,
             cid,
+            ROUTER_AGENT,
             ChannelState::Working,
             ChannelActor::System,
             opts.event_run_id(),
@@ -1231,8 +1236,17 @@ pub async fn execute_dag(
             RunOutcome::Done => ChannelState::Completed,
         };
         if let Some(cid) = opts.channel_id.as_deref() {
-            let _ = ChannelService::open(mur_home)
-                .and_then(|svc| svc.transition(cid, st, ChannelActor::System, opts.event_run_id()));
+            let _ = ChannelService::open(mur_home).and_then(|svc| {
+                crate::channel_writer::transition_as_writer(
+                    &svc,
+                    mur_home,
+                    cid,
+                    ROUTER_AGENT,
+                    st,
+                    ChannelActor::System,
+                    opts.event_run_id(),
+                )
+            });
         }
     };
 


### PR DESCRIPTION
## The hole

`ChannelService::transition` was the only write path that never signed. So on
every channel, the two events every surface reads to decide whether work is in
flight — *the run started*, *the run failed* — were the only ones nothing could
attribute, while every `message` and `delegation` between them was signed.

Measured on a live fleet channel, before this PR:

```
33 state-change  UNSIGNED     ← every one, from sandboxed and unsandboxed alike
25 delegation    signed
22 message       signed
```

## The fix

- `transition_signed` takes a writer the way `append_signed` does; `transition`
  becomes its unsigned wrapper, so every existing caller is untouched.
- In `mur-core`, "how does this process sign as X" moves into one `writer_key()`
  shared by the append and transition paths. An append and a state change on the
  same channel must not be able to disagree about whether that channel is
  protected — that is the same one-derivation rule #1239 was about.
- Both of the DAG executor's transitions (run start, run terminal) use it.

## How it was found

By running #1239's acceptance test instead of trusting it. That run proved the
in-sandbox signing handoff works — the sandboxed child's `delegation` event came
back **signed**, which is what the whole design was for — and in the same breath
showed the criterion it was being checked against ("zero unsigned events") could
never have held, because `StateChange` took a different path entirely. A signed
and an unsigned event, written one second apart by the same run, is what made it
visible. The spec now records both halves.

## Verification

- `cargo clippy -p mur-channel -p mur-core --all-targets -- -D warnings` → exit 0
- 36 tests pass, including the new `transition_signed_stores_verifiable_sig` and
  every existing signing / HITL-gate test (the gate writes transitions too)

**Not verified live.** This changes `mur-core`, which runs as the spawned `mur`
child, so seeing a signed `StateChange` on a real channel needs a release, an
install, and a rerun of the probe. Saying it works before that would repeat the
mistake this PR exists to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)