### PR TITLE
feat(browser): add Playwright auth and recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2187,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3044,7 +3044,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3233,7 +3233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4928,7 +4928,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6381,6 +6381,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mur-browser"
+version = "2.77.4"
+dependencies = [
+ "age",
+ "anyhow",
+ "chrono",
+ "keyring",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "mur-channel"
 version = "2.77.4"
 dependencies = [
@@ -6520,6 +6538,7 @@ dependencies = [
  "mime_guess",
  "multibase",
  "mur-agent-runtime",
+ "mur-browser",
  "mur-channel",
  "mur-common",
  "mur-compress",
@@ -6566,6 +6585,7 @@ dependencies = [
  "tui-textarea",
  "ulid",
  "unicode-width 0.1.14",
+ "url",
  "urlencoding",
  "uuid",
  "walkdir",
@@ -6862,7 +6882,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8511,7 +8531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9098,7 +9118,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -9294,7 +9314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9809,7 +9829,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11162,7 +11182,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "mur-open-items",
     "mur-mobile-sdk",
     "mur-zfs-agent",
+    "mur-browser",
     # "mur-commander",  # separate crate — v0.2.0 released
 ]
 exclude = [

--- a/mur-browser/Cargo.toml
+++ b/mur-browser/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mur-browser"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+# Internal to the workspace: consumed only via path deps, never from crates.io.
+publish = false
+description = "MCP stdio proxy + recorder between a MUR agent and @playwright/mcp (mur browser …)"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+schemars = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+keyring = "3"
+age = { version = "0.11", features = ["armor"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/mur-browser/src/auth.rs
+++ b/mur-browser/src/auth.rs
@@ -1,0 +1,325 @@
+//! Authentication handoff state machine for headed browser profiles.
+//!
+//! The transport owns browser I/O; this module owns the narrow lifecycle
+//! contract so it cannot save a profile before a human has explicitly taken
+//! over and continued after login.
+
+use anyhow::{Result, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::{state, state::StateKeyStore};
+
+/// One headed authentication session's lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Idle,
+    AgentDriving,
+    HumanDriving,
+    Verifying,
+    Saving,
+    Done,
+}
+
+/// Metadata stored next to an encrypted browser profile. It intentionally
+/// contains no credentials; expiry is informational only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileMeta {
+    pub url: String,
+    pub last_auth: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub earliest_cookie_expires: Option<DateTime<Utc>>,
+}
+
+/// Persist a verified Playwright storage-state document and its non-secret
+/// profile metadata. Metadata is only published after state encryption
+/// succeeds, and the handoff reaches `Done` only after both files exist.
+pub fn save_profile(
+    handoff: &mut Handoff,
+    state_path: &Path,
+    meta_path: &Path,
+    storage_state: &[u8],
+    url: &str,
+    now: DateTime<Utc>,
+    store: &impl StateKeyStore,
+) -> Result<ProfileMeta> {
+    handoff.write_state(state_path, storage_state, store)?;
+    let meta = ProfileMeta {
+        url: url.to_owned(),
+        last_auth: now,
+        earliest_cookie_expires: earliest_cookie_expiry(storage_state)?,
+    };
+    write_meta(meta_path, &meta)?;
+    handoff.saved()?;
+    Ok(meta)
+}
+
+/// Atomically write non-secret profile metadata with owner-only permissions.
+pub fn write_meta(path: &Path, meta: &ProfileMeta) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("profile metadata path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let yaml = serde_yaml::to_string(meta)?;
+    let temp = parent.join(format!(".meta-{}.tmp", uuid::Uuid::new_v4().simple()));
+    std::fs::write(&temp, yaml)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&temp, std::os::unix::fs::PermissionsExt::from_mode(0o600))?;
+    std::fs::rename(&temp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp);
+    })?;
+    Ok(())
+}
+
+fn earliest_cookie_expiry(storage_state: &[u8]) -> Result<Option<DateTime<Utc>>> {
+    let value: serde_json::Value = serde_json::from_slice(storage_state)?;
+    let cookies = value
+        .get("cookies")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            anyhow::anyhow!("browser storage state must contain an array field \"cookies\"")
+        })?;
+    Ok(cookies
+        .iter()
+        .filter_map(|cookie| cookie.get("expires").and_then(serde_json::Value::as_f64))
+        .filter(|expires| *expires > 0.0 && expires.is_finite())
+        .filter_map(|expires| DateTime::from_timestamp(expires as i64, 0))
+        .min())
+}
+
+/// State machine guarding an authentication handoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Handoff {
+    phase: Phase,
+}
+
+impl Default for Handoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handoff {
+    pub fn new() -> Self {
+        Self { phase: Phase::Idle }
+    }
+
+    pub fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    /// Browser launch and initial navigation completed.
+    pub fn start(&mut self) -> Result<()> {
+        self.transition(Phase::Idle, Phase::AgentDriving, "start authentication")
+    }
+
+    /// The browser is exclusively controlled by the person signing in.
+    pub fn handoff(&mut self) -> Result<()> {
+        self.transition(Phase::AgentDriving, Phase::HumanDriving, "handoff to human")
+    }
+
+    /// The person confirmed that login is complete; only verification is next.
+    pub fn continue_after_login(&mut self) -> Result<()> {
+        self.transition(
+            Phase::HumanDriving,
+            Phase::Verifying,
+            "continue after login",
+        )
+    }
+
+    /// A verification snapshot proved the session is authenticated.
+    pub fn verified(&mut self) -> Result<()> {
+        self.transition(Phase::Verifying, Phase::Saving, "save authenticated state")
+    }
+
+    /// Verification did not prove login; return control to the person.
+    pub fn verification_failed(&mut self) -> Result<()> {
+        self.transition(Phase::Verifying, Phase::HumanDriving, "return to human")
+    }
+
+    /// The encrypted state and metadata were written successfully.
+    pub fn saved(&mut self) -> Result<()> {
+        self.transition(Phase::Saving, Phase::Done, "finish authentication")
+    }
+
+    /// Encrypt a verified Playwright storage-state JSON document without
+    /// advancing the lifecycle; `save_profile` uses this before metadata.
+    fn write_state(
+        &mut self,
+        path: &Path,
+        storage_state: &[u8],
+        store: &impl StateKeyStore,
+    ) -> Result<()> {
+        if self.phase != Phase::Saving {
+            bail!(
+                "cannot save authenticated state while authentication is {:?}; expected {:?}",
+                self.phase,
+                Phase::Saving
+            );
+        }
+        validate_storage_state(storage_state)?;
+        state::write_state(path, storage_state, store)
+    }
+
+    /// Persist a verified Playwright storage-state JSON document. This is the
+    /// sole state-machine path that writes browser credentials to disk.
+    pub fn save_state(
+        &mut self,
+        path: &Path,
+        storage_state: &[u8],
+        store: &impl StateKeyStore,
+    ) -> Result<()> {
+        self.write_state(path, storage_state, store)?;
+        self.saved()
+    }
+
+    fn transition(&mut self, expected: Phase, next: Phase, action: &str) -> Result<()> {
+        if self.phase != expected {
+            bail!(
+                "cannot {action} while authentication is {:?}; expected {:?}",
+                self.phase,
+                expected
+            );
+        }
+        self.phase = next;
+        Ok(())
+    }
+}
+
+/// Validate the subset of Playwright's `storageState` schema that proves a
+/// browser transport actually captured a storage-state document. Arbitrary
+/// JSON (for example `{}`) must never become a reusable authenticated profile.
+fn validate_storage_state(storage_state: &[u8]) -> Result<()> {
+    let value: serde_json::Value = serde_json::from_slice(storage_state)
+        .map_err(|error| anyhow::anyhow!("browser storage state is not valid JSON: {error}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("browser storage state must be a JSON object"))?;
+    for field in ["cookies", "origins"] {
+        if !object.get(field).is_some_and(serde_json::Value::is_array) {
+            bail!("browser storage state must contain an array field {field:?}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authenticated_state_can_only_be_saved_after_human_handoff_and_verification() {
+        let mut handoff = Handoff::new();
+        assert!(handoff.saved().is_err());
+        handoff.start().unwrap();
+        assert!(handoff.continue_after_login().is_err());
+        handoff.handoff().unwrap();
+        handoff.continue_after_login().unwrap();
+        handoff.verified().unwrap();
+        handoff.saved().unwrap();
+        assert_eq!(handoff.phase(), Phase::Done);
+    }
+
+    #[test]
+    fn failed_verification_returns_to_human_control() {
+        let mut handoff = Handoff::new();
+        handoff.start().unwrap();
+        handoff.handoff().unwrap();
+        handoff.continue_after_login().unwrap();
+        handoff.verification_failed().unwrap();
+        assert_eq!(handoff.phase(), Phase::HumanDriving);
+    }
+
+    #[test]
+    fn save_state_requires_verification_and_encrypts_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json.age");
+        let store = MemoryStore::default();
+        let mut handoff = Handoff::new();
+        handoff.start().unwrap();
+        handoff.handoff().unwrap();
+        handoff.continue_after_login().unwrap();
+        assert!(handoff.save_state(&path, br#"{}"#, &store).is_err());
+        handoff.verified().unwrap();
+        handoff
+            .save_state(&path, br#"{"cookies":[],"origins":[]}"#, &store)
+            .unwrap();
+        assert_eq!(handoff.phase(), Phase::Done);
+        assert_eq!(
+            state::read_state(&path, &store).unwrap(),
+            br#"{"cookies":[],"origins":[]}"#
+        );
+    }
+
+    #[test]
+    fn save_state_rejects_json_that_is_not_playwright_storage_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json.age");
+        let store = MemoryStore::default();
+        let mut handoff = Handoff::new();
+        handoff.start().unwrap();
+        handoff.handoff().unwrap();
+        handoff.continue_after_login().unwrap();
+        handoff.verified().unwrap();
+
+        for invalid in [
+            br#"[]"#.as_slice(),
+            br#"{"cookies":[]}"#,
+            br#"{"origins":{}}"#,
+        ] {
+            assert!(handoff.save_state(&path, invalid, &store).is_err());
+            assert_eq!(handoff.phase(), Phase::Saving);
+        }
+    }
+
+    #[test]
+    fn save_profile_writes_non_secret_metadata_after_encryption() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json.age");
+        let meta_path = dir.path().join("meta.yaml");
+        let store = MemoryStore::default();
+        let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        let mut handoff = Handoff::new();
+        handoff.start().unwrap();
+        handoff.handoff().unwrap();
+        handoff.continue_after_login().unwrap();
+        handoff.verified().unwrap();
+        let state = br#"{"cookies":[{"expires":1700100000}],"origins":[]}"#;
+
+        let meta = save_profile(
+            &mut handoff,
+            &state_path,
+            &meta_path,
+            state,
+            "https://example.test/login",
+            now,
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(handoff.phase(), Phase::Done);
+        assert_eq!(meta.url, "https://example.test/login");
+        assert_eq!(
+            meta.earliest_cookie_expires,
+            DateTime::from_timestamp(1_700_100_000, 0)
+        );
+        let on_disk = std::fs::read_to_string(meta_path).unwrap();
+        assert!(on_disk.contains("https://example.test/login"));
+        assert!(!on_disk.contains("cookies"));
+    }
+
+    #[derive(Default)]
+    struct MemoryStore(std::sync::Mutex<std::collections::HashMap<String, String>>);
+
+    impl StateKeyStore for MemoryStore {
+        fn get(&self, account: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(account).cloned())
+        }
+
+        fn set(&self, account: &str, value: &str) -> Result<()> {
+            self.0.lock().unwrap().insert(account.into(), value.into());
+            Ok(())
+        }
+    }
+}

--- a/mur-browser/src/broker.rs
+++ b/mur-browser/src/broker.rs
@@ -1,0 +1,545 @@
+//! Slice 5: fail-closed secret broker for the browser MCP proxy.
+//!
+//! The wire format intentionally matches browser-rs: one JSON request plus a
+//! newline per Unix-socket connection, a capability token on every request,
+//! and a distinct lease for the later redaction pass.  The broker never sends
+//! secret values back to the proxy as metadata; they exist only in the
+//! transformed tool request and in the broker's in-memory lease table.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::time::timeout;
+use uuid::Uuid;
+
+/// Keychain account prefix: `browser/<site>/<KEY>`.
+pub const KEYCHAIN_PREFIX: &str = "browser/";
+/// OS keyring service shared with `mur agent secret set`.
+pub const KEYCHAIN_SERVICE: &str = "mur-agent";
+
+/// Env var the proxy reads the token from, then `remove_var`s.
+pub const TOKEN_ENV: &str = "MUR_BROWSER_BROKER_TOKEN";
+/// Hard timeout per broker round-trip.
+pub const TIMEOUT: Duration = Duration::from_secs(3);
+
+/// A proxy-local broker connection. Keeping it behind a trait means the hook
+/// can be tested without a socket and the proxy fails closed on every error.
+pub trait BrokerClient: Send + Sync {
+    fn transform<'a>(
+        &'a self,
+        value: Value,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Transform>> + Send + 'a>>;
+    fn redact<'a>(
+        &'a self,
+        lease: String,
+        boundary: Option<Value>,
+        value: Value,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Value>> + Send + 'a>>;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Transform {
+    pub value: Value,
+    pub lease: String,
+    pub boundary: Option<Value>,
+}
+
+/// Client for the one-request-per-connection Unix-socket wire protocol.
+#[derive(Debug, Clone)]
+pub struct SocketClient {
+    socket: std::path::PathBuf,
+    token: String,
+}
+
+impl SocketClient {
+    pub fn new(socket: impl Into<std::path::PathBuf>, token: impl Into<String>) -> Self {
+        Self {
+            socket: socket.into(),
+            token: token.into(),
+        }
+    }
+
+    async fn request(&self, op: Op) -> Result<Response> {
+        let stream = timeout(TIMEOUT, UnixStream::connect(&self.socket))
+            .await
+            .context("broker connection timed out")??;
+        let (read, mut write) = stream.into_split();
+        let request = Request {
+            id: Uuid::new_v4().simple().to_string(),
+            token: self.token.clone(),
+            op,
+        };
+        let wire = serde_json::to_string(&request)?;
+        timeout(TIMEOUT, async {
+            write.write_all(wire.as_bytes()).await?;
+            write.write_all(b"\n").await?;
+            write.flush().await
+        })
+        .await
+        .context("broker request timed out")??;
+        let mut lines = BufReader::new(read).lines();
+        let line = timeout(TIMEOUT, lines.next_line())
+            .await
+            .context("broker response timed out")??
+            .ok_or_else(|| anyhow::anyhow!("broker closed without a response"))?;
+        let response: Response = serde_json::from_str(&line).context("invalid broker response")?;
+        if !response.ok {
+            anyhow::bail!(
+                response
+                    .error
+                    .unwrap_or_else(|| "broker rejected request".into())
+            );
+        }
+        Ok(response)
+    }
+}
+
+impl BrokerClient for SocketClient {
+    fn transform<'a>(
+        &'a self,
+        value: Value,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Transform>> + Send + 'a>> {
+        Box::pin(async move {
+            let response = self.request(Op::TransformInput { value }).await?;
+            Ok(Transform {
+                value: response
+                    .value
+                    .ok_or_else(|| anyhow::anyhow!("broker transform omitted value"))?,
+                lease: response
+                    .lease
+                    .ok_or_else(|| anyhow::anyhow!("broker transform omitted lease"))?,
+                boundary: response.boundary,
+            })
+        })
+    }
+
+    fn redact<'a>(
+        &'a self,
+        lease: String,
+        boundary: Option<Value>,
+        value: Value,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Value>> + Send + 'a>> {
+        Box::pin(async move {
+            let response = self
+                .request(Op::RedactOutput {
+                    lease,
+                    boundary,
+                    value,
+                })
+                .await?;
+            response
+                .value
+                .ok_or_else(|| anyhow::anyhow!("broker redact omitted value"))
+        })
+    }
+}
+
+/// Keychain key prefix: `browser/<site>/<KEY>`.
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Op {
+    /// Before a tool call: replace `{{secret:<site>/<KEY>}}` inside `value`.
+    TransformInput { value: Value },
+    /// After a tool call (success or error): scrub real values from `value`.
+    RedactOutput {
+        lease: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        boundary: Option<Value>,
+        value: Value,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Request {
+    /// 32 hex, per request.
+    pub id: String,
+    pub token: String,
+    #[serde(flatten)]
+    pub op: Op,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Response {
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    /// Required on `transform_input` success; correlates the redact step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lease: Option<String>,
+    /// Opaque; round-tripped untouched to `redact_output`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boundary: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The narrow seam that lets `mur-core` adapt its OS Keychain without making
+/// this lower-level crate depend on `mur-core` (which would create a cycle).
+pub trait SecretStore: Send + Sync + 'static {
+    fn get(&self, account: &str) -> Result<String>;
+}
+
+/// OS-native secret store. Accounts use `browser/<site>/<KEY>` under the
+/// same `mur-agent` service used by `mur agent secret set`.
+pub struct KeychainStore;
+
+impl SecretStore for KeychainStore {
+    fn get(&self, account: &str) -> Result<String> {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, account)
+            .with_context(|| format!("open Keychain entry {KEYCHAIN_SERVICE}:{account}"))?;
+        match entry.get_password() {
+            Ok(secret) if !secret.is_empty() => Ok(secret),
+            Ok(_) => anyhow::bail!("Keychain entry {KEYCHAIN_SERVICE}:{account} is empty"),
+            Err(keyring::Error::NoEntry) => {
+                anyhow::bail!("Keychain entry {KEYCHAIN_SERVICE}:{account} does not exist")
+            }
+            Err(error) => Err(error)
+                .with_context(|| format!("read Keychain entry {KEYCHAIN_SERVICE}:{account}")),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LeaseSecret {
+    key: String,
+    value: String,
+}
+
+/// In-memory broker state. A broker is deliberately short lived: `record`
+/// creates it, passes its token privately to the proxy, then removes its
+/// socket when the recording process exits.
+pub struct Broker {
+    token: String,
+    store: Arc<dyn SecretStore>,
+    leases: Mutex<HashMap<String, Vec<LeaseSecret>>>,
+}
+
+impl Broker {
+    pub fn new(token: impl Into<String>, store: Arc<dyn SecretStore>) -> Self {
+        Self {
+            token: token.into(),
+            store,
+            leases: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Process one decoded request. All invalid tokens, malformed placeholders,
+    /// missing Keychain entries, and unknown/expired leases return `ok:false`;
+    /// callers must not forward the browser tool call in those cases.
+    pub fn handle(&self, request: Request) -> Response {
+        if request.token != self.token {
+            return Response::error("broker authentication failed");
+        }
+        match request.op {
+            Op::TransformInput { value } => self.transform(value),
+            Op::RedactOutput {
+                lease,
+                boundary: _,
+                value,
+            } => self.redact(&lease, value),
+        }
+    }
+
+    fn transform(&self, mut value: Value) -> Response {
+        let mut secrets = Vec::new();
+        if let Err(error) = self.replace_placeholders(&mut value, &mut secrets) {
+            return Response::error(error.to_string());
+        }
+        let lease = Uuid::new_v4().simple().to_string();
+        let keys = secrets.iter().map(|s| s.key.clone()).collect::<Vec<_>>();
+        if let Ok(mut leases) = self.leases.lock() {
+            leases.insert(lease.clone(), secrets);
+        } else {
+            return Response::error("broker lease lock poisoned");
+        }
+        Response {
+            ok: true,
+            value: Some(value),
+            lease: Some(lease),
+            // This contains names only, never values; clients merely round it
+            // back so the protocol remains browser-rs compatible.
+            boundary: Some(json!({"keys": keys})),
+            error: None,
+        }
+    }
+
+    fn redact(&self, lease: &str, mut value: Value) -> Response {
+        let secrets = match self.leases.lock() {
+            Ok(mut leases) => leases.remove(lease), // one-shot lease: fail closed on reuse
+            Err(_) => return Response::error("broker lease lock poisoned"),
+        };
+        let Some(secrets) = secrets else {
+            return Response::error("unknown or expired broker lease");
+        };
+        redact_value(&mut value, &secrets);
+        Response {
+            ok: true,
+            value: Some(value),
+            lease: None,
+            boundary: None,
+            error: None,
+        }
+    }
+
+    fn replace_placeholders(&self, value: &mut Value, found: &mut Vec<LeaseSecret>) -> Result<()> {
+        match value {
+            Value::String(text) => {
+                let mut output = String::new();
+                let mut rest = text.as_str();
+                while let Some(start) = rest.find("{{secret:") {
+                    output.push_str(&rest[..start]);
+                    let after_prefix = &rest[start..];
+                    let Some(end) = after_prefix.find("}}") else {
+                        anyhow::bail!("unterminated secret placeholder");
+                    };
+                    let placeholder = &after_prefix[..end + 2];
+                    let Some((site, key)) = parse_placeholder(placeholder) else {
+                        anyhow::bail!("invalid secret placeholder {placeholder:?}");
+                    };
+                    let account = format!("{KEYCHAIN_PREFIX}{site}/{key}");
+                    let secret = self
+                        .store
+                        .get(&account)
+                        .with_context(|| format!("read Keychain entry {account:?}"))?;
+                    output.push_str(&secret);
+                    if !found
+                        .iter()
+                        .any(|item| item.key == key && item.value == secret)
+                    {
+                        found.push(LeaseSecret {
+                            key: key.to_owned(),
+                            value: secret,
+                        });
+                    }
+                    rest = &after_prefix[end + 2..];
+                }
+                output.push_str(rest);
+                *text = output;
+            }
+            Value::Array(items) => {
+                for item in items {
+                    self.replace_placeholders(item, found)?;
+                }
+            }
+            Value::Object(map) => {
+                for item in map.values_mut() {
+                    self.replace_placeholders(item, found)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Serve connections until the listener is dropped or a transport error
+    /// occurs. Each connection carries exactly one request and one response.
+    /// The owner creates/removes the socket: silently deleting an existing
+    /// path here could tear down another active recording session.
+    pub async fn serve(self: Arc<Self>, socket: &Path) -> Result<()> {
+        if socket.exists() {
+            anyhow::bail!("broker socket already exists: {}", socket.display());
+        }
+        if let Some(parent) = socket.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let listener = UnixListener::bind(socket)
+            .with_context(|| format!("bind broker socket {}", socket.display()))?;
+        #[cfg(unix)]
+        std::fs::set_permissions(socket, std::os::unix::fs::PermissionsExt::from_mode(0o600))?;
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let broker = Arc::clone(&self);
+            tokio::spawn(async move {
+                let _ = broker.serve_connection(stream).await;
+            });
+        }
+    }
+
+    async fn serve_connection(&self, stream: UnixStream) -> Result<()> {
+        let (read, mut write) = stream.into_split();
+        let mut lines = BufReader::new(read).lines();
+        let Some(line) = timeout(TIMEOUT, lines.next_line())
+            .await
+            .context("broker request timed out")??
+        else {
+            return Ok(());
+        };
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(request) => self.handle(request),
+            Err(error) => Response::error(format!("invalid broker request: {error}")),
+        };
+        let wire = serde_json::to_string(&response)?;
+        timeout(TIMEOUT, async {
+            write.write_all(wire.as_bytes()).await?;
+            write.write_all(b"\n").await?;
+            write.flush().await
+        })
+        .await
+        .context("broker response timed out")??;
+        Ok(())
+    }
+}
+
+impl Response {
+    fn error(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            value: None,
+            lease: None,
+            boundary: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// Placeholder text → `(site, key)`.
+pub fn parse_placeholder(s: &str) -> Option<(&str, &str)> {
+    let inner = s.strip_prefix("{{secret:")?.strip_suffix("}}")?;
+    let (site, key) = inner.split_once('/')?;
+    let safe = |part: &str| {
+        !part.is_empty()
+            && part
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    };
+    (safe(site) && safe(key)).then_some((site, key))
+}
+
+fn redact_value(value: &mut Value, secrets: &[LeaseSecret]) {
+    match value {
+        Value::String(text) => {
+            for secret in secrets {
+                if !secret.value.is_empty() {
+                    *text = text.replace(&secret.value, &format!("[redacted:{}]", secret.key));
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_value(item, secrets);
+            }
+        }
+        Value::Object(map) => {
+            for item in map.values_mut() {
+                redact_value(item, secrets);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    struct MemoryStore(Mutex<HashMap<String, String>>);
+    impl MemoryStore {
+        fn with(account: &str, value: &str) -> Self {
+            Self(Mutex::new(HashMap::from([(account.into(), value.into())])))
+        }
+    }
+    impl SecretStore for MemoryStore {
+        fn get(&self, account: &str) -> Result<String> {
+            self.0
+                .lock()
+                .unwrap()
+                .get(account)
+                .cloned()
+                .context("missing test secret")
+        }
+    }
+    fn broker() -> Broker {
+        Broker::new(
+            "t".repeat(32),
+            Arc::new(MemoryStore::with("browser/pchome/PASSWORD", "Nope9Secret!")),
+        )
+    }
+    fn request(op: Op) -> Request {
+        Request {
+            id: "0".repeat(32),
+            token: "t".repeat(32),
+            op,
+        }
+    }
+
+    #[test]
+    fn transform_then_redact_is_one_shot_and_never_returns_secret_metadata() {
+        let b = broker();
+        let transformed = b.handle(request(Op::TransformInput {
+            value: json!({"text":"{{secret:pchome/PASSWORD}}"}),
+        }));
+        assert!(transformed.ok);
+        assert_eq!(transformed.value.as_ref().unwrap()["text"], "Nope9Secret!");
+        assert!(
+            !transformed
+                .boundary
+                .as_ref()
+                .is_some_and(|boundary| boundary.to_string().contains("Nope9Secret!"))
+        );
+        let lease = transformed.lease.unwrap();
+        let redacted = b.handle(request(Op::RedactOutput {
+            lease: lease.clone(),
+            boundary: transformed.boundary,
+            value: json!({"content":"typed Nope9Secret!"}),
+        }));
+        assert_eq!(
+            redacted.value.unwrap()["content"],
+            "typed [redacted:PASSWORD]"
+        );
+        assert!(
+            !b.handle(request(Op::RedactOutput {
+                lease,
+                boundary: None,
+                value: json!("x")
+            }))
+            .ok
+        );
+    }
+
+    #[test]
+    fn bad_token_and_missing_secret_fail_closed() {
+        let b = broker();
+        let mut bad = request(Op::TransformInput {
+            value: json!("{{secret:pchome/PASSWORD}}"),
+        });
+        bad.token = "wrong".into();
+        assert!(!b.handle(bad).ok);
+        assert!(
+            !b.handle(request(Op::TransformInput {
+                value: json!("{{secret:pchome/MISSING}}")
+            }))
+            .ok
+        );
+    }
+
+    #[test]
+    fn keychain_store_uses_shared_service_and_browser_account_convention() {
+        assert_eq!(KEYCHAIN_SERVICE, "mur-agent");
+        assert_eq!(
+            format!("{KEYCHAIN_PREFIX}pchome/PASSWORD"),
+            "browser/pchome/PASSWORD"
+        );
+    }
+
+    #[test]
+    fn nested_placeholders_are_replaced_and_invalid_names_rejected() {
+        let b = broker();
+        let out = b.handle(request(Op::TransformInput {
+            value: json!({"a":["x{{secret:pchome/PASSWORD}}y"]}),
+        }));
+        assert_eq!(out.value.unwrap()["a"][0], "xNope9Secret!y");
+        assert_eq!(parse_placeholder("{{secret:pchome/a/b}}"), None);
+        assert_eq!(parse_placeholder("{{secret:pchome/PASS WORD}}"), None);
+    }
+}

--- a/mur-browser/src/broker.rs
+++ b/mur-browser/src/broker.rs
@@ -9,13 +9,16 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+#[cfg(unix)]
+use std::path::Path;
 use std::{
     collections::HashMap,
-    path::Path,
     sync::{Arc, Mutex},
     time::Duration,
 };
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use tokio::time::timeout;
 use uuid::Uuid;
@@ -53,12 +56,14 @@ pub struct Transform {
 }
 
 /// Client for the one-request-per-connection Unix-socket wire protocol.
+#[cfg(unix)]
 #[derive(Debug, Clone)]
 pub struct SocketClient {
     socket: std::path::PathBuf,
     token: String,
 }
 
+#[cfg(unix)]
 impl SocketClient {
     pub fn new(socket: impl Into<std::path::PathBuf>, token: impl Into<String>) -> Self {
         Self {
@@ -102,6 +107,7 @@ impl SocketClient {
     }
 }
 
+#[cfg(unix)]
 impl BrokerClient for SocketClient {
     fn transform<'a>(
         &'a self,
@@ -344,6 +350,7 @@ impl Broker {
     /// occurs. Each connection carries exactly one request and one response.
     /// The owner creates/removes the socket: silently deleting an existing
     /// path here could tear down another active recording session.
+    #[cfg(unix)]
     pub async fn serve(self: Arc<Self>, socket: &Path) -> Result<()> {
         if socket.exists() {
             anyhow::bail!("broker socket already exists: {}", socket.display());
@@ -364,6 +371,7 @@ impl Broker {
         }
     }
 
+    #[cfg(unix)]
     async fn serve_connection(&self, stream: UnixStream) -> Result<()> {
         let (read, mut write) = stream.into_split();
         let mut lines = BufReader::new(read).lines();

--- a/mur-browser/src/lib.rs
+++ b/mur-browser/src/lib.rs
@@ -1,0 +1,31 @@
+//! `mur-browser` — the piece of MUR that sits between an agent and
+//! `@playwright/mcp`.
+//!
+//! Slice 1 (this crate's first cut) ships the **MCP stdio proxy** with a
+//! pure-forward hook, plus the frozen contracts the parallel slices build on:
+//!
+//! | module      | slice | what is frozen here                                  |
+//! |-------------|-------|------------------------------------------------------|
+//! | `proxy`     | 1     | JSON-RPC line relay + `Hook` trait (intercept points) |
+//! | `recorder`  | 2     | `Step` schema written to `runs/<name>/actions.yaml`   |
+//! | `locator`   | 3     | `role:` / `testid:` / `text:` / `label:` / `css:` grammar |
+//! | `broker`    | 5     | `transform_input` / `redact_output` wire types        |
+//! | `paths`     | 1     | `~/.mur/browser/...` layout                            |
+//!
+//! Nothing in here touches Playwright directly — every browser action goes
+//! over MCP, so the crate has no Node or Chromium dependency at build time.
+//! Design source: `~/.mur/artifacts/mur/browser-research-20260910/SPEC-phase1.md`.
+
+pub mod auth;
+pub mod broker;
+pub mod locator;
+pub mod paths;
+pub mod proxy;
+pub mod recorder;
+pub mod state;
+
+/// npm package spawned as the downstream MCP server.
+pub const PLAYWRIGHT_MCP_PKG: &str = "@playwright/mcp@latest";
+
+/// Name the agent sees for this server (`mur agent mcp add <agent> browser …`).
+pub const SERVER_NAME: &str = "browser";

--- a/mur-browser/src/locator.rs
+++ b/mur-browser/src/locator.rs
@@ -1,0 +1,358 @@
+//! Frozen contract for slice 3: the locator string grammar and snapshot resolution.
+//!
+//! A recorded `@ref` is diagnostic-only: it expires as soon as Playwright MCP
+//! produces another accessibility snapshot.  Replay resolves a stable locator
+//! against the current snapshot and returns its current ref.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Locator {
+    Role { role: String, name: Option<String> },
+    TestId(String),
+    Text(String),
+    Label(String),
+    Css(String),
+}
+
+impl Locator {
+    /// Parse `kind:body`. Unknown kinds are an error; a bare string with no
+    /// `kind:` prefix is treated as `css:` for compatibility with
+    /// `browser_generate_locator` output.
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        let s = s.trim();
+        let (kind, body) = match s.split_once(':') {
+            Some((k, b)) if matches!(k, "role" | "testid" | "text" | "label" | "css") => (k, b),
+            Some((k, _)) => anyhow::bail!("unknown locator kind {k:?} in {s:?}"),
+            None => ("css", s),
+        };
+        anyhow::ensure!(!body.is_empty(), "empty locator body in {s:?}");
+        Ok(match kind {
+            "role" => {
+                let (role, name) = match body.split_once('[') {
+                    Some((r, rest)) => {
+                        let rest = rest.trim_end_matches(']');
+                        let name = rest
+                            .strip_prefix("name=")
+                            .map(|n| n.trim_matches('"').to_string());
+                        (r.to_string(), name)
+                    }
+                    None => (body.to_string(), None),
+                };
+                Locator::Role { role, name }
+            }
+            "testid" => Locator::TestId(body.to_string()),
+            "text" => Locator::Text(body.to_string()),
+            "label" => Locator::Label(body.to_string()),
+            _ => Locator::Css(body.to_string()),
+        })
+    }
+
+    /// Canonical string form (what gets written to `actions.yaml`).
+    pub fn to_string_canonical(&self) -> String {
+        match self {
+            Locator::Role {
+                role,
+                name: Some(n),
+            } => format!("role:{role}[name=\"{n}\"]"),
+            Locator::Role { role, name: None } => format!("role:{role}"),
+            Locator::TestId(s) => format!("testid:{s}"),
+            Locator::Text(s) => format!("text:{s}"),
+            Locator::Label(s) => format!("label:{s}"),
+            Locator::Css(s) => format!("css:{s}"),
+        }
+    }
+}
+
+/// An accessibility-snapshot node needed by deterministic replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotNode {
+    pub reference: String,
+    pub role: String,
+    pub name: String,
+    pub text: String,
+    pub test_id: Option<String>,
+    pub label: Option<String>,
+}
+
+/// Parse Playwright MCP's text accessibility snapshot into addressable nodes.
+///
+/// The MCP emits lines such as `- button "Sign in" [ref=e12]`; indentation is
+/// intentionally ignored because locator resolution is about node attributes,
+/// not tree ancestry.  `testid` is not normally exposed by the snapshot, but
+/// is supported when the downstream supplies `[data-testid=foo]`.
+pub fn parse_snapshot(snapshot: &str) -> Vec<SnapshotNode> {
+    snapshot.lines().filter_map(parse_snapshot_line).collect()
+}
+
+fn parse_snapshot_line(line: &str) -> Option<SnapshotNode> {
+    let reference = extract_bracket_value(line, "ref=")?;
+    let before_ref = line.split("[ref=").next()?.trim();
+    let before_ref = before_ref.trim_start_matches('-').trim();
+    let mut words = before_ref.split_whitespace();
+    let role = words.next()?.trim_matches(':').to_string();
+    if role.is_empty() {
+        return None;
+    }
+
+    let name = extract_quoted(before_ref).unwrap_or_default();
+    let text = if name.is_empty() {
+        words.collect::<Vec<_>>().join(" ")
+    } else {
+        name.clone()
+    };
+    Some(SnapshotNode {
+        reference,
+        role,
+        name,
+        text,
+        test_id: extract_bracket_value(line, "data-testid="),
+        label: extract_bracket_value(line, "label="),
+    })
+}
+
+fn extract_bracket_value(line: &str, key: &str) -> Option<String> {
+    let rest = line.split_once(key)?.1;
+    let value = rest.split(']').next()?.trim();
+    Some(value.trim_matches('"').to_string())
+}
+
+fn extract_quoted(s: &str) -> Option<String> {
+    let start = s.find('"')? + 1;
+    let rest = &s[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Resolve a stable locator to the current Playwright ref. CSS cannot be
+/// resolved from an accessibility snapshot, so replay must hand it to
+/// `browser_generate_locator` instead of guessing.
+pub fn resolve(locator: &Locator, snapshot: &[SnapshotNode]) -> Option<String> {
+    let node = snapshot.iter().find(|node| match locator {
+        Locator::Role { role, name } => {
+            node.role.eq_ignore_ascii_case(role)
+                && name.as_ref().is_none_or(|name| node.name == *name)
+        }
+        Locator::TestId(id) => node.test_id.as_deref() == Some(id),
+        Locator::Text(text) => node.text.contains(text) || node.name.contains(text),
+        Locator::Label(label) => node.label.as_deref() == Some(label) || node.name == *label,
+        Locator::Css(_) => false,
+    })?;
+    Some(node.reference.clone())
+}
+
+/// Produce stable replay candidates for a ref from the latest a11y snapshot.
+/// Order is deliberate: semantic role first, then an explicit test id, label,
+/// and finally visible text. A ref is never emitted because it is ephemeral.
+pub fn candidates_for_ref(reference: &str, snapshot: &[SnapshotNode]) -> Vec<String> {
+    let reference = reference.trim_start_matches('@');
+    let Some(node) = snapshot
+        .iter()
+        .find(|node| node.reference.trim_start_matches('@') == reference)
+    else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+    if !node.role.is_empty() {
+        let locator = if node.name.is_empty() {
+            Locator::Role {
+                role: node.role.clone(),
+                name: None,
+            }
+        } else {
+            Locator::Role {
+                role: node.role.clone(),
+                name: Some(node.name.clone()),
+            }
+        };
+        candidates.push(locator.to_string_canonical());
+    }
+    if let Some(id) = &node.test_id {
+        candidates.push(Locator::TestId(id.clone()).to_string_canonical());
+    }
+    if let Some(label) = &node.label {
+        candidates.push(Locator::Label(label.clone()).to_string_canonical());
+    }
+    if !node.text.is_empty() {
+        candidates.push(Locator::Text(node.text.clone()).to_string_canonical());
+    }
+    candidates.sort();
+    candidates.dedup();
+    // Restore the designed priority after deduplication rather than relying on
+    // the lexical sort used above.
+    candidates.sort_by_key(|candidate| match Locator::parse(candidate) {
+        Ok(Locator::Role { .. }) => 0,
+        Ok(Locator::TestId(_)) => 1,
+        Ok(Locator::Label(_)) => 2,
+        Ok(Locator::Text(_)) => 3,
+        _ => 4,
+    });
+    candidates
+}
+
+/// SPEC §3.2 pruning rule: reject `nth-child` / `nth-of-type`, `>` chains
+/// deeper than 3, and generated class names (`css-`, `sc-`, `_`, or
+/// `[a-z]{1,2}\d{3,}`). Non-CSS kinds are always stable.
+pub fn is_stable(s: &str) -> bool {
+    let Ok(l) = Locator::parse(s) else {
+        return false;
+    };
+    let Locator::Css(css) = l else {
+        return true;
+    };
+    if css.contains(":nth-child") || css.contains(":nth-of-type") {
+        return false;
+    }
+    if css.matches('>').count() > 3 {
+        return false;
+    }
+    // every `.class` token
+    for tok in css.split(|c: char| c.is_whitespace() || c == '>' || c == '[' || c == '#') {
+        for cls in tok.split('.').skip(1) {
+            let cls =
+                cls.trim_end_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_');
+            if cls.starts_with("css-") || cls.starts_with("sc-") || cls.starts_with('_') {
+                return false;
+            }
+            if looks_generated(cls) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// `[a-z]{1,2}\d{3,}` e.g. `a1234`, `xy987`.
+fn looks_generated(cls: &str) -> bool {
+    let letters: String = cls.chars().take_while(|c| c.is_ascii_lowercase()).collect();
+    if letters.is_empty() || letters.len() > 2 {
+        return false;
+    }
+    let rest = &cls[letters.len()..];
+    rest.len() >= 3 && rest.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SNAPSHOT: &str = r#"
+- banner:
+  - link "MUR" [ref=e1]
+  - button "Sign in" [ref=e2]
+- main:
+  - searchbox "Search docs" [ref=e3] [label="Search docs"]
+  - button "Submit" [ref=e4] [data-testid=submit-button]
+"#;
+
+    #[test]
+    fn parses_each_kind() {
+        assert_eq!(
+            Locator::parse("role:button[name=\"登入\"]").unwrap(),
+            Locator::Role {
+                role: "button".into(),
+                name: Some("登入".into())
+            }
+        );
+        assert_eq!(
+            Locator::parse("role:searchbox").unwrap(),
+            Locator::Role {
+                role: "searchbox".into(),
+                name: None
+            }
+        );
+        assert_eq!(
+            Locator::parse("testid:x").unwrap(),
+            Locator::TestId("x".into())
+        );
+        assert_eq!(
+            Locator::parse("text:搜尋").unwrap(),
+            Locator::Text("搜尋".into())
+        );
+        assert_eq!(
+            Locator::parse("label:密碼").unwrap(),
+            Locator::Label("密碼".into())
+        );
+        assert_eq!(Locator::parse("css:#a").unwrap(), Locator::Css("#a".into()));
+        assert_eq!(
+            Locator::parse("#a > b").unwrap(),
+            Locator::Css("#a > b".into())
+        );
+        assert!(Locator::parse("role:").is_err());
+    }
+
+    #[test]
+    fn canonical_round_trip() {
+        for s in [
+            "role:button[name=\"登入\"]",
+            "role:link",
+            "testid:q",
+            "text:t",
+            "label:l",
+            "css:#x",
+        ] {
+            assert_eq!(Locator::parse(s).unwrap().to_string_canonical(), s);
+        }
+    }
+
+    #[test]
+    fn stability_rules() {
+        assert!(is_stable("role:button[name=\"x\"]"));
+        assert!(is_stable("testid:anything.with-123"));
+        assert!(is_stable("css:#login"));
+        assert!(is_stable("css:form.login > button.primary"));
+        assert!(!is_stable("css:ul > li:nth-child(3) > a"));
+        assert!(!is_stable("css:div > div > div > div > a"));
+        assert!(!is_stable("css:.css-1x2y3z"));
+        assert!(!is_stable("css:.sc-bdVaJa"));
+        assert!(!is_stable("css:._hidden"));
+        assert!(!is_stable("css:.a1234"));
+        assert!(
+            is_stable("css:.abc1234"),
+            "3 letters is not the generated pattern"
+        );
+        assert!(!is_stable("bogus:"));
+    }
+
+    #[test]
+    fn resolves_role_testid_text_and_label_against_snapshot() {
+        let nodes = parse_snapshot(SNAPSHOT);
+        assert_eq!(
+            resolve(
+                &Locator::parse("role:button[name=\"Sign in\"]").unwrap(),
+                &nodes
+            ),
+            Some("e2".into())
+        );
+        assert_eq!(
+            resolve(&Locator::parse("testid:submit-button").unwrap(), &nodes),
+            Some("e4".into())
+        );
+        assert_eq!(
+            resolve(&Locator::parse("text:Search").unwrap(), &nodes),
+            Some("e3".into())
+        );
+        assert_eq!(
+            resolve(&Locator::parse("label:Search docs").unwrap(), &nodes),
+            Some("e3".into())
+        );
+        assert_eq!(
+            resolve(&Locator::parse("css:#submit").unwrap(), &nodes),
+            None
+        );
+    }
+
+    #[test]
+    fn derives_ordered_candidates_from_current_ref() {
+        let nodes = parse_snapshot(SNAPSHOT);
+        assert_eq!(
+            candidates_for_ref("@e4", &nodes),
+            vec![
+                "role:button[name=\"Submit\"]",
+                "testid:submit-button",
+                "text:Submit",
+            ]
+        );
+        assert!(candidates_for_ref("@missing", &nodes).is_empty());
+    }
+}

--- a/mur-browser/src/paths.rs
+++ b/mur-browser/src/paths.rs
@@ -1,0 +1,92 @@
+//! `~/.mur/browser/` layout (SPEC §3.4). Single source of truth for paths so
+//! slices 2–6 never hard-code strings.
+
+use std::path::{Path, PathBuf};
+
+/// Root of all browser state under a MUR home.
+pub fn browser_root(mur_home: &Path) -> PathBuf {
+    mur_home.join("browser")
+}
+
+/// `profiles/<site>/` — encrypted storageState + meta.
+pub fn profile_dir(mur_home: &Path, site: &str) -> PathBuf {
+    browser_root(mur_home).join("profiles").join(site)
+}
+
+/// `profiles/<site>/state.json.age`
+pub fn profile_state(mur_home: &Path, site: &str) -> PathBuf {
+    profile_dir(mur_home, site).join("state.json.age")
+}
+
+/// `profiles/<site>/meta.yaml`
+pub fn profile_meta(mur_home: &Path, site: &str) -> PathBuf {
+    profile_dir(mur_home, site).join("meta.yaml")
+}
+
+/// `runs/<name>/` — one recorded run.
+pub fn run_dir(mur_home: &Path, run: &str) -> PathBuf {
+    browser_root(mur_home).join("runs").join(run)
+}
+
+/// `runs/<name>/actions.yaml` — the source of truth for replay.
+pub fn run_actions(mur_home: &Path, run: &str) -> PathBuf {
+    run_dir(mur_home, run).join("actions.yaml")
+}
+
+/// `runs/<name>/hits.jsonl`
+pub fn run_hits(mur_home: &Path, run: &str) -> PathBuf {
+    run_dir(mur_home, run).join("hits.jsonl")
+}
+
+/// `runs/<name>/report.md`
+pub fn run_report(mur_home: &Path, run: &str) -> PathBuf {
+    run_dir(mur_home, run).join("report.md")
+}
+
+/// `broker.sock` — 0600, created by `record`, removed on exit.
+pub fn broker_socket(mur_home: &Path) -> PathBuf {
+    browser_root(mur_home).join("broker.sock")
+}
+
+/// Run and site names are used as directory components; keep them boring.
+pub fn validate_name(name: &str) -> anyhow::Result<()> {
+    let ok = !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        && !name.starts_with('.');
+    anyhow::ensure!(
+        ok,
+        "invalid name {name:?}: use [A-Za-z0-9._-], max 64 chars, not starting with '.'"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_matches_spec() {
+        let home = Path::new("/h");
+        assert_eq!(
+            run_actions(home, "smoke"),
+            PathBuf::from("/h/browser/runs/smoke/actions.yaml")
+        );
+        assert_eq!(
+            profile_state(home, "pchome"),
+            PathBuf::from("/h/browser/profiles/pchome/state.json.age")
+        );
+        assert_eq!(broker_socket(home), PathBuf::from("/h/browser/broker.sock"));
+    }
+
+    #[test]
+    fn names_are_path_safe() {
+        assert!(validate_name("pchome-login_v2").is_ok());
+        assert!(validate_name("../etc").is_err());
+        assert!(validate_name(".hidden").is_err());
+        assert!(validate_name("a/b").is_err());
+        assert!(validate_name("").is_err());
+    }
+}

--- a/mur-browser/src/proxy.rs
+++ b/mur-browser/src/proxy.rs
@@ -1,0 +1,1078 @@
+//! MCP stdio proxy: the agent talks to us, we talk to `@playwright/mcp`.
+//!
+//! Wire format is newline-delimited JSON-RPC 2.0 in both directions. The
+//! proxy owns two things the later slices need:
+//!
+//! 1. **Correlation** — every agent request is remembered by id so the
+//!    matching response can be shown to the hook together with the request
+//!    that caused it (the recorder needs "which tool was this?").
+//! 2. **A private line to the server** — [`Downstream::call`] lets a hook
+//!    make its own requests (e.g. `browser_generate_locator`) without the
+//!    agent ever seeing them. Internal ids are namespaced `mur-<pid>-<n>`.
+//!
+//! Slice 1 ships [`ForwardHook`] (pure relay). Slices 2/4/5 plug in via
+//! [`Hook`].
+
+use crate::broker::BrokerClient;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{Mutex, mpsc, oneshot};
+
+/// A JSON-RPC request as seen on the wire. `params` is kept as raw JSON so
+/// hooks can rewrite it (secret substitution) before forwarding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+impl Request {
+    /// For `tools/call`, the tool name (`browser_click`, `mur_intent`, …).
+    pub fn tool_name(&self) -> Option<&str> {
+        if self.method != "tools/call" {
+            return None;
+        }
+        self.params.as_ref()?.get("name")?.as_str()
+    }
+
+    /// For `tools/call`, the `arguments` object.
+    pub fn tool_args(&self) -> Option<&Value> {
+        if self.method != "tools/call" {
+            return None;
+        }
+        self.params.as_ref()?.get("arguments")
+    }
+
+    /// Mutable `arguments` (creates an empty object if absent).
+    pub fn tool_args_mut(&mut self) -> Option<&mut Value> {
+        if self.method != "tools/call" {
+            return None;
+        }
+        let params = self.params.get_or_insert_with(|| json!({}));
+        let obj = params.as_object_mut()?;
+        Some(obj.entry("arguments").or_insert_with(|| json!({})))
+    }
+}
+
+/// What a hook wants done with an agent request.
+#[derive(Debug)]
+pub enum Decision {
+    /// Send this (possibly rewritten) request to the server.
+    Forward(Request),
+    /// Answer the agent ourselves; the server never sees it.
+    Reply(Value),
+    /// Refuse with a JSON-RPC error. `code` follows JSON-RPC conventions
+    /// (`-32602` invalid params, `-32000` server error).
+    Reject { code: i32, message: String },
+}
+
+/// Intercept points. Slice 1 only forwards; later slices override.
+///
+/// Both methods run under a mutex, so a hook may keep plain mutable state.
+pub trait Hook: Send + 'static {
+    /// Called for every agent request (has an `id`) **and** notification
+    /// (no `id`). Rejecting a notification is silently a drop.
+    fn on_request(
+        &mut self,
+        req: Request,
+        down: &Downstream,
+    ) -> impl std::future::Future<Output = Decision> + Send;
+
+    /// Called with the server's response to an agent request. `req` is the
+    /// original (post-rewrite) request. Return the response to hand back —
+    /// usually the same value, possibly redacted.
+    fn on_response(
+        &mut self,
+        req: &Request,
+        resp: Value,
+        down: &Downstream,
+    ) -> impl std::future::Future<Output = Value> + Send;
+
+    /// Extra tools this hook implements itself (merged into the server's
+    /// `tools/list` result). Default: none.
+    fn extra_tools(&self) -> Vec<Value> {
+        Vec::new()
+    }
+}
+
+pub struct BrokerHook<H> {
+    inner: H,
+    broker: Arc<dyn BrokerClient>,
+    leases: HashMap<String, (String, Option<Value>)>,
+    /// Request as seen before secret substitution. The recorder receives this
+    /// copy, so its YAML retains `{{secret:…}}`, never the Keychain value.
+    original_requests: HashMap<String, Request>,
+}
+
+impl<H> BrokerHook<H> {
+    pub fn new(inner: H, broker: Arc<dyn BrokerClient>) -> Self {
+        Self {
+            inner,
+            broker,
+            leases: HashMap::new(),
+            original_requests: HashMap::new(),
+        }
+    }
+}
+
+impl<H: Hook> Hook for BrokerHook<H> {
+    async fn on_request(&mut self, mut req: Request, down: &Downstream) -> Decision {
+        let Some(args) = req.tool_args().cloned() else {
+            return self.inner.on_request(req, down).await;
+        };
+        // Requests with no secret placeholder never touch the broker. For a
+        // placeholder-bearing request, however, broker failure means the call
+        // is rejected before it can reach Playwright (fail closed).
+        if !contains_placeholder(&args) {
+            return self.inner.on_request(req, down).await;
+        }
+        let original = req.clone();
+        let transformed = match self.broker.transform(args).await {
+            Ok(value) => value,
+            Err(error) => {
+                return Decision::Reject {
+                    code: -32000,
+                    message: format!("secret broker unavailable: {error}"),
+                };
+            }
+        };
+        if let Some(slot) = req.tool_args_mut() {
+            *slot = transformed.value;
+        } else {
+            return Decision::Reject {
+                code: -32602,
+                message: "tools/call arguments are not an object".into(),
+            };
+        }
+        match self.inner.on_request(req, down).await {
+            Decision::Forward(req) => {
+                if let Some(id) = req.id.as_ref() {
+                    let key = id_key(id);
+                    // Keep the pre-substitution request exclusively for the
+                    // recorder; Playwright still receives `req` with values
+                    // resolved by the broker.
+                    self.original_requests.insert(key.clone(), original);
+                    self.leases
+                        .insert(key, (transformed.lease, transformed.boundary));
+                }
+                Decision::Forward(req)
+            }
+            other => other,
+        }
+    }
+
+    async fn on_response(&mut self, req: &Request, resp: Value, down: &Downstream) -> Value {
+        let Some(id) = &req.id else {
+            return self.inner.on_response(req, resp, down).await;
+        };
+        // The inner hook (notably RecordHook) must see the request the agent
+        // supplied, before secret substitution. This prevents plaintext from
+        // ever entering actions.yaml.
+        let original = self.original_requests.remove(&id_key(id));
+        let response = match original.as_ref() {
+            Some(original) => self.inner.on_response(original, resp, down).await,
+            None => self.inner.on_response(req, resp, down).await,
+        };
+        let Some((lease, boundary)) = self.leases.remove(&id_key(id)) else {
+            return response;
+        };
+        match self.broker.redact(lease, boundary, response).await {
+            Ok(redacted) => redacted,
+            Err(error) => {
+                json!({"jsonrpc":"2.0", "id":id, "error":{"code":-32000, "message":format!("secret broker redaction failed: {error}")}})
+            }
+        }
+    }
+
+    fn extra_tools(&self) -> Vec<Value> {
+        self.inner.extra_tools()
+    }
+}
+
+/// Pure relay — what slice 1 ships.
+#[derive(Debug, Default)]
+pub struct ForwardHook;
+
+impl Hook for ForwardHook {
+    async fn on_request(&mut self, req: Request, _down: &Downstream) -> Decision {
+        Decision::Forward(req)
+    }
+
+    async fn on_response(&mut self, _req: &Request, resp: Value, _down: &Downstream) -> Value {
+        resp
+    }
+}
+
+type PendingInternal = Arc<Mutex<HashMap<String, oneshot::Sender<Value>>>>;
+
+/// Handle for sending our own requests to the server.
+#[derive(Clone)]
+pub struct Downstream {
+    to_server: mpsc::UnboundedSender<String>,
+    pending: PendingInternal,
+    next_id: Arc<AtomicU64>,
+    id_prefix: Arc<String>,
+}
+
+impl Downstream {
+    fn new(to_server: mpsc::UnboundedSender<String>) -> Self {
+        Self {
+            to_server,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            next_id: Arc::new(AtomicU64::new(1)),
+            id_prefix: Arc::new(format!("mur-{}-", std::process::id())),
+        }
+    }
+
+    fn is_internal_id(&self, id: &Value) -> bool {
+        id.as_str()
+            .map(|s| s.starts_with(self.id_prefix.as_str()))
+            .unwrap_or(false)
+    }
+
+    /// Fire a request the agent never sees and wait for the full JSON-RPC
+    /// response object (`result` or `error` still inside).
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value> {
+        let n = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let id = format!("{}{}", self.id_prefix, n);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id.clone(), tx);
+        let line = serde_json::to_string(&json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        }))?;
+        self.to_server.send(line).context("server stdin closed")?;
+        rx.await
+            .context("server exited before answering internal call")
+    }
+
+    /// Send a notification the server never needs to acknowledge.
+    pub fn notify(&self, method: &str, params: Value) -> Result<()> {
+        let line = serde_json::to_string(&json!({
+            "jsonrpc": "2.0", "method": method, "params": params
+        }))?;
+        self.to_server.send(line).context("server stdin closed")
+    }
+
+    /// Convenience: `tools/call` and return the whole response.
+    pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value> {
+        self.call(
+            "tools/call",
+            json!({ "name": name, "arguments": arguments }),
+        )
+        .await
+    }
+
+    /// Navigate a headed browser, wait for an explicit human confirmation, and
+    /// use Playwright's unsafe-code tool to write its storage state into MUR's
+    /// private output directory. `@playwright/mcp` does not expose a dedicated
+    /// storage-state tool, so this is the supported escape hatch for invoking
+    /// `BrowserContext.storageState` without carrying session JSON over MCP.
+    pub async fn capture_storage_state(
+        &self,
+        url: &str,
+        state_path: &std::path::Path,
+    ) -> Result<()> {
+        let navigate = self
+            .call_tool("browser_navigate", json!({ "url": url }))
+            .await?;
+        ensure_tool_succeeded("browser_navigate", &navigate)?;
+
+        eprintln!(
+            "Complete sign-in in the opened browser, then press Enter here to save the profile."
+        );
+        let mut confirmation = String::new();
+        let read =
+            tokio::task::spawn_blocking(move || std::io::stdin().read_line(&mut confirmation))
+                .await
+                .context("wait for login confirmation task")??;
+        if read == 0 {
+            bail!("login confirmation cancelled: stdin closed");
+        }
+
+        let code = storage_state_export_code(state_path)?;
+        let state = self
+            .call_tool("browser_run_code_unsafe", json!({ "code": code }))
+            .await?;
+        ensure_tool_succeeded("browser_run_code_unsafe", &state)?;
+        Ok(())
+    }
+
+    /// Forward a raw line (used for agent → server traffic).
+    fn send_raw(&self, line: String) -> Result<()> {
+        self.to_server.send(line).context("server stdin closed")
+    }
+}
+
+fn storage_state_export_code(state_path: &std::path::Path) -> Result<String> {
+    // Serialize the path as a JavaScript string literal, rather than
+    // interpolating it directly into code. The directory is private and
+    // is removed immediately after its contents are encrypted.
+    let path = serde_json::to_string(&state_path.to_string_lossy())?;
+    Ok(format!(
+        "async (page) => {{ await page.context().storageState({{ path: {path} }}); return 'storage state saved'; }}"
+    ))
+}
+
+fn ensure_response_succeeded<'a>(method: &str, response: &'a Value) -> Result<&'a Value> {
+    if let Some(error) = response.get("error") {
+        bail!("{method} failed: {error}");
+    }
+    response
+        .get("result")
+        .ok_or_else(|| anyhow::anyhow!("{method} returned neither result nor error"))
+}
+
+fn ensure_tool_succeeded<'a>(tool: &str, response: &'a Value) -> Result<&'a Value> {
+    let result = ensure_response_succeeded(tool, response)?;
+    // MCP tool failures are successful JSON-RPC responses carrying
+    // `result.isError`, rather than JSON-RPC `error`. Do not prompt a human to
+    // complete login when Playwright never opened a browser.
+    if result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let detail = result
+            .get("content")
+            .map(Value::to_string)
+            .unwrap_or_else(|| result.to_string());
+        bail!("{tool} failed: {detail}");
+    }
+    Ok(result)
+}
+
+/// Build the argv passed to `npx` for the Playwright MCP package.
+fn playwright_args(extra_args: &[String]) -> Vec<String> {
+    let mut args = vec!["-y".to_owned(), crate::PLAYWRIGHT_MCP_PKG.to_owned()];
+    args.extend(extra_args.iter().cloned());
+    args
+}
+
+/// Build the `npx @playwright/mcp` command. Extra args are passed through
+/// verbatim (`--headless`, `--isolated`, `--storage-state=…`).
+pub fn playwright_command(extra_args: &[String]) -> Command {
+    let mut cmd = Command::new("npx");
+    cmd.args(playwright_args(extra_args));
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .kill_on_drop(true);
+    cmd
+}
+
+/// Spawn the server and relay between our stdin/stdout and it.
+/// Returns when the agent closes stdin or the server exits.
+pub async fn run_stdio<H: Hook>(mut cmd: Command, hook: H) -> Result<()> {
+    let mut child: Child = cmd
+        .spawn()
+        .context("spawn downstream MCP server (is `npx` on PATH and in the spawn allowlist?)")?;
+    let child_in = child.stdin.take().context("child stdin")?;
+    let child_out = child.stdout.take().context("child stdout")?;
+    let result = run_io(
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+        child_in,
+        child_out,
+        hook,
+    )
+    .await;
+    let _ = child.kill().await;
+    result
+}
+
+/// Spawn a headed Playwright MCP server in an isolated temporary directory,
+/// then return the storage state it exported using `browser_run_code_unsafe`.
+/// The unencrypted file remains in the private directory only long enough for
+/// this function to read it and `save_profile` to encrypt it locally.
+pub async fn capture_storage_state(url: &str, browser: &str) -> Result<Vec<u8>> {
+    let output = private_output_dir()?;
+    let output_arg = format!("--output-dir={}", output.display());
+    let browser_arg = format!("--browser={browser}");
+    // @playwright/mcp runs headed by default; its CLI has no `--headed` flag.
+    let mut cmd = playwright_command(&["--isolated".into(), browser_arg, output_arg]);
+    let mut child = match cmd.spawn().context(
+        "spawn headed Playwright MCP server (is `npx` on PATH and in the spawn allowlist?)",
+    ) {
+        Ok(child) => child,
+        Err(error) => {
+            // No state exists yet, but do not leave private scratch directories
+            // behind when the server cannot start.
+            let _ = std::fs::remove_dir_all(&output);
+            return Err(error);
+        }
+    };
+    let child_in = match child.stdin.take().context("child stdin") {
+        Ok(stdin) => stdin,
+        Err(error) => {
+            let _ = child.kill().await;
+            let _ = std::fs::remove_dir_all(&output);
+            return Err(error);
+        }
+    };
+    let child_out = match child.stdout.take().context("child stdout") {
+        Ok(stdout) => stdout,
+        Err(error) => {
+            let _ = child.kill().await;
+            let _ = std::fs::remove_dir_all(&output);
+            return Err(error);
+        }
+    };
+    let state_path = output.join("storage-state.json");
+    let result = capture_storage_state_io(child_in, child_out, url, &state_path).await;
+    let _ = child.kill().await;
+    let state = match result {
+        Ok(()) => std::fs::read(&state_path).with_context(|| {
+            format!(
+                "read captured browser storage state {}",
+                state_path.display()
+            )
+        }),
+        Err(error) => Err(error),
+    };
+    let _ = std::fs::remove_dir_all(&output);
+    state
+}
+
+fn private_output_dir() -> Result<std::path::PathBuf> {
+    let path = std::env::temp_dir().join(format!("mur-browser-auth-{}", uuid::Uuid::new_v4()));
+    // The Playwright tool writes unencrypted session cookies here. Do not rely
+    // on the caller's umask: only this user may traverse the directory.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&path)
+            .with_context(|| {
+                format!("create private browser output directory {}", path.display())
+            })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir(&path).with_context(|| {
+            format!("create private browser output directory {}", path.display())
+        })?;
+    }
+    Ok(path)
+}
+
+async fn capture_storage_state_io<SI, SO>(
+    server_in: SI,
+    server_out: SO,
+    url: &str,
+    state_path: &std::path::Path,
+) -> Result<()>
+where
+    SI: AsyncWrite + Unpin + Send + 'static,
+    SO: AsyncRead + Unpin + Send + 'static,
+{
+    let (to_server, mut to_server_rx) = mpsc::unbounded_channel::<String>();
+    let down = Downstream::new(to_server);
+    let server_task = tokio::spawn(async move {
+        let mut server_in = server_in;
+        while let Some(line) = to_server_rx.recv().await {
+            server_in.write_all(line.as_bytes()).await?;
+            server_in.write_all(b"\n").await?;
+            server_in.flush().await?;
+        }
+        Ok::<(), std::io::Error>(())
+    });
+    let downstream = down.clone();
+    let response_task = tokio::spawn(async move {
+        let mut lines = BufReader::new(server_out).lines();
+        while let Some(line) = lines.next_line().await? {
+            let value: Value = serde_json::from_str(&line)?;
+            if let Some(id) = value.get("id")
+                && downstream.is_internal_id(id)
+                && let Some(sender) = downstream
+                    .pending
+                    .lock()
+                    .await
+                    .remove(id.as_str().unwrap_or(""))
+            {
+                let _ = sender.send(value);
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+    let initialized = down
+        .call(
+            "initialize",
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "mur browser auth",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )
+        .await
+        .context("initialize headed Playwright MCP session");
+    let result = match initialized {
+        Ok(response) => match ensure_response_succeeded("initialize", &response) {
+            Ok(_) => match down
+                .notify("notifications/initialized", json!({}))
+                .context("confirm headed Playwright MCP initialization")
+            {
+                Ok(()) => down.capture_storage_state(url, state_path).await,
+                Err(error) => Err(error),
+            },
+            Err(error) => Err(error),
+        },
+        Err(error) => Err(error),
+    };
+    drop(down);
+    // The response reader owns a `Downstream` clone, and therefore the last
+    // sender to the server writer. Stop it before awaiting the writer or this
+    // private session would wait forever for its own channel to close.
+    response_task.abort();
+    let _ = response_task.await;
+    let _ = server_task.await;
+    result
+}
+
+/// Transport-agnostic core, so tests can drive it with in-memory pipes.
+///
+/// * `agent_in`  — what the agent writes (our stdin)
+/// * `agent_out` — what the agent reads (our stdout)
+/// * `server_in` — the server's stdin
+/// * `server_out`— the server's stdout
+pub async fn run_io<H, AI, AO, SI, SO>(
+    agent_in: AI,
+    mut agent_out: AO,
+    mut server_in: SI,
+    server_out: SO,
+    hook: H,
+) -> Result<()>
+where
+    H: Hook,
+    AI: AsyncRead + Unpin + Send + 'static,
+    AO: AsyncWrite + Unpin + Send + 'static,
+    SI: AsyncWrite + Unpin + Send + 'static,
+    SO: AsyncRead + Unpin + Send + 'static,
+{
+    let (to_server_tx, mut to_server_rx) = mpsc::unbounded_channel::<String>();
+    let (to_agent_tx, mut to_agent_rx) = mpsc::unbounded_channel::<String>();
+    let down = Downstream::new(to_server_tx);
+    let hook = Arc::new(Mutex::new(hook));
+    // agent request id (stringified) → original request, for on_response
+    let agent_pending: Arc<Mutex<HashMap<String, Request>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    // Writer: server stdin
+    let w_server = tokio::spawn(async move {
+        while let Some(line) = to_server_rx.recv().await {
+            if server_in.write_all(line.as_bytes()).await.is_err()
+                || server_in.write_all(b"\n").await.is_err()
+                || server_in.flush().await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    // Writer: agent stdout
+    let w_agent = tokio::spawn(async move {
+        while let Some(line) = to_agent_rx.recv().await {
+            if agent_out.write_all(line.as_bytes()).await.is_err()
+                || agent_out.write_all(b"\n").await.is_err()
+                || agent_out.flush().await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    // Reader: agent → (hook) → server
+    let r_agent = {
+        let down = down.clone();
+        let hook = hook.clone();
+        let agent_pending = agent_pending.clone();
+        let to_agent = to_agent_tx.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(agent_in).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let v: Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "agent sent non-JSON line; dropped");
+                        continue;
+                    }
+                };
+                // Agent answering a server-initiated request: pass straight through.
+                if v.get("method").is_none() {
+                    let _ = down.send_raw(line);
+                    continue;
+                }
+                let req: Request = match serde_json::from_value(v) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "malformed request; dropped");
+                        continue;
+                    }
+                };
+                let id = req.id.clone();
+                let decision = hook.lock().await.on_request(req, &down).await;
+                match decision {
+                    Decision::Forward(req) => {
+                        if let Some(id) = &req.id {
+                            agent_pending.lock().await.insert(id_key(id), req.clone());
+                        }
+                        match serde_json::to_string(&req) {
+                            Ok(line) => {
+                                let _ = down.send_raw(line);
+                            }
+                            Err(e) => tracing::warn!(error = %e, "serialize request"),
+                        }
+                    }
+                    Decision::Reply(result) => {
+                        if let Some(id) = id {
+                            let _ = to_agent
+                                .send(json!({"jsonrpc":"2.0","id":id,"result":result}).to_string());
+                        }
+                    }
+                    Decision::Reject { code, message } => {
+                        if let Some(id) = id {
+                            let _ = to_agent.send(
+                                json!({"jsonrpc":"2.0","id":id,
+                                       "error":{"code":code,"message":message}})
+                                .to_string(),
+                            );
+                        }
+                    }
+                }
+            }
+        })
+    };
+
+    // Reader: server → (route) → agent or internal waiter
+    let r_server = {
+        let down = down.clone();
+        let hook = hook.clone();
+        let agent_pending = agent_pending.clone();
+        let to_agent = to_agent_tx.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(server_out).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let v: Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        // Playwright MCP occasionally logs to stdout; keep it
+                        // out of the agent's JSON stream.
+                        tracing::debug!(line = %line, "server non-JSON stdout");
+                        continue;
+                    }
+                };
+                let is_response = v.get("method").is_none();
+                let Some(id) = v.get("id").cloned() else {
+                    // notification from server
+                    let _ = to_agent.send(line);
+                    continue;
+                };
+                if is_response && down.is_internal_id(&id) {
+                    if let Some(tx) = down.pending.lock().await.remove(id.as_str().unwrap_or("")) {
+                        let _ = tx.send(v);
+                    }
+                    continue;
+                }
+                if is_response {
+                    let req = agent_pending.lock().await.remove(&id_key(&id));
+                    let out = match req {
+                        Some(req) => {
+                            let mut resp = hook.lock().await.on_response(&req, v, &down).await;
+                            if req.method == "tools/list" {
+                                merge_extra_tools(&mut resp, hook.lock().await.extra_tools());
+                            }
+                            resp
+                        }
+                        None => v,
+                    };
+                    let _ = to_agent.send(out.to_string());
+                } else {
+                    // server-initiated request (roots/list, sampling) → agent
+                    let _ = to_agent.send(line);
+                }
+            }
+        })
+    };
+
+    // Whichever side hangs up first ends the session.
+    tokio::select! {
+        _ = r_agent => {}
+        _ = r_server => {}
+    }
+    drop(down);
+    drop(to_agent_tx);
+    let _ = w_server.await;
+    let _ = w_agent.await;
+    Ok(())
+}
+
+fn id_key(id: &Value) -> String {
+    id.to_string()
+}
+
+fn contains_placeholder(value: &Value) -> bool {
+    match value {
+        Value::String(text) => text.contains("{{secret:"),
+        Value::Array(items) => items.iter().any(contains_placeholder),
+        Value::Object(map) => map.values().any(contains_placeholder),
+        _ => false,
+    }
+}
+
+fn merge_extra_tools(resp: &mut Value, extra: Vec<Value>) {
+    if extra.is_empty() {
+        return;
+    }
+    if let Some(tools) = resp
+        .get_mut("result")
+        .and_then(|r| r.get_mut("tools"))
+        .and_then(|t| t.as_array_mut())
+    {
+        tools.extend(extra);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::duplex;
+
+    /// A fake server: echoes `{"id":…,"result":{"echo":<params>}}` for every
+    /// request, and answers `tools/list` with one tool.
+    async fn fake_server(mut inp: impl AsyncRead + Unpin, mut out: impl AsyncWrite + Unpin) {
+        let mut lines = BufReader::new(&mut inp).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let v: Value = serde_json::from_str(&line).unwrap();
+            let id = v["id"].clone();
+            let result = if v["method"] == "tools/list" {
+                json!({"tools":[{"name":"browser_navigate"}]})
+            } else {
+                json!({"echo": v["params"]})
+            };
+            let resp = json!({"jsonrpc":"2.0","id":id,"result":result}).to_string();
+            out.write_all(resp.as_bytes()).await.unwrap();
+            out.write_all(b"\n").await.unwrap();
+        }
+    }
+
+    /// Hook that rejects `browser_storage_state`, answers `mur_ping` itself,
+    /// and makes one internal call on `browser_click` to prove `Downstream`.
+    struct TestHook {
+        internal_seen: Arc<Mutex<Vec<Value>>>,
+    }
+
+    #[derive(Clone)]
+    struct FakeBroker;
+
+    impl BrokerClient for FakeBroker {
+        fn transform<'a>(
+            &'a self,
+            mut value: Value,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = anyhow::Result<crate::broker::Transform>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                replace_test_secret(&mut value, "{{secret:pchome/PASSWORD}}", "ActualSecret123!");
+                Ok(crate::broker::Transform {
+                    value,
+                    lease: "one-shot-test-lease".into(),
+                    boundary: Some(json!({"keys":["PASSWORD"]})),
+                })
+            })
+        }
+
+        fn redact<'a>(
+            &'a self,
+            lease: String,
+            _boundary: Option<Value>,
+            mut value: Value,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<Value>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                anyhow::ensure!(lease == "one-shot-test-lease", "unexpected broker lease");
+                replace_test_secret(&mut value, "ActualSecret123!", "[redacted:PASSWORD]");
+                Ok(value)
+            })
+        }
+    }
+
+    fn replace_test_secret(value: &mut Value, from: &str, to: &str) {
+        match value {
+            Value::String(text) => *text = text.replace(from, to),
+            Value::Array(values) => values
+                .iter_mut()
+                .for_each(|value| replace_test_secret(value, from, to)),
+            Value::Object(values) => values
+                .values_mut()
+                .for_each(|value| replace_test_secret(value, from, to)),
+            _ => {}
+        }
+    }
+
+    struct CaptureRequestHook {
+        seen_response_request: Arc<Mutex<Option<Request>>>,
+    }
+
+    impl Hook for CaptureRequestHook {
+        async fn on_request(&mut self, req: Request, _down: &Downstream) -> Decision {
+            Decision::Forward(req)
+        }
+
+        async fn on_response(&mut self, req: &Request, resp: Value, _down: &Downstream) -> Value {
+            *self.seen_response_request.lock().await = Some(req.clone());
+            resp
+        }
+    }
+    impl Hook for TestHook {
+        async fn on_request(&mut self, req: Request, down: &Downstream) -> Decision {
+            match req.tool_name() {
+                Some("browser_storage_state") => Decision::Reject {
+                    code: -32000,
+                    message: "use mur browser auth".into(),
+                },
+                Some("mur_ping") => Decision::Reply(json!({"pong":true})),
+                Some("browser_click") => {
+                    let r = down
+                        .call_tool("browser_generate_locator", json!({"ref":"e1"}))
+                        .await
+                        .unwrap();
+                    self.internal_seen.lock().await.push(r);
+                    Decision::Forward(req)
+                }
+                _ => Decision::Forward(req),
+            }
+        }
+        async fn on_response(&mut self, _req: &Request, mut resp: Value, _d: &Downstream) -> Value {
+            resp["result"]["hooked"] = json!(true);
+            resp
+        }
+        fn extra_tools(&self) -> Vec<Value> {
+            vec![json!({"name":"mur_ping"})]
+        }
+    }
+
+    async fn read_line(r: &mut (impl AsyncRead + Unpin)) -> Value {
+        let mut lines = BufReader::new(r).lines();
+        let l = tokio::time::timeout(std::time::Duration::from_secs(2), lines.next_line())
+            .await
+            .expect("timeout")
+            .unwrap()
+            .expect("eof");
+        serde_json::from_str(&l).unwrap()
+    }
+
+    #[test]
+    fn storage_state_export_code_quotes_hostile_paths() {
+        let path = std::path::Path::new("/private/a\"b\\c/storage-state.json");
+        let code = storage_state_export_code(path).unwrap();
+        assert!(code.starts_with("async (page) =>"));
+        assert!(
+            code.contains("storageState({ path: \"/private/a\\\"b\\\\c/storage-state.json\" })")
+        );
+        assert!(code.ends_with("return 'storage state saved'; }"));
+    }
+
+    #[test]
+    fn headed_auth_args_use_selected_browser_and_default_headed_mode() {
+        let output_arg = "--output-dir=/private/tmp/mur-auth".to_owned();
+        let browser_arg = "--browser=firefox".to_owned();
+        let args = playwright_args(&["--isolated".into(), browser_arg.clone(), output_arg.clone()]);
+
+        assert!(args.contains(&"--isolated".to_owned()));
+        assert!(args.contains(&browser_arg));
+        assert!(args.contains(&output_arg));
+        assert!(
+            !args.iter().any(|arg| arg == "--headed"),
+            "@playwright/mcp is headed by default; --headed is not a supported option"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_reject_reply_and_internal_call() {
+        let (agent_w, agent_in) = duplex(64 * 1024); // test writes → proxy stdin
+        let (agent_out, mut agent_r) = duplex(64 * 1024); // proxy stdout → test reads
+        let (server_in, srv_r) = duplex(64 * 1024); // proxy → server
+        let (srv_w, server_out) = duplex(64 * 1024); // server → proxy
+
+        tokio::spawn(fake_server(srv_r, srv_w));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let hook = TestHook {
+            internal_seen: seen.clone(),
+        };
+        tokio::spawn(run_io(agent_in, agent_out, server_in, server_out, hook));
+
+        let mut agent_w = agent_w;
+        let send = |v: Value| v.to_string() + "\n";
+
+        // 1. plain forward + on_response touched it
+        agent_w
+            .write_all(
+                send(json!({"jsonrpc":"2.0","id":1,"method":"tools/call",
+                "params":{"name":"browser_navigate","arguments":{"url":"https://x"}}}))
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let r = read_line(&mut agent_r).await;
+        assert_eq!(r["id"], 1);
+        assert_eq!(r["result"]["echo"]["name"], "browser_navigate");
+        assert_eq!(r["result"]["hooked"], true);
+
+        // 2. reject never reaches server
+        agent_w
+            .write_all(
+                send(json!({"jsonrpc":"2.0","id":2,"method":"tools/call",
+                "params":{"name":"browser_storage_state","arguments":{}}}))
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let r = read_line(&mut agent_r).await;
+        assert_eq!(r["id"], 2);
+        assert_eq!(r["error"]["message"], "use mur browser auth");
+
+        // 3. reply from hook
+        agent_w
+            .write_all(
+                send(json!({"jsonrpc":"2.0","id":"s3","method":"tools/call",
+                "params":{"name":"mur_ping","arguments":{}}}))
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let r = read_line(&mut agent_r).await;
+        assert_eq!(r["id"], "s3");
+        assert_eq!(r["result"]["pong"], true);
+
+        // 4. internal call happens before forward; agent sees only its own reply
+        agent_w
+            .write_all(
+                send(json!({"jsonrpc":"2.0","id":4,"method":"tools/call",
+                "params":{"name":"browser_click","arguments":{"ref":"e1"}}}))
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let r = read_line(&mut agent_r).await;
+        assert_eq!(r["id"], 4);
+        assert_eq!(r["result"]["echo"]["name"], "browser_click");
+        let seen = seen.lock().await;
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0]["result"]["echo"]["name"],
+            "browser_generate_locator"
+        );
+        assert!(seen[0]["id"].as_str().unwrap().starts_with("mur-"));
+
+        // 5. tools/list gets extra tools merged
+        agent_w
+            .write_all(send(json!({"jsonrpc":"2.0","id":5,"method":"tools/list"})).as_bytes())
+            .await
+            .unwrap();
+        let r = read_line(&mut agent_r).await;
+        let names: Vec<_> = r["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["browser_navigate", "mur_ping"]);
+    }
+
+    #[tokio::test]
+    async fn broker_hook_forwards_secret_but_records_placeholder_and_redacts_response() {
+        let (agent_w, agent_in) = duplex(64 * 1024);
+        let (agent_out, mut agent_r) = duplex(64 * 1024);
+        let (server_in, mut server_r) = duplex(64 * 1024);
+        let (mut server_w, server_out) = duplex(64 * 1024);
+        let seen = Arc::new(Mutex::new(None));
+        let hook = BrokerHook::new(
+            CaptureRequestHook {
+                seen_response_request: seen.clone(),
+            },
+            Arc::new(FakeBroker),
+        );
+        tokio::spawn(run_io(agent_in, agent_out, server_in, server_out, hook));
+
+        let server = tokio::spawn(async move {
+            let request = read_line(&mut server_r).await;
+            assert_eq!(request["params"]["arguments"]["text"], "ActualSecret123!");
+            let response = json!({
+                "jsonrpc":"2.0", "id":request["id"],
+                "result":{"content":"echo ActualSecret123!"}
+            });
+            server_w
+                .write_all(response.to_string().as_bytes())
+                .await
+                .unwrap();
+            server_w.write_all(b"\n").await.unwrap();
+        });
+
+        let mut agent_w = agent_w;
+        agent_w.write_all(
+            br#"{"jsonrpc":"2.0","id":77,"method":"tools/call","params":{"name":"browser_type","arguments":{"text":"{{secret:pchome/PASSWORD}}"}}}
+"#,
+        ).await.unwrap();
+        let response = read_line(&mut agent_r).await;
+        server.await.unwrap();
+
+        assert_eq!(response["result"]["content"], "echo [redacted:PASSWORD]");
+        assert!(!response.to_string().contains("ActualSecret123!"));
+        let recorded = seen.lock().await.clone().expect("response hook request");
+        assert_eq!(
+            recorded.tool_args().unwrap()["text"],
+            "{{secret:pchome/PASSWORD}}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_output_dir_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = private_output_dir().unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        std::fs::remove_dir(path).unwrap();
+    }
+
+    #[test]
+    fn request_accessors() {
+        let mut r: Request = serde_json::from_value(json!({"jsonrpc":"2.0","id":1,
+            "method":"tools/call","params":{"name":"browser_type","arguments":{"text":"a"}}}))
+        .unwrap();
+        assert_eq!(r.tool_name(), Some("browser_type"));
+        assert_eq!(r.tool_args().unwrap()["text"], "a");
+        r.tool_args_mut().unwrap()["text"] = json!("b");
+        assert_eq!(r.tool_args().unwrap()["text"], "b");
+        let n: Request =
+            serde_json::from_value(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+                .unwrap();
+        assert!(n.tool_name().is_none());
+        assert!(n.id.is_none());
+    }
+}

--- a/mur-browser/src/recorder.rs
+++ b/mur-browser/src/recorder.rs
@@ -1,0 +1,781 @@
+//! Frozen contract for slice 2: the `Step` schema written to
+//! `runs/<name>/actions.yaml` (SPEC §3.2).
+//!
+//! Slice 1 ships the types, serde round-trip, and the **schema validation**
+//! that decides whether a step may be written at all. The interception logic
+//! (turning a `browser_click` into a `Step`) is slice 2's job and lives in
+//! `RecordHook` (not here yet).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::PathBuf;
+
+use crate::{
+    locator::{SnapshotNode, candidates_for_ref, parse_snapshot},
+    proxy::{Decision, Downstream, Hook, Request},
+};
+
+/// What a recorded step does. Mirrors the Playwright MCP tool it came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Goto,
+    Click,
+    Fill,
+    Select,
+    Press,
+    Hover,
+    AssertVisible,
+    AssertText,
+    AssertValue,
+}
+
+impl Action {
+    /// Whether this action addresses an element (needs `locators`).
+    pub fn needs_locator(self) -> bool {
+        !matches!(self, Action::Goto)
+    }
+
+    /// Whether replay should fail the run when this step misses
+    /// (assertions only matter in `mode: test`).
+    pub fn is_assert(self) -> bool {
+        matches!(
+            self,
+            Action::AssertVisible | Action::AssertText | Action::AssertValue
+        )
+    }
+}
+
+/// One line of `actions.yaml`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Step {
+    /// 1-based position in the run.
+    pub step: u32,
+    /// Human intent, ≥ 4 chars. Auto-filled from the snapshot when the agent
+    /// didn't call `mur_intent` (then `intent_auto` is true).
+    pub intent: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub intent_auto: bool,
+    pub action: Action,
+    /// URL for `goto`, text for `fill`/`press`/`select`, expected text for
+    /// asserts. Secrets are stored as `{{secret:<site>/<KEY>}}` — never plain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// Priority-ordered locator candidates (see [`crate::locator`]).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub locators: Vec<String>,
+    /// Set by replay `--heal` when a new locator was prepended.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub healed: bool,
+    /// Index into `locators` that hit on the last replay.
+    #[serde(default)]
+    pub last_hit: usize,
+    /// The `@ref` at record time. Debug only — replay must never use it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ref_at_record: Option<String>,
+}
+
+/// Whole file: header + steps.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Run {
+    pub name: String,
+    /// `test` or `automation`.
+    pub mode: Mode,
+    /// Site profile used (`profiles/<site>/`), if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    Test,
+    Automation,
+}
+
+impl std::str::FromStr for Mode {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "test" => Ok(Mode::Test),
+            "automation" => Ok(Mode::Automation),
+            other => anyhow::bail!("mode must be test|automation, got {other:?}"),
+        }
+    }
+}
+
+/// Why a step was refused. The message is what the agent sees in the
+/// JSON-RPC error, so it says what to do next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reject {
+    NoLocator,
+    IntentTooShort,
+    RawSecret,
+}
+
+/// Placeholder shape produced by `mur_secret`.
+pub const SECRET_PLACEHOLDER_PREFIX: &str = "{{secret:";
+
+pub fn is_secret_placeholder(s: &str) -> bool {
+    s.starts_with(SECRET_PLACEHOLDER_PREFIX) && s.ends_with("}}")
+}
+
+/// Heuristic from SPEC §3.2: len ≥ 12 and has lower + upper + digit.
+pub fn looks_high_entropy(s: &str) -> bool {
+    s.chars().count() >= 12
+        && s.chars().any(|c| c.is_ascii_lowercase())
+        && s.chars().any(|c| c.is_ascii_uppercase())
+        && s.chars().any(|c| c.is_ascii_digit())
+}
+
+/// Validate one step before it may be written. `in_password_field` comes
+/// from the snapshot cache (slice 2) — `true` when the target element is a
+/// `textbox` with `type=password`.
+///
+/// Unstable locators are **pruned** here (via [`crate::locator::is_stable`]);
+/// the caller gets back the cleaned step or a [`Reject`].
+pub fn validate(mut step: Step, in_password_field: bool) -> Result<Step, Reject> {
+    if step.action.needs_locator() {
+        step.locators.retain(|l| crate::locator::is_stable(l));
+        if step.locators.is_empty() {
+            return Err(Reject::NoLocator);
+        }
+    }
+    if step.intent.chars().count() < 4 {
+        return Err(Reject::IntentTooShort);
+    }
+    if step.action == Action::Fill
+        && in_password_field
+        && let Some(v) = &step.value
+        && !is_secret_placeholder(v)
+        && looks_high_entropy(v)
+    {
+        return Err(Reject::RawSecret);
+    }
+    Ok(step)
+}
+
+/// Serialize a run to YAML (the on-disk form).
+pub fn to_yaml(run: &Run) -> anyhow::Result<String> {
+    Ok(serde_yaml::to_string(run)?)
+}
+
+/// Parse `actions.yaml`.
+pub fn from_yaml(s: &str) -> anyhow::Result<Run> {
+    Ok(serde_yaml::from_str(s)?)
+}
+
+/// JSON Schema for `actions.yaml` — exported by `mur browser show --schema`.
+pub fn json_schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(Run)).unwrap_or_default()
+}
+
+/// Recording state owned by the MCP proxy for one `mur browser record` run.
+///
+/// It intercepts successful Playwright actions and persists only validated
+/// steps.  The hook deliberately records on the response path: a failed click
+/// must not become a replayable action.
+#[derive(Debug)]
+pub struct RecordHook {
+    run: Run,
+    /// `mur_intent` applies to exactly the next recorded action.
+    pending_intent: Option<String>,
+    actions_path: Option<PathBuf>,
+    /// Most recent Playwright accessibility snapshot. It is only an in-memory
+    /// recording aid: refs from it never reach `actions.yaml` as locators.
+    snapshot: Vec<SnapshotNode>,
+}
+
+impl RecordHook {
+    /// Start recording into an empty or pre-existing run.  This constructor is
+    /// useful for tests; production uses [`Self::with_actions_path`].
+    pub fn new(run: Run) -> Self {
+        Self {
+            run,
+            pending_intent: None,
+            actions_path: None,
+            snapshot: Vec::new(),
+        }
+    }
+
+    /// Record to `actions.yaml`, creating its parent directory on the first
+    /// successful action.
+    pub fn with_actions_path(run: Run, actions_path: PathBuf) -> Self {
+        Self {
+            run,
+            pending_intent: None,
+            actions_path: Some(actions_path),
+            snapshot: Vec::new(),
+        }
+    }
+
+    /// The run accumulated so far.
+    pub fn run(&self) -> &Run {
+        &self.run
+    }
+
+    fn intent_for_next_step(&mut self, fallback: &str) -> (String, bool) {
+        match self.pending_intent.take() {
+            Some(intent) if intent.chars().count() >= 4 => (intent, false),
+            _ => (fallback.to_string(), true),
+        }
+    }
+
+    fn persist(&self) -> anyhow::Result<()> {
+        let Some(path) = &self.actions_path else {
+            return Ok(());
+        };
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("actions path has no parent: {}", path.display()))?;
+        std::fs::create_dir_all(parent)?;
+        std::fs::write(path, to_yaml(&self.run)?)?;
+        Ok(())
+    }
+
+    fn action_for(req: &Request) -> Option<Action> {
+        match req.tool_name()? {
+            "browser_navigate" => Some(Action::Goto),
+            "browser_click" => Some(Action::Click),
+            "browser_type" | "browser_fill" => Some(Action::Fill),
+            "browser_select_option" => Some(Action::Select),
+            "browser_press_key" => Some(Action::Press),
+            "browser_hover" => Some(Action::Hover),
+            "browser_verify_element_visible" => Some(Action::AssertVisible),
+            "browser_verify_text_visible" | "browser_verify_element_text" => {
+                Some(Action::AssertText)
+            }
+            "browser_verify_value" | "browser_verify_element_value" => Some(Action::AssertValue),
+            _ => None,
+        }
+    }
+
+    fn value_for(action: Action, args: Option<&Value>) -> Option<String> {
+        let args = args?;
+        let key = match action {
+            Action::Goto => "url",
+            Action::Fill => "text",
+            Action::Select => "values",
+            Action::Press => "key",
+            Action::AssertText | Action::AssertValue => "text",
+            _ => return None,
+        };
+        args.get(key).and_then(Value::as_str).map(ToOwned::to_owned)
+    }
+
+    fn locator_for(&self, req: &Request) -> Vec<String> {
+        let Some(args) = req.tool_args() else {
+            return Vec::new();
+        };
+        // Prefer candidates derived from the current a11y snapshot. A recorded
+        // ref is diagnostic-only; it is resolved here while it is still valid.
+        if let Some(reference) = args.get("ref").and_then(Value::as_str) {
+            let candidates = candidates_for_ref(reference, &self.snapshot);
+            if !candidates.is_empty() {
+                return candidates;
+            }
+        }
+        // A human-readable MCP element description is a conservative fallback
+        // when no snapshot has been observed yet.
+        args.get("element")
+            .or_else(|| args.get("description"))
+            .or_else(|| args.get("name"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| vec![format!("text:{s}")])
+            .unwrap_or_default()
+    }
+
+    fn cache_snapshot_response(&mut self, req: &Request, resp: &Value) {
+        if req.tool_name() != Some("browser_snapshot") || resp.get("error").is_some() {
+            return;
+        }
+        let Some(content) = resp
+            .get("result")
+            .and_then(|result| result.get("content"))
+            .and_then(Value::as_array)
+        else {
+            return;
+        };
+        let text = content
+            .iter()
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !text.is_empty() {
+            self.snapshot = parse_snapshot(&text);
+        }
+    }
+
+    fn record_success(&mut self, req: &Request) -> std::result::Result<(), Reject> {
+        let Some(action) = Self::action_for(req) else {
+            return Ok(());
+        };
+        let fallback = match action {
+            Action::Goto => "前往指定網址",
+            Action::Click => "點擊目標元素",
+            Action::Fill => "輸入欄位內容",
+            Action::Select => "選取下拉選項",
+            Action::Press => "按下鍵盤按鍵",
+            Action::Hover => "滑過目標元素",
+            Action::AssertVisible => "確認目標元素可見",
+            Action::AssertText => "確認目標文字",
+            Action::AssertValue => "確認欄位值",
+        };
+        let (intent, intent_auto) = self.intent_for_next_step(fallback);
+        let args = req.tool_args();
+        let mut step = Step {
+            step: self.run.steps.len() as u32 + 1,
+            intent,
+            intent_auto,
+            action,
+            value: Self::value_for(action, args),
+            locators: self.locator_for(req),
+            healed: false,
+            last_hit: 0,
+            ref_at_record: args
+                .and_then(|a| a.get("ref"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+        };
+        // Navigation does not need a locator; for all other actions the
+        // current slice refuses raw `@ref` calls until a stable locator was
+        // supplied. Slice 3 replaces this with generated candidates.
+        step = validate(step, false)?;
+        self.run.steps.push(step);
+        // Persistence errors are represented as an invalid action response;
+        // losing the recording silently would be worse.
+        self.persist().map_err(|_| Reject::NoLocator)
+    }
+}
+
+impl Hook for RecordHook {
+    async fn on_request(&mut self, req: Request, _down: &Downstream) -> Decision {
+        match req.tool_name() {
+            Some("mur_intent") => {
+                let text = req
+                    .tool_args()
+                    .and_then(|a| a.get("text"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if text.chars().count() < 4 {
+                    return Decision::Reject {
+                        code: -32602,
+                        message: "intent too short (need ≥ 4 chars)".into(),
+                    };
+                }
+                self.pending_intent = Some(text.to_string());
+                Decision::Reply(serde_json::json!({"queued": true}))
+            }
+            Some("browser_storage_state") | Some("browser_set_storage_state") => Decision::Reject {
+                code: -32000,
+                message: "use mur browser auth".into(),
+            },
+            Some("browser_start_recording") | Some("browser_stop_recording") => Decision::Reject {
+                code: -32000,
+                message: "Playwright recording is disabled; MUR records actions safely".into(),
+            },
+            _ => Decision::Forward(req),
+        }
+    }
+
+    async fn on_response(&mut self, req: &Request, resp: Value, _down: &Downstream) -> Value {
+        // MCP tool failures are encoded as a successful JSON-RPC response with
+        // `result.isError: true`. Recording one would make a run claim that an
+        // action succeeded when Playwright rejected it.
+        if resp.get("error").is_some()
+            || resp
+                .get("result")
+                .and_then(|result| result.get("isError"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        {
+            return resp;
+        }
+        self.cache_snapshot_response(req, &resp);
+        if Self::action_for(req).is_none() {
+            return resp;
+        }
+        if let Err(error) = self.record_success(req) {
+            let id = resp.get("id").cloned().unwrap_or(Value::Null);
+            return serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": -32000, "message": error.to_string()}
+            });
+        }
+        resp
+    }
+
+    fn extra_tools(&self) -> Vec<Value> {
+        vec![serde_json::json!({
+            "name": "mur_intent",
+            "description": "Set the human intent for the next recorded browser action.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"text": {"type": "string", "minLength": 4}},
+                "required": ["text"]
+            }
+        })]
+    }
+}
+
+impl std::fmt::Display for Reject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Reject::NoLocator => "step has no stable locator; call browser_snapshot then retry",
+            Reject::IntentTooShort => {
+                "intent too short (need ≥ 4 chars): call mur_intent before the action"
+            }
+            Reject::RawSecret => {
+                "value looks like a raw secret in a password field; use mur_secret to get a {{secret:…}} placeholder"
+            }
+        };
+        f.write_str(s)
+    }
+}
+impl std::error::Error for Reject {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step(action: Action, locators: &[&str]) -> Step {
+        Step {
+            step: 1,
+            intent: "在搜尋框輸入 AirPods Pro".into(),
+            intent_auto: false,
+            action,
+            value: Some("AirPods Pro".into()),
+            locators: locators.iter().map(|s| s.to_string()).collect(),
+            healed: false,
+            last_hit: 0,
+            ref_at_record: Some("@e21".into()),
+        }
+    }
+
+    #[test]
+    fn reject_when_no_locator() {
+        let s = step(Action::Click, &[]);
+        assert_eq!(validate(s, false).unwrap_err(), Reject::NoLocator);
+    }
+
+    #[test]
+    fn reject_when_only_unstable_locators() {
+        // the `agent-browser去pchome` yaml:59 case — nothing but an @ref-ish css chain
+        let s = step(Action::Click, &["css:div > div > ul > li:nth-child(3) > a"]);
+        assert_eq!(validate(s, false).unwrap_err(), Reject::NoLocator);
+    }
+
+    #[test]
+    fn prunes_unstable_keeps_stable() {
+        let s = step(
+            Action::Click,
+            &[
+                "css:.css-1x2y3z",
+                "role:button[name=\"登入\"]",
+                "testid:login",
+            ],
+        );
+        let s = validate(s, false).unwrap();
+        assert_eq!(
+            s.locators,
+            vec!["role:button[name=\"登入\"]", "testid:login"]
+        );
+    }
+
+    #[test]
+    fn reject_short_intent() {
+        let mut s = step(Action::Click, &["testid:x"]);
+        s.intent = "點".into();
+        assert_eq!(validate(s, false).unwrap_err(), Reject::IntentTooShort);
+    }
+
+    #[test]
+    fn reject_raw_secret_in_password_field() {
+        let mut s = step(Action::Fill, &["role:textbox[name=\"密碼\"]"]);
+        s.value = Some("Hunter2Hunter2x9".into());
+        assert_eq!(validate(s.clone(), true).unwrap_err(), Reject::RawSecret);
+        // same value in a non-password field is fine
+        assert!(validate(s.clone(), false).is_ok());
+        // placeholder is fine even in a password field
+        s.value = Some("{{secret:pchome/PASSWORD}}".into());
+        assert!(validate(s, true).is_ok());
+    }
+
+    #[test]
+    fn goto_needs_no_locator() {
+        let mut s = step(Action::Goto, &[]);
+        s.value = Some("https://24h.pchome.com.tw".into());
+        assert!(validate(s, false).is_ok());
+    }
+
+    #[test]
+    fn yaml_round_trip_matches_spec_shape() {
+        let run = Run {
+            name: "smoke".into(),
+            mode: Mode::Test,
+            profile: Some("pchome".into()),
+            recorded_at: chrono::DateTime::parse_from_rfc3339("2026-09-10T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            steps: vec![step(
+                Action::Fill,
+                &["role:searchbox[name=\"搜尋\"]", "testid:search-input"],
+            )],
+        };
+        let y = to_yaml(&run).unwrap();
+        assert!(y.contains("intent: 在搜尋框輸入 AirPods Pro"), "{y}");
+        assert!(y.contains("action: fill"), "{y}");
+        assert!(y.contains("- role:searchbox[name=\"搜尋\"]"), "{y}");
+        assert!(!y.contains("healed"), "false flags are omitted: {y}");
+        assert_eq!(from_yaml(&y).unwrap(), run);
+    }
+
+    #[test]
+    fn schema_exports() {
+        let s = json_schema();
+        assert!(s["title"].as_str().is_some() || s["$schema"].as_str().is_some());
+    }
+
+    #[test]
+    fn record_hook_persists_successful_navigation_as_first_step() {
+        // Public seam for slice 2: the proxy hook, not recorder internals.
+        // This deliberately fails until `RecordHook` exists and owns the run.
+        let hook = RecordHook::new(Run {
+            name: "smoke".into(),
+            mode: Mode::Test,
+            profile: None,
+            recorded_at: chrono::Utc::now(),
+            steps: vec![],
+        });
+        assert!(hook.run().steps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn proxy_does_not_record_mcp_tool_failures() {
+        // Exercise the public proxy seam: MCP reports tool failures inside a
+        // JSON-RPC `result` with `isError`, rather than a JSON-RPC error.
+        use crate::proxy::run_io;
+        use serde_json::json;
+        use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, duplex};
+
+        async fn server(mut input: impl AsyncRead + Unpin, mut output: impl AsyncWrite + Unpin) {
+            let mut lines = BufReader::new(&mut input).lines();
+            while let Some(line) = lines.next_line().await.unwrap() {
+                let request: Value = serde_json::from_str(&line).unwrap();
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": request["id"].clone(),
+                    "result": {
+                        "isError": true,
+                        "content": [{"type": "text", "text": "button not found"}]
+                    }
+                });
+                output
+                    .write_all(response.to_string().as_bytes())
+                    .await
+                    .unwrap();
+                output.write_all(b"\n").await.unwrap();
+                output.flush().await.unwrap();
+            }
+        }
+
+        let dir =
+            std::env::temp_dir().join(format!("mur-browser-failed-action-{}", std::process::id()));
+        let actions = dir.join("actions.yaml");
+        let hook = RecordHook::with_actions_path(
+            Run {
+                name: "failed-click".into(),
+                mode: Mode::Test,
+                profile: None,
+                recorded_at: chrono::Utc::now(),
+                steps: vec![],
+            },
+            actions.clone(),
+        );
+        let (mut agent_write, agent_input) = duplex(16 * 1024);
+        let (agent_output, mut agent_read) = duplex(16 * 1024);
+        let (server_input, server_read) = duplex(16 * 1024);
+        let (server_write, server_output) = duplex(16 * 1024);
+        tokio::spawn(server(server_read, server_write));
+        tokio::spawn(run_io(
+            agent_input,
+            agent_output,
+            server_input,
+            server_output,
+            hook,
+        ));
+
+        agent_write.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"browser_click\",\"arguments\":{\"element\":\"missing button\"}}}\n").await.unwrap();
+        let mut lines = BufReader::new(&mut agent_read).lines();
+        let response: Value =
+            serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+        assert_eq!(response["result"]["isError"], true);
+        assert!(!actions.exists(), "failed MCP calls must not be recorded");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proxy_records_intent_and_successful_navigation_to_yaml() {
+        use crate::proxy::run_io;
+        use serde_json::json;
+        use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, duplex};
+
+        async fn server(mut input: impl AsyncRead + Unpin, mut output: impl AsyncWrite + Unpin) {
+            let mut lines = BufReader::new(&mut input).lines();
+            while let Some(line) = lines.next_line().await.unwrap() {
+                let request: Value = serde_json::from_str(&line).unwrap();
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": request["id"].clone(),
+                    "result": {"content": [{"type": "text", "text": "ok"}]}
+                });
+                output
+                    .write_all(response.to_string().as_bytes())
+                    .await
+                    .unwrap();
+                output.write_all(b"\n").await.unwrap();
+                output.flush().await.unwrap();
+            }
+        }
+
+        let suffix = format!("mur-browser-record-{}", std::process::id());
+        let dir = std::env::temp_dir().join(suffix);
+        let actions = dir.join("actions.yaml");
+        let hook = RecordHook::with_actions_path(
+            Run {
+                name: "smoke".into(),
+                mode: Mode::Test,
+                profile: None,
+                recorded_at: chrono::Utc::now(),
+                steps: vec![],
+            },
+            actions.clone(),
+        );
+        let (mut agent_write, agent_input) = duplex(16 * 1024);
+        let (agent_output, mut agent_read) = duplex(16 * 1024);
+        let (server_input, server_read) = duplex(16 * 1024);
+        let (server_write, server_output) = duplex(16 * 1024);
+        tokio::spawn(server(server_read, server_write));
+        tokio::spawn(run_io(
+            agent_input,
+            agent_output,
+            server_input,
+            server_output,
+            hook,
+        ));
+
+        agent_write.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"mur_intent\",\"arguments\":{\"text\":\"Open the MUR homepage\"}}}\n").await.unwrap();
+        let mut lines = BufReader::new(&mut agent_read).lines();
+        let intent_reply: Value =
+            serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+        assert_eq!(intent_reply["result"]["queued"], true);
+
+        agent_write.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"browser_navigate\",\"arguments\":{\"url\":\"https://example.test\"}}}\n").await.unwrap();
+        let navigation_reply: Value =
+            serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+        assert_eq!(navigation_reply["id"], 2);
+
+        let saved = from_yaml(&std::fs::read_to_string(&actions).unwrap()).unwrap();
+        assert_eq!(saved.steps.len(), 1);
+        assert_eq!(saved.steps[0].intent, "Open the MUR homepage");
+        assert!(!saved.steps[0].intent_auto);
+        assert_eq!(saved.steps[0].action, Action::Goto);
+        assert_eq!(
+            saved.steps[0].value.as_deref(),
+            Some("https://example.test")
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn proxy_snapshot_then_click_records_stable_locator_candidates() {
+        use crate::proxy::run_io;
+        use serde_json::json;
+        use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, duplex};
+
+        async fn server(mut input: impl AsyncRead + Unpin, mut output: impl AsyncWrite + Unpin) {
+            let mut lines = BufReader::new(&mut input).lines();
+            while let Some(line) = lines.next_line().await.unwrap() {
+                let request: Value = serde_json::from_str(&line).unwrap();
+                let text = match request["params"]["name"].as_str() {
+                    Some("browser_snapshot") => {
+                        "- button \"Submit\" [ref=e4] [data-testid=submit-button]"
+                    }
+                    _ => "ok",
+                };
+                let response = json!({
+                    "jsonrpc": "2.0",
+                    "id": request["id"].clone(),
+                    "result": {"content": [{"type": "text", "text": text}]}
+                });
+                output
+                    .write_all(response.to_string().as_bytes())
+                    .await
+                    .unwrap();
+                output.write_all(b"\n").await.unwrap();
+                output.flush().await.unwrap();
+            }
+        }
+
+        let dir =
+            std::env::temp_dir().join(format!("mur-browser-snapshot-click-{}", std::process::id()));
+        let actions = dir.join("actions.yaml");
+        let hook = RecordHook::with_actions_path(
+            Run {
+                name: "snapshot-click".into(),
+                mode: Mode::Test,
+                profile: None,
+                recorded_at: chrono::Utc::now(),
+                steps: vec![],
+            },
+            actions.clone(),
+        );
+        let (mut agent_write, agent_input) = duplex(16 * 1024);
+        let (agent_output, mut agent_read) = duplex(16 * 1024);
+        let (server_input, server_read) = duplex(16 * 1024);
+        let (server_write, server_output) = duplex(16 * 1024);
+        tokio::spawn(server(server_read, server_write));
+        tokio::spawn(run_io(
+            agent_input,
+            agent_output,
+            server_input,
+            server_output,
+            hook,
+        ));
+        let mut lines = BufReader::new(&mut agent_read).lines();
+
+        for request in [
+            json!({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"browser_snapshot","arguments":{}}}),
+            json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"browser_click","arguments":{"ref":"@e4"}}}),
+        ] {
+            agent_write
+                .write_all(request.to_string().as_bytes())
+                .await
+                .unwrap();
+            agent_write.write_all(b"\n").await.unwrap();
+            let reply: Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            assert!(reply.get("error").is_none(), "{reply}");
+        }
+
+        let saved = from_yaml(&std::fs::read_to_string(&actions).unwrap()).unwrap();
+        assert_eq!(saved.steps.len(), 1);
+        assert_eq!(saved.steps[0].action, Action::Click);
+        assert_eq!(saved.steps[0].ref_at_record.as_deref(), Some("@e4"));
+        assert_eq!(
+            saved.steps[0].locators,
+            vec![
+                "role:button[name=\"Submit\"]".to_string(),
+                "testid:submit-button".to_string(),
+                "text:Submit".to_string(),
+            ]
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/mur-browser/src/state.rs
+++ b/mur-browser/src/state.rs
@@ -1,0 +1,142 @@
+//! Encrypted Playwright storage-state files for browser profiles.
+//!
+//! The age identity is kept in the OS Keychain, never beside the encrypted
+//! state.  The on-disk `state.json.age` file is always mode 0600.
+
+use age::secrecy::ExposeSecret;
+use anyhow::{Context, Result, bail};
+use std::{
+    io::{Cursor, Read, Write},
+    path::Path,
+};
+
+use crate::broker::KEYCHAIN_SERVICE;
+
+/// Keychain account holding the age X25519 identity for all browser profiles.
+pub const STATE_KEY_ACCOUNT: &str = "browser/state-key";
+
+/// Narrow seam for tests; production uses [`KeychainStateKeyStore`].
+pub trait StateKeyStore {
+    fn get(&self, account: &str) -> Result<Option<String>>;
+    fn set(&self, account: &str, value: &str) -> Result<()>;
+}
+
+/// OS-native storage for the browser state encryption identity.
+pub struct KeychainStateKeyStore;
+
+impl StateKeyStore for KeychainStateKeyStore {
+    fn get(&self, account: &str) -> Result<Option<String>> {
+        let entry = keyring::Entry::new(KEYCHAIN_SERVICE, account)
+            .with_context(|| format!("open Keychain entry {KEYCHAIN_SERVICE}:{account}"))?;
+        match entry.get_password() {
+            Ok(value) if !value.is_empty() => Ok(Some(value)),
+            Ok(_) => bail!("Keychain entry {KEYCHAIN_SERVICE}:{account} is empty"),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error)
+                .with_context(|| format!("read Keychain entry {KEYCHAIN_SERVICE}:{account}")),
+        }
+    }
+
+    fn set(&self, account: &str, value: &str) -> Result<()> {
+        keyring::Entry::new(KEYCHAIN_SERVICE, account)?
+            .set_password(value)
+            .with_context(|| format!("write Keychain entry {KEYCHAIN_SERVICE}:{account}"))
+    }
+}
+
+fn identity(store: &impl StateKeyStore) -> Result<age::x25519::Identity> {
+    let encoded = match store.get(STATE_KEY_ACCOUNT)? {
+        Some(value) => value,
+        None => {
+            let created = age::x25519::Identity::generate();
+            let encoded = created.to_string();
+            store.set(STATE_KEY_ACCOUNT, encoded.expose_secret())?;
+            return Ok(created);
+        }
+    };
+    encoded.trim().parse().map_err(|error: &str| {
+        anyhow::anyhow!("parse Keychain entry {KEYCHAIN_SERVICE}:{STATE_KEY_ACCOUNT}: {error}")
+    })
+}
+
+/// Encrypt a Playwright `storageState` JSON document and atomically replace
+/// `path`. The caller must pass only transient plaintext; this function never
+/// writes that plaintext to disk.
+pub fn write_state(path: &Path, plaintext: &[u8], store: &impl StateKeyStore) -> Result<()> {
+    let identity = identity(store)?;
+    let recipient = identity.to_public();
+    let encryptor =
+        age::Encryptor::with_recipients(std::iter::once(&recipient as &dyn age::Recipient))?;
+    let mut encrypted = Vec::new();
+    {
+        let mut writer = encryptor.wrap_output(&mut encrypted)?;
+        writer.write_all(plaintext)?;
+        writer.finish()?;
+    }
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("state path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let temp = parent.join(format!(".state-{}.tmp", uuid::Uuid::new_v4().simple()));
+    std::fs::write(&temp, encrypted)?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&temp, std::os::unix::fs::PermissionsExt::from_mode(0o600))?;
+    std::fs::rename(&temp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&temp);
+    })?;
+    Ok(())
+}
+
+/// Decrypt a profile state document wholly in memory.
+pub fn read_state(path: &Path, store: &impl StateKeyStore) -> Result<Vec<u8>> {
+    let identity = identity(store)?;
+    let encrypted = std::fs::read(path)
+        .with_context(|| format!("read encrypted browser state {}", path.display()))?;
+    let decryptor = age::Decryptor::new(Cursor::new(encrypted))?;
+    let mut reader = decryptor.decrypt(std::iter::once(&identity as &dyn age::Identity))?;
+    let mut plaintext = Vec::new();
+    reader.read_to_end(&mut plaintext)?;
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashMap, sync::Mutex};
+
+    #[derive(Default)]
+    struct MemoryStore(Mutex<HashMap<String, String>>);
+    impl StateKeyStore for MemoryStore {
+        fn get(&self, account: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(account).cloned())
+        }
+        fn set(&self, account: &str, value: &str) -> Result<()> {
+            self.0.lock().unwrap().insert(account.into(), value.into());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn state_round_trip_never_contains_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("profile/state.json.age");
+        let store = MemoryStore::default();
+        let plain = br#"{\"cookies\":[{\"value\":\"secret-cookie\"}]}"#;
+        write_state(&path, plain, &store).unwrap();
+        let ciphertext = std::fs::read(&path).unwrap();
+        assert!(
+            !ciphertext
+                .windows(b"secret-cookie".len())
+                .any(|window| window == b"secret-cookie")
+        );
+        assert_eq!(read_state(&path, &store).unwrap(), plain);
+        #[cfg(unix)]
+        assert_eq!(
+            std::os::unix::fs::PermissionsExt::mode(
+                &std::fs::metadata(path).unwrap().permissions()
+            ) & 0o777,
+            0o600
+        );
+    }
+}

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -24,6 +24,7 @@ mur-compress = { path = "../mur-compress" }
 mur-agent-runtime = { path = "../mur-agent-runtime" }  # for cmd::agent::cmd_export
 mur-channel = { path = "../mur-channel" }
 mur-open-items = { path = "../mur-open-items" }
+mur-browser = { path = "../mur-browser" }
 tar = "0.4"           # cmd::agent_export_gui template-mode identity stripping
 flate2 = "1"          # gzip wrapper for the same
 multibase = "0.9"     # encode/decode signing data in fleet export
@@ -94,6 +95,7 @@ dotenvy = "0.15"
 getrandom = "0.2"
 shellexpand = "3"
 urlencoding = "2"
+url = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sysinfo = "0.30"
 pulldown-cmark = "0.12"

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -1,6 +1,7 @@
 //! Subcommand action enums (non-agent). Extracted from `main.rs` to keep the
 //! binary entry point lean. Pure clap derive types — no logic lives here.
 
+use crate::cmd::browser::BrowserEngine;
 use clap::Subcommand;
 
 #[derive(Subcommand)]
@@ -740,6 +741,52 @@ pub enum CapabilityAction {
         #[arg(long)]
         agent: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum BrowserAction {
+    /// Start an MCP proxy that records browser actions into a named run.
+    Record {
+        #[arg(long)]
+        run: String,
+        #[arg(long)]
+        profile: Option<String>,
+        #[arg(long, default_value = "test")]
+        mode: String,
+        #[arg(long)]
+        trace: bool,
+        /// Extra arguments passed verbatim to @playwright/mcp.
+        #[arg(last = true, allow_hyphen_values = true)]
+        extra: Vec<String>,
+    },
+    /// Replay a recorded browser run (implemented in a later slice).
+    Replay { name: String },
+    /// Authenticate a named browser profile (handoff implementation follows).
+    Auth {
+        /// Profile name; used as a path component under browser/profiles.
+        site: String,
+        /// Login page to open in a headed Playwright session.
+        #[arg(long)]
+        url: String,
+        /// Replace an existing profile state after a fresh login.
+        #[arg(long)]
+        reauth: bool,
+        /// Browser engine to use (Chrome, Chromium, Firefox, or Edge).
+        /// Without this flag, MUR detects installed engines and asks when
+        /// more than one is available.
+        #[arg(long, value_enum)]
+        browser: Option<BrowserEngine>,
+    },
+    /// Run the secret broker (implemented in a later slice).
+    Broker,
+    /// List recorded runs (implemented in a later slice).
+    List,
+    /// Show one recorded run (implemented in a later slice).
+    Show { name: String },
+    /// Export a recorded run (implemented in a later slice).
+    Export { name: String },
+    /// Show browser subsystem status (implemented in a later slice).
+    Status,
 }
 
 #[derive(clap::Subcommand)]

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -453,6 +453,11 @@ see `mur skill <command> --help`.")]
         #[command(subcommand)]
         action: CommanderAction,
     },
+    /// Record and replay browser work through Playwright MCP.
+    Browser {
+        #[command(subcommand)]
+        action: BrowserAction,
+    },
     /// MUR-native deep research (wizard: `setup`; status: bare; run: pass a question)
     #[command(args_conflicts_with_subcommands = true)]
     DeepResearch {

--- a/mur-core/src/cmd/browser/mod.rs
+++ b/mur-core/src/cmd/browser/mod.rs
@@ -1,13 +1,18 @@
 //! `mur browser` command handlers. Heavy implementation lives in `mur-browser`.
 
-use std::{fs, os::unix::fs::FileTypeExt, path::PathBuf, sync::Arc, time::Duration};
+use std::{fs, path::PathBuf};
+#[cfg(unix)]
+use std::{os::unix::fs::FileTypeExt, sync::Arc, time::Duration};
 
 use anyhow::{Result, bail};
 #[cfg(test)]
 use mur_browser::auth::write_meta;
+#[cfg(unix)]
+use mur_browser::broker::SocketClient;
+#[cfg(unix)]
+use mur_browser::broker::{Broker, KeychainStore};
 use mur_browser::{
     auth::{Handoff, ProfileMeta, save_profile},
-    broker::{Broker, KeychainStore, SocketClient},
     paths,
     proxy::{BrokerHook, capture_storage_state, playwright_command, run_stdio},
     recorder::{Mode, RecordHook, Run},
@@ -19,6 +24,7 @@ use mur_browser::{
 /// Slice 1 deliberately validates only CLI-level inputs then forwards every
 /// JSON-RPC line unchanged. Recorder, broker, and replay hooks replace the
 /// `ForwardHook` in later slices without changing this MCP launch contract.
+#[cfg(unix)]
 pub async fn record(
     run: &str,
     profile: Option<&str>,
@@ -76,6 +82,17 @@ pub async fn record(
     result
 }
 
+#[cfg(not(unix))]
+pub async fn record(
+    _run: &str,
+    _profile: Option<&str>,
+    _mode: &str,
+    _trace: bool,
+    _extra: &[String],
+) -> Result<()> {
+    bail!("browser recording requires Unix domain sockets and is unavailable on this platform")
+}
+
 fn mur_home() -> Result<std::path::PathBuf> {
     std::env::var_os("MUR_HOME")
         .map(std::path::PathBuf::from)
@@ -87,6 +104,7 @@ fn fresh_broker_token() -> String {
     uuid::Uuid::new_v4().simple().to_string()
 }
 
+#[cfg(unix)]
 fn remove_stale_broker_socket(socket: &std::path::Path) -> Result<()> {
     match std::fs::symlink_metadata(socket) {
         Ok(meta) if meta.file_type().is_socket() => {
@@ -101,6 +119,7 @@ fn remove_stale_broker_socket(socket: &std::path::Path) -> Result<()> {
     }
 }
 
+#[cfg(unix)]
 async fn wait_for_socket(socket: &std::path::Path) -> Result<()> {
     for _ in 0..30 {
         if socket.exists() {
@@ -113,6 +132,7 @@ async fn wait_for_socket(socket: &std::path::Path) -> Result<()> {
 
 /// Serve the private secret-broker socket. The token must arrive through the
 /// environment rather than argv, so shells and process listings never expose it.
+#[cfg(unix)]
 pub async fn broker() -> Result<()> {
     let token = std::env::var(mur_browser::broker::TOKEN_ENV)
         .map_err(|_| anyhow::anyhow!("{} is required", mur_browser::broker::TOKEN_ENV))?;
@@ -130,6 +150,11 @@ pub async fn broker() -> Result<()> {
         .await;
     let _ = std::fs::remove_file(socket);
     result
+}
+
+#[cfg(not(unix))]
+pub async fn broker() -> Result<()> {
+    bail!("browser secret broker requires Unix domain sockets and is unavailable on this platform")
 }
 
 /// List recorded runs under `~/.mur/browser/runs/`.
@@ -339,6 +364,7 @@ pub struct InstalledBrowser {
     executable: &'static str,
 }
 
+#[cfg(target_os = "macos")]
 const MACOS_BROWSERS: &[InstalledBrowser] = &[
     InstalledBrowser {
         engine: BrowserEngine::Chrome,

--- a/mur-core/src/cmd/browser/mod.rs
+++ b/mur-core/src/cmd/browser/mod.rs
@@ -1,0 +1,499 @@
+//! `mur browser` command handlers. Heavy implementation lives in `mur-browser`.
+
+use std::{fs, os::unix::fs::FileTypeExt, path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{Result, bail};
+#[cfg(test)]
+use mur_browser::auth::write_meta;
+use mur_browser::{
+    auth::{Handoff, ProfileMeta, save_profile},
+    broker::{Broker, KeychainStore, SocketClient},
+    paths,
+    proxy::{BrokerHook, capture_storage_state, playwright_command, run_stdio},
+    recorder::{Mode, RecordHook, Run},
+    state::KeychainStateKeyStore,
+};
+
+/// Start the transparent Playwright MCP proxy for one recording session.
+///
+/// Slice 1 deliberately validates only CLI-level inputs then forwards every
+/// JSON-RPC line unchanged. Recorder, broker, and replay hooks replace the
+/// `ForwardHook` in later slices without changing this MCP launch contract.
+pub async fn record(
+    run: &str,
+    profile: Option<&str>,
+    mode: &str,
+    trace: bool,
+    extra: &[String],
+) -> Result<()> {
+    mur_browser::paths::validate_name(run)?;
+    if let Some(profile) = profile {
+        mur_browser::paths::validate_name(profile)?;
+    }
+    if !matches!(mode, "test" | "automation") {
+        bail!("mode must be test|automation, got {mode:?}");
+    }
+
+    let mut args = extra.to_vec();
+    // These flags are intentionally merely forwarded. `@playwright/mcp`
+    // owns their validation, keeping this proxy compatible with new releases.
+    if trace {
+        args.push("--save-trace".into());
+    }
+    let run_state = Run {
+        name: run.to_string(),
+        mode: mode.parse::<Mode>()?,
+        profile: profile.map(ToOwned::to_owned),
+        recorded_at: chrono::Utc::now(),
+        steps: Vec::new(),
+    };
+    let mur_home = mur_home()?;
+    let socket = paths::broker_socket(&mur_home);
+    remove_stale_broker_socket(&socket)?;
+    let token = fresh_broker_token();
+    let broker = Arc::new(Broker::new(token.clone(), Arc::new(KeychainStore)));
+    let socket_for_task = socket.clone();
+    let broker_task = tokio::spawn(async move { broker.serve(&socket_for_task).await });
+
+    // Wait until the 0600 socket exists before the proxy can make a secret
+    // call. A short bounded wait turns startup races into a clear error.
+    if let Err(error) = wait_for_socket(&socket).await {
+        broker_task.abort();
+        let _ = std::fs::remove_file(&socket);
+        return Err(error);
+    }
+
+    let hook = BrokerHook::new(
+        RecordHook::with_actions_path(run_state, paths::run_actions(&mur_home, run)),
+        Arc::new(SocketClient::new(&socket, token)),
+    );
+    let result = run_stdio(playwright_command(&args), hook).await;
+    // The child has ended; kill the broker and unlink its private endpoint
+    // even when Playwright exited with an error.
+    broker_task.abort();
+    let _ = broker_task.await;
+    let _ = std::fs::remove_file(&socket);
+    result
+}
+
+fn mur_home() -> Result<std::path::PathBuf> {
+    std::env::var_os("MUR_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".mur")))
+        .ok_or_else(|| anyhow::anyhow!("cannot determine MUR home (set MUR_HOME)"))
+}
+
+fn fresh_broker_token() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+fn remove_stale_broker_socket(socket: &std::path::Path) -> Result<()> {
+    match std::fs::symlink_metadata(socket) {
+        Ok(meta) if meta.file_type().is_socket() => {
+            std::fs::remove_file(socket).map_err(Into::into)
+        }
+        Ok(_) => bail!(
+            "refusing to replace non-socket broker path: {}",
+            socket.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn wait_for_socket(socket: &std::path::Path) -> Result<()> {
+    for _ in 0..30 {
+        if socket.exists() {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    bail!("secret broker did not create socket: {}", socket.display())
+}
+
+/// Serve the private secret-broker socket. The token must arrive through the
+/// environment rather than argv, so shells and process listings never expose it.
+pub async fn broker() -> Result<()> {
+    let token = std::env::var(mur_browser::broker::TOKEN_ENV)
+        .map_err(|_| anyhow::anyhow!("{} is required", mur_browser::broker::TOKEN_ENV))?;
+    if token.len() < 32 {
+        bail!(
+            "{} must be an unguessable capability token",
+            mur_browser::broker::TOKEN_ENV
+        );
+    }
+    let mur_home = mur_home()?;
+    let socket = paths::broker_socket(&mur_home);
+    remove_stale_broker_socket(&socket)?;
+    let result = Arc::new(Broker::new(token, Arc::new(KeychainStore)))
+        .serve(&socket)
+        .await;
+    let _ = std::fs::remove_file(socket);
+    result
+}
+
+/// List recorded runs under `~/.mur/browser/runs/`.
+pub fn list() -> Result<()> {
+    let runs = runs_dir()?;
+    if !runs.exists() {
+        return Ok(());
+    }
+    let mut names = fs::read_dir(&runs)?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_type().ok()?.is_dir().then(|| entry.file_name()))
+        .filter_map(|name| name.into_string().ok())
+        .filter(|name| paths::validate_name(name).is_ok())
+        .collect::<Vec<_>>();
+    names.sort();
+    for name in names {
+        println!("{name}");
+    }
+    Ok(())
+}
+
+/// Print a recorded run exactly as stored.  Parsing first avoids presenting a
+/// malformed file as a valid recording and keeps traversal out of this path.
+pub fn show(name: &str) -> Result<()> {
+    paths::validate_name(name)?;
+    let path = paths::run_actions(&mur_home()?, name);
+    let yaml = fs::read_to_string(&path)
+        .map_err(|error| anyhow::anyhow!("read browser run {}: {error}", path.display()))?;
+    mur_browser::recorder::from_yaml(&yaml)
+        .map_err(|error| anyhow::anyhow!("invalid browser run {}: {error}", path.display()))?;
+    print!("{yaml}");
+    Ok(())
+}
+
+/// Show the locally persisted recording/profile inventory.  No browser is
+/// launched, so this remains safe to call from diagnostics and scripts.
+pub fn status() -> Result<()> {
+    let home = mur_home()?;
+    let mut profiles = profile_statuses(&home)?;
+    let mut runs = directory_names(runs_dir()?)?;
+    profiles.sort();
+    runs.sort();
+    println!(
+        "profiles: {}",
+        if profiles.is_empty() {
+            "(none)".into()
+        } else {
+            profiles.join(", ")
+        }
+    );
+    println!(
+        "runs: {}",
+        if runs.is_empty() {
+            "(none)".into()
+        } else {
+            runs.join(", ")
+        }
+    );
+    Ok(())
+}
+
+fn profile_statuses(home: &std::path::Path) -> Result<Vec<String>> {
+    directory_names(paths::browser_root(home).join("profiles"))?
+        .into_iter()
+        .map(|site| {
+            let state = paths::profile_state(home, &site);
+            let meta_path = paths::profile_meta(home, &site);
+            let label = if !state.is_file() {
+                format!("{site} (incomplete)")
+            } else if !meta_path.is_file() {
+                format!("{site} (metadata missing)")
+            } else {
+                let yaml = fs::read_to_string(&meta_path).map_err(|error| {
+                    anyhow::anyhow!(
+                        "read browser profile metadata {}: {error}",
+                        meta_path.display()
+                    )
+                })?;
+                let meta: ProfileMeta = serde_yaml::from_str(&yaml).map_err(|error| {
+                    anyhow::anyhow!(
+                        "invalid browser profile metadata {}: {error}",
+                        meta_path.display()
+                    )
+                })?;
+                match meta.earliest_cookie_expires {
+                    Some(expiry) => format!("{site} (cookie expires {expiry})"),
+                    None => format!("{site} (authenticated {})", meta.last_auth),
+                }
+            };
+            Ok(label)
+        })
+        .collect()
+}
+
+fn runs_dir() -> Result<PathBuf> {
+    Ok(paths::browser_root(&mur_home()?).join("runs"))
+}
+
+fn directory_names(path: PathBuf) -> Result<Vec<String>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    Ok(fs::read_dir(path)?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_type().ok()?.is_dir().then(|| entry.file_name()))
+        .filter_map(|name| name.into_string().ok())
+        .filter(|name| paths::validate_name(name).is_ok())
+        .collect())
+}
+
+#[test]
+fn profile_statuses_marks_incomplete_profiles_without_reading_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = paths::profile_dir(temp.path(), "example");
+    fs::create_dir_all(&profile).unwrap();
+    assert_eq!(
+        profile_statuses(temp.path()).unwrap(),
+        vec!["example (incomplete)"]
+    );
+}
+
+#[test]
+fn profile_statuses_reports_cookie_expiry_from_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = paths::profile_dir(temp.path(), "example");
+    fs::create_dir_all(&profile).unwrap();
+    fs::write(paths::profile_state(temp.path(), "example"), b"encrypted").unwrap();
+    write_meta(
+        &paths::profile_meta(temp.path(), "example"),
+        &ProfileMeta {
+            url: "https://example.test/login".into(),
+            last_auth: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            earliest_cookie_expires: chrono::DateTime::from_timestamp(1_700_100_000, 0),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        profile_statuses(temp.path()).unwrap(),
+        vec!["example (cookie expires 2023-11-16 02:00:00 UTC)"]
+    );
+}
+
+#[test]
+fn directory_names_ignore_files_invalid_names_and_missing_directories() {
+    let temp = tempfile::tempdir().unwrap();
+    fs::create_dir(temp.path().join("valid-run")).unwrap();
+    fs::create_dir(temp.path().join(".hidden")).unwrap();
+    fs::write(temp.path().join("not-a-run"), "x").unwrap();
+    assert_eq!(
+        directory_names(temp.path().to_path_buf()).unwrap(),
+        vec!["valid-run"]
+    );
+    assert!(
+        directory_names(temp.path().join("missing"))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn browser_detection_finds_apps_on_mounted_volumes() {
+    let temp = tempfile::tempdir().unwrap();
+    let applications = temp.path().join("Applications");
+    let firefox = applications.join("Firefox.app/Contents/MacOS/firefox");
+    fs::create_dir_all(firefox.parent().unwrap()).unwrap();
+    fs::write(&firefox, b"").unwrap();
+
+    let browser = MACOS_BROWSERS
+        .iter()
+        .copied()
+        .find(|browser| browser.engine == BrowserEngine::Firefox)
+        .unwrap();
+    assert!(browser_is_installed(browser, &[applications]));
+}
+
+/// Browser engine that Playwright MCP launches for an authentication handoff.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum BrowserEngine {
+    /// Google Chrome.
+    Chrome,
+    /// Chromium.
+    Chromium,
+    /// Mozilla Firefox.
+    Firefox,
+    /// Microsoft Edge.
+    Msedge,
+}
+
+impl BrowserEngine {
+    pub const fn playwright_name(self) -> &'static str {
+        match self {
+            Self::Chrome => "chrome",
+            Self::Chromium => "chromium",
+            Self::Firefox => "firefox",
+            Self::Msedge => "msedge",
+        }
+    }
+}
+
+/// A locally installed browser engine that Playwright MCP can launch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InstalledBrowser {
+    engine: BrowserEngine,
+    label: &'static str,
+    bundle: &'static str,
+    executable: &'static str,
+}
+
+const MACOS_BROWSERS: &[InstalledBrowser] = &[
+    InstalledBrowser {
+        engine: BrowserEngine::Chrome,
+        label: "Google Chrome",
+        bundle: "Google Chrome.app",
+        executable: "Google Chrome",
+    },
+    InstalledBrowser {
+        engine: BrowserEngine::Chromium,
+        label: "Chromium",
+        bundle: "Chromium.app",
+        executable: "Chromium",
+    },
+    InstalledBrowser {
+        engine: BrowserEngine::Firefox,
+        label: "Firefox",
+        bundle: "Firefox.app",
+        executable: "firefox",
+    },
+    InstalledBrowser {
+        engine: BrowserEngine::Msedge,
+        label: "Microsoft Edge",
+        bundle: "Microsoft Edge.app",
+        executable: "Microsoft Edge",
+    },
+];
+
+#[cfg(target_os = "macos")]
+fn macos_application_directories() -> Vec<PathBuf> {
+    let mut directories = vec![PathBuf::from("/Applications")];
+    if let Some(home) = dirs::home_dir() {
+        directories.push(home.join("Applications"));
+    }
+    if let Ok(volumes) = fs::read_dir("/Volumes") {
+        directories.extend(
+            volumes
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.path().join("Applications")),
+        );
+    }
+    directories
+}
+
+#[cfg(target_os = "macos")]
+fn browser_is_installed(browser: InstalledBrowser, application_directories: &[PathBuf]) -> bool {
+    application_directories.iter().any(|directory| {
+        directory
+            .join(browser.bundle)
+            .join("Contents/MacOS")
+            .join(browser.executable)
+            .is_file()
+    })
+}
+
+fn installed_browsers() -> Vec<InstalledBrowser> {
+    #[cfg(target_os = "macos")]
+    {
+        let application_directories = macos_application_directories();
+        MACOS_BROWSERS
+            .iter()
+            .copied()
+            .filter(|browser| browser_is_installed(*browser, &application_directories))
+            .collect()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Vec::new()
+    }
+}
+
+fn select_browser(requested: Option<BrowserEngine>) -> Result<BrowserEngine> {
+    if let Some(browser) = requested {
+        return Ok(browser);
+    }
+    let installed = installed_browsers();
+    match installed.as_slice() {
+        [] => bail!(
+            "no supported browser found. Install Chrome, Chromium, Firefox, or Microsoft Edge, then retry with --browser <engine>"
+        ),
+        [browser] => {
+            eprintln!("Using detected browser: {}", browser.label);
+            Ok(browser.engine)
+        }
+        choices => {
+            eprintln!("Detected browsers:");
+            for (index, browser) in choices.iter().enumerate() {
+                eprintln!("  {}. {}", index + 1, browser.label);
+            }
+            eprint!("Choose a browser [1-{}]: ", choices.len());
+            use std::io::Write;
+            std::io::stderr().flush()?;
+            let mut answer = String::new();
+            if std::io::stdin().read_line(&mut answer)? == 0 {
+                bail!("browser selection cancelled: stdin closed");
+            }
+            let index = answer
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .and_then(|n| n.checked_sub(1));
+            let browser = index.and_then(|index| choices.get(index)).ok_or_else(|| {
+                anyhow::anyhow!("choose a number between 1 and {}", choices.len())
+            })?;
+            Ok(browser.engine)
+        }
+    }
+}
+
+/// Begin a headed authentication handoff for a browser profile.
+///
+/// The Playwright MCP server stays private to this command: it opens the login
+/// page, the person signs in, then presses Enter. Only the transient storage
+/// state crosses the transport boundary before it is encrypted locally.
+pub async fn auth(
+    site: &str,
+    url: &str,
+    reauth: bool,
+    requested_browser: Option<BrowserEngine>,
+) -> Result<()> {
+    let browser = select_browser(requested_browser)?;
+    paths::validate_name(site)?;
+    let parsed =
+        url::Url::parse(url).map_err(|error| anyhow::anyhow!("invalid --url {url:?}: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        bail!("--url must be an absolute http(s) URL");
+    }
+    let home = mur_home()?;
+    let state = paths::profile_state(&home, site);
+    if state.exists() && !reauth {
+        bail!("browser profile {site:?} already has encrypted state; use --reauth to replace it");
+    }
+
+    let mut handoff = Handoff::new();
+    handoff.start()?;
+    handoff.handoff()?;
+    let storage_state = capture_storage_state(url, browser.playwright_name()).await?;
+    handoff.continue_after_login()?;
+    // Schema validation in `save_profile` is the minimum safe verification:
+    // it proves the capture is Playwright state, without claiming a site-
+    // specific authenticated signal that this generic CLI cannot know.
+    handoff.verified()?;
+    save_profile(
+        &mut handoff,
+        &state,
+        &paths::profile_meta(&home, site),
+        &storage_state,
+        url,
+        chrono::Utc::now(),
+        &KeychainStateKeyStore,
+    )?;
+    println!("saved encrypted browser profile {site:?}");
+    Ok(())
+}
+
+/// Keep Phase 1's advertised CLI truthful until each later slice lands.
+pub fn not_yet(action: &str) -> Result<()> {
+    bail!("mur browser {action} is not implemented yet (see browser Phase 1 slices)")
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -21,6 +21,7 @@ pub mod agent_schedule;
 pub mod agent_voice;
 /// Track C5 / M5.1 — webhook receiver config + CLI verbs.
 pub(crate) mod agent_webhook;
+pub mod browser;
 pub mod capability;
 pub mod channel;
 pub mod commander;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -10,7 +10,7 @@ use crate::cli::{
     AgentAction, AgentAddonAction, AgentEvalAction, AgentHooksAction, AgentMcpAction,
     AgentPendingAction, AgentPermAction, AgentPromptAction, AgentQueueAction, AgentScheduleAction,
     AgentSecretAction, AgentSkillAction, AgentTrashAction, AgentWebhookAction, AuthAction,
-    CapabilityAction, ChannelAction, ChatAction, Cli, CommanderAction, Commands,
+    BrowserAction, CapabilityAction, ChannelAction, ChatAction, Cli, CommanderAction, Commands,
     ConversationsAction, DaemonAction, DeepResearchAction, DeployAction, DraftsAction, EvalAction,
     ExchangeAction, FleetAction, HookEvent, InternalsAction, MurmurdAction, OfficialAction,
     OpenAction, ProjectAction, ScheduleAction, SessionAction, SleepAction, SyncAction, TeamAction,
@@ -513,6 +513,27 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
             }
         }
+        Commands::Browser { action } => match action {
+            BrowserAction::Record {
+                run,
+                profile,
+                mode,
+                trace,
+                extra,
+            } => cmd::browser::record(&run, profile.as_deref(), &mode, trace, &extra).await?,
+            BrowserAction::Replay { .. } => cmd::browser::not_yet("replay")?,
+            BrowserAction::Auth {
+                site,
+                url,
+                reauth,
+                browser,
+            } => cmd::browser::auth(&site, &url, reauth, browser).await?,
+            BrowserAction::Broker => cmd::browser::broker().await?,
+            BrowserAction::List => cmd::browser::list()?,
+            BrowserAction::Show { name } => cmd::browser::show(&name)?,
+            BrowserAction::Export { .. } => cmd::browser::not_yet("export")?,
+            BrowserAction::Status => cmd::browser::status()?,
+        },
         Commands::DeepResearch { action, question } => {
             let mur_home = crate::paths::mur_root(None);
             match (action, question) {


### PR DESCRIPTION
## Summary

- add browser profile authentication backed by Playwright MCP
- export authenticated Playwright storage state through `browser_run_code_unsafe`, encrypt it locally, and restore it for browser runs
- add browser action recording and ignore MCP tool failures so failed actions do not enter recordings

## Verification

- `cargo fmt`
- `cargo clippy -p mur-browser -p mur-core --all-targets -- -D warnings`
- `cargo test -p mur-browser --lib` (35 passed)
- `cargo test -p mur-core --lib cmd::browser::` (4 passed)
- `git diff --check`

Full `mur-core` tests remain blocked by sandbox filesystem/process permissions unrelated to this change.