### PR TITLE
fix(test): serialise the tests sharing PRESEAL_CACHE

### DIFF
--- a/mur-common/src/secret.rs
+++ b/mur-common/src/secret.rs
@@ -950,6 +950,19 @@ mod keychain_helpers_tests {
 
 #[cfg(test)]
 mod resolve_blocking_tests {
+    /// Serialises the tests that touch [`PRESEAL_CACHE`].
+    ///
+    /// That cache is a process-global. `cargo test` runs every test in this
+    /// module in ONE process on a thread pool, so two tests inserting
+    /// concurrently corrupt each other's view of the entry count — the delta
+    /// one test measures includes rows another test just added. `cargo
+    /// nextest` gives each test its own process, which hides the problem
+    /// rather than removing it, and nextest is this repo's canonical runner.
+    ///
+    /// Poison is deliberately ignored: a panic in one guarded test must fail
+    /// that test alone, not cascade into every other one.
+    static PRESEAL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// A secret cached before the seal resolves afterwards even when the path
     /// has become unreachable — which is what a sandboxed agent faces for a
     /// `file:` ref inside the denied credential store (#866).
@@ -958,6 +971,7 @@ mod resolve_blocking_tests {
     /// as far as the process is concerned, exactly as a deny makes it.
     #[test]
     fn a_cached_secret_survives_its_path_becoming_unreachable() {
+        let _preseal_guard = PRESEAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("provider.key");
         std::fs::write(&path, "sk-test-value").unwrap();
@@ -1005,6 +1019,7 @@ mod resolve_blocking_tests {
     /// `secret:` of its own still broke on every upgrade.
     #[test]
     fn preseal_cached_lookup_does_not_touch_the_backend() {
+        let _preseal_guard = PRESEAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let r = SecretRef::Keychain {
             service: "mur-agent-test-nonexistent".into(),
             account: "no-such-agent/NO_SUCH_KEY".into(),
@@ -1033,6 +1048,7 @@ mod resolve_blocking_tests {
     /// Caching is idempotent and does not grow on repeat calls.
     #[test]
     fn caching_the_same_ref_twice_stores_one_entry() {
+        let _preseal_guard = PRESEAL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dup.key");
         std::fs::write(&path, "v").unwrap();


### PR DESCRIPTION
One-file change, test code only (+16 lines).

## The failure

```
$ cargo test -p mur-common --lib
test result: FAILED. 880 passed; 1 failed

---- secret::resolve_blocking_tests::caching_the_same_ref_twice_stores_one_entry ----
assertion `left == right` failed
  left: 2
 right: 1

$ cargo nextest run -p mur-common --lib
881 tests run: 881 passed

$ cargo test -p mur-common --lib -- --test-threads=1
test result: ok. 881 passed
```

Parallel red, single-threaded green, process-isolated green — a shared-state
race between tests in one process.

## Cause

`PRESEAL_CACHE` (`mur-common/src/secret.rs:64`) is a process-global
`OnceLock<Mutex<Vec<..>>>`. Three tests call `cache_before_seal`. `cargo test`
runs them on a thread pool in one process; `cargo nextest` gives each its own
process, so it never sees the collision.

The assertion was already a delta (`before + 1`), so "assert the delta instead
of the absolute count" was not available as a fix — that is what it does. A
concurrent test inserting a *different* ref between the two reads inflates the
delta regardless.

## Fix

A module-level `PRESEAL_TEST_LOCK` taken at the top of the three tests that
touch the cache. No production code changes. Poison is ignored on purpose so a
panic in one guarded test fails that test alone instead of cascading.

Rejected: a test-only `preseal_cached_count_for(&r)` accessor (adds production
API to solve a test problem) and injecting the cache (restructures real code
for the same reason).

## Verification

| Check | Result |
|---|---|
| `cargo test -p mur-common --lib` | 881 passed (was 1 failed) |
| `cargo nextest run -p mur-common --lib` | 881 passed |
| `cargo test ... -- --test-threads=1` | 881 passed |
| `cargo clippy -p mur-common --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |

Mutation-checked: removing the dedup in `cache_before_seal` makes the guarded
test FAIL, and it passes again once restored — so the guard did not turn the
test into a no-op.

## Note

nextest is this repo's canonical runner, so this was never gating CI. It is
still a latent order-dependency between tests, and it cost a real debugging
detour when an agent ran plain `cargo test` and reported the failure as a
product bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)