### PR TITLE
chore(release): bump workspace version to 2.77.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.77.4"
+version = "2.77.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6632,8 +6632,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mur-browser"
+version = "2.77.5"
+dependencies = [
+ "age",
+ "anyhow",
+ "chrono",
+ "keyring",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "mur-channel"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6652,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6702,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "blake3",
  "chrono",
@@ -6728,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6766,6 +6783,7 @@ dependencies = [
  "mime_guess",
  "multibase",
  "mur-agent-runtime",
+ "mur-browser",
  "mur-channel",
  "mur-common",
  "mur-compress",
@@ -6809,6 +6827,7 @@ dependencies = [
  "tui-textarea",
  "ulid",
  "unicode-width 0.1.14",
+ "url",
  "urlencoding",
  "uuid",
  "walkdir",
@@ -6817,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6878,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.4"
+version = "2.77.5"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release PR. **Merging this to `main` IS the release** — `tag.yml` tags the
merge commit and dispatches `release.yml` (crates.io publish is irreversible),
so this PR is the release approval; there is no later gate.

Both lock files moved with the version: the root `Cargo.lock` and
`mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every
workspace crate's version and breaks the Hub's release build when it
disagrees. Verified: zero `2.77.4` strings remain in either.

## What ships in 2.77.5

**#1244 — `feat(browser)`: Playwright auth and recording** (+4020/-13)
The substantive feature in this release.

**#1243 — `fix(channel)`: sign state transitions like every other event**
State-transition events were written unsigned, leaving them outside the v3d
signing guarantee.

## Also on main, not user-visible

- **#1249** — test-only: serialises three tests sharing a process-global
  cache. Nothing in the shipped binary changes.
- **#1245, #1246, #1248** — three design specs written from a live
  investigation in which an agent could not run `cargo` and every permission
  surface reported success: unreachable filesystem grants, spawn-denial
  attribution, and a `rust-build` capability. All marked
  `Designed, not implemented`.

## Post-release

`mur update --restart-agents` — that is the whole step. On a Homebrew install
it runs the brew upgrade itself and refreshes/re-signs
`~/.local/bin/mur-agent-runtime`; a bare `brew upgrade mur` leaves agents on
the old build while `restart --stale` still reports ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)