### PR TITLE
fix(deep-research): never re-pin a running worker; unchanged pin is a no-op

### DIFF
--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -622,6 +622,27 @@ fn pin_package_version(entry: &mut McpServerEntry) -> Option<String> {
     }
 }
 
+/// True when re-pinning would write back exactly what the profile already
+/// holds. `mur deep-research` re-pins on every run, sometimes from inside an
+/// agent sandbox that cannot (and must not) write a sibling agent's profile —
+/// so an unchanged pin has to be a no-op on disk, not a rewrite that only
+/// bumps `installed_at` and trips the sandbox.
+fn pin_unchanged(
+    entry: &McpServerEntry,
+    new_hash: &str,
+    new_description_hash: Option<&str>,
+    version_pinned: bool,
+    publisher: &Option<mur_common::agent::McpPublisherInfo>,
+) -> bool {
+    !version_pinned
+        && entry
+            .binary_sha256
+            .as_deref()
+            .is_some_and(|old| old.eq_ignore_ascii_case(new_hash))
+        && new_description_hash.is_none_or(|h| entry.description_hash.as_deref() == Some(h))
+        && entry.publisher == *publisher
+}
+
 pub fn cmd_mcp_pin(
     name: &str,
     server_id: &str,
@@ -710,6 +731,19 @@ pub fn cmd_mcp_pin(
             registry_id: r.or_else(|| entry.publisher.as_ref().and_then(|p| p.registry_id.clone())),
         }),
     };
+
+    if pin_unchanged(
+        entry,
+        &new_hash,
+        new_description_hash.as_deref(),
+        version_pinned.is_some(),
+        &publisher,
+    ) {
+        println!(
+            "MCP `{server_id}` on agent `{name}` already pinned to {new_hash} — nothing to write."
+        );
+        return Ok(());
+    }
 
     if !force {
         println!("Re-approving MCP `{server_id}` on agent `{name}`:");
@@ -976,6 +1010,32 @@ mod tests {
             compute_description_hash(&order_a),
             compute_description_hash(&order_b),
         );
+    }
+
+    #[test]
+    fn unchanged_pin_is_a_noop_and_any_difference_is_not() {
+        let same = "ab".repeat(32);
+        let mut e = entry_for("/bin/sh", Some(&same));
+        e.description_hash = Some("d1".into());
+        let pub_ = e.publisher.clone();
+        assert!(pin_unchanged(&e, &same.to_uppercase(), None, false, &pub_));
+        assert!(pin_unchanged(&e, &same, Some("d1"), false, &pub_));
+        assert!(!pin_unchanged(&e, &"cd".repeat(32), None, false, &pub_));
+        assert!(!pin_unchanged(&e, &same, Some("d2"), false, &pub_));
+        assert!(!pin_unchanged(&e, &same, None, true, &pub_));
+        let other = Some(mur_common::agent::McpPublisherInfo {
+            name: "x".into(),
+            ..Default::default()
+        });
+        assert!(!pin_unchanged(&e, &same, None, false, &other));
+        let unpinned = entry_for("/bin/sh", None);
+        assert!(!pin_unchanged(
+            &unpinned,
+            &same,
+            None,
+            false,
+            &unpinned.publisher
+        ));
     }
 
     #[test]

--- a/mur-core/src/cmd/deep_research/ask.rs
+++ b/mur-core/src/cmd/deep_research/ask.rs
@@ -49,12 +49,20 @@ pub fn plan_preflight(s: &DeepResearchStatus) -> Result<Vec<PreflightAction>> {
     }
     let mut plan = Vec::new();
     for w in &s.workers {
-        if !w.running {
-            plan.push(PreflightAction::StartWorker(w.name.clone()));
+        // A running worker has already proved its gateway pin against ITS
+        // OWN PATH. Re-pinning it from this process records whatever THIS
+        // process resolves, which on a dual-install box is a different copy
+        // (Hub-launched concierge: /opt/homebrew/bin first; launchd worker:
+        // ~/.local/bin first) — and the worker refuses to start next time
+        // (B0 rule 6). It would also need to write a sibling agent's profile,
+        // which the sandbox rightly denies. Only a stopped worker — the shape
+        // of a post-upgrade pin refusal — is healed: pin first, because the
+        // runtime reads its profile once, at start.
+        if w.running {
+            continue;
         }
-        // Unconditional idempotent re-pin: cheaper than drift detection and
-        // covers the known gateway-binary-swap failure mode.
         plan.push(PreflightAction::RepinGateway(w.name.clone()));
+        plan.push(PreflightAction::StartWorker(w.name.clone()));
     }
     Ok(plan)
 }
@@ -250,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn stopped_worker_planned_for_start_and_repin_always() {
+    fn only_stopped_workers_are_repinned_then_started() {
         let s = DeepResearchStatus {
             workers: vec![
                 worker("dr_worker_1", false, true),
@@ -260,21 +268,27 @@ mod tests {
             model: Some("m".into()),
         };
         let plan = plan_preflight(&s).unwrap();
+        // The running worker has proved its own pin; touching it from a
+        // process with a different PATH is how a worker gets bricked.
         assert!(
-            plan.iter()
-                .any(|a| matches!(a, PreflightAction::StartWorker(n) if n == "dr_worker_1"))
+            !plan.iter().any(
+                |a| matches!(a, PreflightAction::StartWorker(n) | PreflightAction::RepinGateway(n) if n == "dr_worker_2")
+            )
         );
+        // The stopped one is healed: pin first (the runtime reads the
+        // profile once, at start), then start.
+        let names: Vec<&str> = plan
+            .iter()
+            .map(|a| match a {
+                PreflightAction::RepinGateway(_) => "repin",
+                PreflightAction::StartWorker(_) => "start",
+            })
+            .collect();
+        assert_eq!(names, ["repin", "start"]);
         assert!(
-            !plan
-                .iter()
-                .any(|a| matches!(a, PreflightAction::StartWorker(n) if n == "dr_worker_2"))
-        );
-        // One re-pin per worker (idempotent, covers binary-swap drift):
-        assert_eq!(
-            plan.iter()
-                .filter(|a| matches!(a, PreflightAction::RepinGateway(_)))
-                .count(),
-            2
+            plan.iter().all(
+                |a| matches!(a, PreflightAction::StartWorker(n) | PreflightAction::RepinGateway(n) if n == "dr_worker_1")
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- `mur deep-research "<q>"` re-pinned `research-gateway` on **every** worker on **every** run, using the caller's PATH, and `cmd_mcp_pin` always rewrote `profile.yaml` even when nothing but `installed_at` changed.
- From the Hub-launched concierge (`fleet_run` tool) that write lands in a sibling agent's dir → launch-chain deny → run dies in preflight before the question reaches `fleet.yaml`, so `mur fleet status` shows the previous goal (seen 2026-09-11).
- Worse if it had succeeded: concierge PATH resolves `/opt/homebrew/bin` first (`cc8d…`), the launchd workers resolve `~/.local/bin` first (`9871…`) → workers bricked by B0 rule 6 at next start.

## Fix
- `plan_preflight`: a **running** worker is never re-pinned (it has proved its own pin against its own PATH). A stopped worker is healed: pin first, then start.
- `cmd_mcp_pin`: no write when hash / description hash / publisher / package version are unchanged.

## Test plan
- [x] `only_stopped_workers_are_repinned_then_started`, `unchanged_pin_is_a_noop_and_any_difference_is_not` (red → green)
- [x] `cargo clippy -p mur-core --all-targets -D warnings`, `cargo fmt --check`
- [ ] Live: concierge `fleet_run deep-research` with a goal reaches the loop instead of dying on `profile.yaml.tmp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)