### PR TITLE
feat(murmur): add the `clay` skin (warm terracotta on dark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ mur agent cli dev qa ops                      # three agents, tiled panes (tmux/
                                               #   --resume continues the last conversation
 murmur coach                                  # quick form (murmur symlink), identical to mur agent cli coach
 murmur coach --skin mur                       # skins: ansi (default — follows your terminal's own
-                                              #   colours) | light | mur (brand); /skin switches and remembers
+                                              #   colours) | light | mur (brand) | claude (Claude Code's
+                                              #   palette); /skin switches and remembers
 
 mur agent stop coach                          # stops it for real: unloads the service first, so
                                               #   the supervisor cannot respawn it a second later

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ mur agent cli dev qa ops                      # three agents, tiled panes (tmux/
                                               #   --resume continues the last conversation
 murmur coach                                  # quick form (murmur symlink), identical to mur agent cli coach
 murmur coach --skin mur                       # skins: ansi (default — follows your terminal's own
-                                              #   colours) | light | mur (brand) | claude (Claude Code's
-                                              #   palette); /skin switches and remembers
+                                              #   colours) | light | mur (brand) | clay (warm terracotta
+                                              #   on dark); /skin switches and remembers
 
 mur agent stop coach                          # stops it for real: unloads the service first, so
                                               #   the supervisor cannot respawn it a second later

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -195,7 +195,7 @@ pub enum AgentAction {
         /// it back). The old default.
         #[arg(long)]
         ask: bool,
-        /// Visual skin: ansi (default; `dark` is an alias) | light | mur
+        /// Visual skin: ansi (default; `dark` is an alias) | light | mur | claude
         #[arg(long)]
         skin: Option<String>,
         /// Plain line-based output (no full-screen TUI) — for screen readers,

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -195,7 +195,7 @@ pub enum AgentAction {
         /// it back). The old default.
         #[arg(long)]
         ask: bool,
-        /// Visual skin: ansi (default; `dark` is an alias) | light | mur | claude
+        /// Visual skin: ansi (default; `dark` is an alias) | light | mur | clay
         #[arg(long)]
         skin: Option<String>,
         /// Plain line-based output (no full-screen TUI) — for screen readers,

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -120,15 +120,43 @@ pub const MUR: Theme = Theme {
     compact_input: true,
 };
 
+/// Background `claude` is designed against (it does not paint one): a
+/// typical dark terminal, since Claude Code itself never paints one either.
+pub const ASSUMED_BG_CLAUDE: Color = Color::Rgb(0x1a, 0x1a, 0x1a);
+
+/// Claude Code's dark palette: terracotta for the agent, periwinkle for the
+/// operator, its green / amber / rose for status, grey for metadata and
+/// rules. Every value is lifted from Claude Code's own dark theme table;
+/// only the assumed background and the surface tint are ours.
+pub const CLAUDE: Theme = Theme {
+    text: rgb(0xff, 0xff, 0xff),
+    muted: rgb(0x99, 0x99, 0x99),
+    emphasis: rgb(0xff, 0xff, 0xff).add_modifier(Modifier::BOLD),
+    accent: rgb(0xd9, 0x77, 0x57),
+    accent_alt: rgb(0xb1, 0xb9, 0xf9),
+    ok: rgb(0x4e, 0xba, 0x65),
+    warn: rgb(0xff, 0xc1, 0x07),
+    error: rgb(0xff, 0x6b, 0x80),
+    border: rgb(0x88, 0x88, 0x88),
+    surface: Style::new().bg(Color::Rgb(0x26, 0x26, 0x26)),
+    badge: Style::new()
+        .fg(Color::Rgb(0x1a, 0x1a, 0x1a))
+        .bg(Color::Rgb(0xd9, 0x77, 0x57)),
+    border_type: BorderType::Rounded,
+    inner_padding: 1,
+    compact_input: false,
+};
+
 /// The names `/skin` and `--skin` accept, in the order they are listed.
 /// `dark` is an alias of `ansi` and is not listed.
-pub const SKIN_NAMES: &str = "ansi, light, mur";
+pub const SKIN_NAMES: &str = "ansi, light, mur, claude";
 
-const KNOWN: [(&str, &Theme); 4] = [
+const KNOWN: [(&str, &Theme); 5] = [
     ("ansi", &ANSI),
     ("dark", &ANSI),
     ("light", &LIGHT),
     ("mur", &MUR),
+    ("claude", &CLAUDE),
 ];
 
 /// Resolve a skin name to a theme. `dark` is an alias of `ansi`; unknown
@@ -210,10 +238,11 @@ mod tests {
     /// background is a constant beside the palette so this test and the
     /// spec cannot drift apart.
     #[test]
-    fn light_and_mur_meet_wcag() {
+    fn rgb_skins_meet_wcag() {
         for (name, theme, bg) in [
             ("light", &LIGHT, ASSUMED_BG_LIGHT),
             ("mur", &MUR, ASSUMED_BG_MUR),
+            ("claude", &CLAUDE, ASSUMED_BG_CLAUDE),
         ] {
             let fg = |s: Style| s.fg.expect("text token has a colour");
             let r = contrast_ratio(fg(theme.text), bg);

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -120,15 +120,15 @@ pub const MUR: Theme = Theme {
     compact_input: true,
 };
 
-/// Background `claude` is designed against (it does not paint one): a
-/// typical dark terminal, since Claude Code itself never paints one either.
-pub const ASSUMED_BG_CLAUDE: Color = Color::Rgb(0x1a, 0x1a, 0x1a);
+/// Background `clay` is designed against (it does not paint one): a
+/// typical dark terminal.
+pub const ASSUMED_BG_CLAY: Color = Color::Rgb(0x1a, 0x1a, 0x1a);
 
-/// Claude Code's dark palette: terracotta for the agent, periwinkle for the
-/// operator, its green / amber / rose for status, grey for metadata and
-/// rules. Every value is lifted from Claude Code's own dark theme table;
-/// only the assumed background and the surface tint are ours.
-pub const CLAUDE: Theme = Theme {
+/// Warm terracotta on dark: terracotta for the agent, periwinkle for the
+/// operator, green / amber / rose for status, grey for metadata and rules.
+/// The palette follows the familiar coding-assistant dark theme; the assumed
+/// background and the surface tint are ours.
+pub const CLAY: Theme = Theme {
     text: rgb(0xff, 0xff, 0xff),
     muted: rgb(0x99, 0x99, 0x99),
     emphasis: rgb(0xff, 0xff, 0xff).add_modifier(Modifier::BOLD),
@@ -149,14 +149,14 @@ pub const CLAUDE: Theme = Theme {
 
 /// The names `/skin` and `--skin` accept, in the order they are listed.
 /// `dark` is an alias of `ansi` and is not listed.
-pub const SKIN_NAMES: &str = "ansi, light, mur, claude";
+pub const SKIN_NAMES: &str = "ansi, light, mur, clay";
 
 const KNOWN: [(&str, &Theme); 5] = [
     ("ansi", &ANSI),
     ("dark", &ANSI),
     ("light", &LIGHT),
     ("mur", &MUR),
-    ("claude", &CLAUDE),
+    ("clay", &CLAY),
 ];
 
 /// Resolve a skin name to a theme. `dark` is an alias of `ansi`; unknown
@@ -242,7 +242,7 @@ mod tests {
         for (name, theme, bg) in [
             ("light", &LIGHT, ASSUMED_BG_LIGHT),
             ("mur", &MUR, ASSUMED_BG_MUR),
-            ("claude", &CLAUDE, ASSUMED_BG_CLAUDE),
+            ("clay", &CLAY, ASSUMED_BG_CLAY),
         ] {
             let fg = |s: Style| s.fg.expect("text token has a colour");
             let r = contrast_ratio(fg(theme.text), bg);

--- a/mur-core/src/cmd/agent/cli/ui/band/tests.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band/tests.rs
@@ -245,7 +245,7 @@ mod band_growth_tests {
 #[cfg(test)]
 mod layout_guard_tests {
     use super::super::super::super::app::{App, ChatMsg, Role};
-    use super::super::super::super::theme::{ANSI, LIGHT, MUR};
+    use super::super::super::super::theme::{ANSI, CLAUDE, LIGHT, MUR};
     use super::super::super::render;
     use super::super::render_transcript;
     use ratatui::backend::TestBackend;
@@ -256,7 +256,12 @@ mod layout_guard_tests {
     /// one more line on a screen full of them. No skin draws one.
     #[test]
     fn no_rule_between_turns_under_any_skin() {
-        for (name, theme) in [("ansi", &ANSI), ("light", &LIGHT), ("mur", &MUR)] {
+        for (name, theme) in [
+            ("ansi", &ANSI),
+            ("light", &LIGHT),
+            ("mur", &MUR),
+            ("claude", &CLAUDE),
+        ] {
             let mut app = App::test_fixture();
             app.theme = theme;
             app.messages.push(ChatMsg::for_test(Role::User, "hi"));

--- a/mur-core/src/cmd/agent/cli/ui/band/tests.rs
+++ b/mur-core/src/cmd/agent/cli/ui/band/tests.rs
@@ -245,7 +245,7 @@ mod band_growth_tests {
 #[cfg(test)]
 mod layout_guard_tests {
     use super::super::super::super::app::{App, ChatMsg, Role};
-    use super::super::super::super::theme::{ANSI, CLAUDE, LIGHT, MUR};
+    use super::super::super::super::theme::{ANSI, CLAY, LIGHT, MUR};
     use super::super::super::render;
     use super::super::render_transcript;
     use ratatui::backend::TestBackend;
@@ -260,7 +260,7 @@ mod layout_guard_tests {
             ("ansi", &ANSI),
             ("light", &LIGHT),
             ("mur", &MUR),
-            ("claude", &CLAUDE),
+            ("clay", &CLAY),
         ] {
             let mut app = App::test_fixture();
             app.theme = theme;


### PR DESCRIPTION
## Summary
- New skin `clay`: terracotta `#d97757` (agent label, mascot, focused borders, badge fill), periwinkle `#b1b9f9` (operator), `#4eba65` / `#ffc107` / `#ff6b80` status, `#999999` metadata, `#888888` rules, white text — designed against a `#1a1a1a` terminal.
- Registered in `SKIN_NAMES`, `KNOWN`, the `--skin` help, the band no-rule guard, and the WCAG guard (renamed `rgb_skins_meet_wcag`; every text token ≥ 4.5:1, body ≥ 7:1). README skin list updated.

Not done: eyeballing in a real terminal. Docs-site line follows in mur-server#83.

## Test plan
- [x] `rgb_skins_meet_wcag` (includes clay), `no_rule_between_turns_under_any_skin`, theme resolve tests — 24 pass
- [x] `clippy --all-targets -D warnings`, `fmt --check`
- [ ] `murmur <agent> --skin clay` in a real terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)