### PR TITLE
fix(murmur): lay /help out as grouped rows, generated from the skin list

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -29,9 +29,9 @@ const ENTER_HINT_COMPACT: &str = " message — Enter · Shift+Enter · /help ";
 /// Full composer-border hint. macOS calls the modifier "Option" even though
 /// it's still crossterm's `ALT` — every other OS calls it "Alt".
 #[cfg(target_os = "macos")]
-const ENTER_HINT_FULL: &str = " message — Enter to send · Shift+Enter newline (Option+Enter also works) · Ctrl+V image · Ctrl+O transcript · /help · Ctrl+D quit";
+pub(super) const ENTER_HINT_FULL: &str = " message — Enter to send · Shift+Enter newline (Option+Enter also works) · Ctrl+V image · Ctrl+O transcript · /help · Ctrl+D quit";
 #[cfg(not(target_os = "macos"))]
-const ENTER_HINT_FULL: &str = " message — Enter to send · Shift+Enter newline (Alt+Enter also works) · Ctrl+V image · Ctrl+O transcript · /help · Ctrl+D quit";
+pub(super) const ENTER_HINT_FULL: &str = " message — Enter to send · Shift+Enter newline (Alt+Enter also works) · Ctrl+V image · Ctrl+O transcript · /help · Ctrl+D quit";
 
 /// Assumed terminal width until the event loop reports the real one.
 const DEFAULT_WIDTH: u16 = 80;

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -193,7 +193,29 @@ async fn push_memory_reload(home: &std::path::Path, agent: &str) -> String {
     }
 }
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /open (outstanding items)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /model [N|name] (list/switch model)  /login [anthropic|chatgpt] (OAuth health / re-authenticate — unrelated to mur auth login, which signs in to mur.run for the official catalog)  /secret <KEY> [--delete] (hand the agent a credential — hidden input, never enters the chat)  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /quit (or /exit)  /effort [level] (reasoning effort this model accepts) · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+/// The `/help` cheatsheet: one row per group, the settings row first among
+/// the things a session changes. Built rather than a literal so the skin
+/// list is the one `/skin` accepts — a hand-written copy said `dark` for a
+/// year after `ansi` became the name.
+fn help_text() -> String {
+    let skins = theme::SKIN_NAMES.replace(", ", "|");
+    let settings = format!(
+        "  settings  /model [N|name] · /effort [level] · /skin [{skins}] · /auto [on|off] · /verbose [on|off] (expand tool cards)"
+    );
+    [
+        "commands",
+        "  chat      /clear (new conversation) · /sessions · /channels [N] (list/switch) · /channels N --follow (live-tail; bare --follow stops)",
+        "  look      /card · /open (outstanding items) · /memories",
+        settings.as_str(),
+        "  agent     /mcp · /skill · /secret <KEY> [--delete] (hidden input, never enters the chat) · /login [anthropic|chatgpt] (OAuth health; not `mur auth login`)",
+        "  memory    /remember <text> · /forget <name|last>",
+        "  more      /panel [tab] (Hub companion window) · /help · /quit (or /exit)",
+        "  !cmd      run a local shell command (output shared with the agent)",
+        "keys        Enter send · Shift+Enter newline · Ctrl+V image · Ctrl+O transcript · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll",
+        "menus       ↑↓ move · Tab accept · Esc close",
+    ]
+    .join("\n")
+}
 
 /// Entry point dispatched from `AgentAction::Cli`.
 #[allow(clippy::too_many_arguments)]
@@ -1882,7 +1904,7 @@ fn start_turn(app: &mut App, trimmed: String, tx: &mpsc::Sender<StreamMsg>) {
 
 async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>) {
     match cmd {
-        SlashCmd::Help => app.push_system(HELP),
+        SlashCmd::Help => app.push_system(help_text()),
         SlashCmd::Quit => request_quit(app, tx),
         SlashCmd::Clear => {
             // Stop the in-flight turn first so its worker can't write into the
@@ -3118,8 +3140,8 @@ mod hitl_key_tests {
 /// remember" becomes "the build stops."
 #[cfg(test)]
 mod help_coverage_tests {
-    use super::HELP;
     use super::app::{SlashCmd, parse_slash};
+    use super::help_text;
 
     /// Canonical `/name` for a `SlashCmd` variant that must show up in
     /// `/help`, or `None` for a variant that legitimately has none.
@@ -3200,6 +3222,31 @@ mod help_coverage_tests {
     /// and the completion table — and nothing but this test ties them
     /// together. `/effort` shipped in the parser while missing from both of
     /// the others; that is the drift this exists to catch.
+    /// The composer hint and `/help` describe the same keys; the skin list in
+    /// `/help` is the one `/skin` accepts. Both drifted by hand once.
+    #[test]
+    fn help_matches_the_composer_hint_and_the_skin_list() {
+        let help = help_text();
+        for key in ["Enter", "Shift+Enter", "Ctrl+V", "Ctrl+O", "Ctrl+D"] {
+            assert!(
+                super::app::ENTER_HINT_FULL.contains(key) && help.contains(key),
+                "{key} must appear in both the composer hint and /help"
+            );
+        }
+        for skin in super::theme::SKIN_NAMES.split(", ") {
+            assert!(help.contains(skin), "/help does not list skin {skin}");
+        }
+        assert!(
+            !help.contains("dark|"),
+            "`dark` is an alias, not a listed skin"
+        );
+        // One group per row, indented under its heading — the wall of text
+        // this replaced had every command on one line.
+        assert!(help.contains("commands\n  chat      /clear"), "{help}");
+        assert!(help.contains("\n  settings  /model"), "{help}");
+        assert!(help.contains("\nkeys        Enter send"), "{help}");
+    }
+
     #[test]
     fn every_command_is_parsed_documented_and_offered() {
         for cmd in one_of_each() {
@@ -3212,7 +3259,7 @@ mod help_coverage_tests {
                 "/{name} is in the documented list but the parser rejects it: {parsed:?}"
             );
             assert!(
-                HELP.contains(&format!("/{name}")),
+                help_text().contains(&format!("/{name}")),
                 "/{name} works but /help never mentions it"
             );
             assert!(


### PR DESCRIPTION
## Summary
- Audit: all 20 commands were present (the parser/help/menu guard already enforces that). Stale: `/skin [dark|light|mur]` (`dark` is an alias; the names are `ansi|light|mur`, `clay` after #1254), `Ctrl+O transcript` missing, `Ctrl+V` called "attach screenshot" in one place and "image" in the other.
- Layout: one row per group — chat / look / settings / agent / memory / more / !cmd — then `keys` and `menus`, indented under headings, instead of one 900-character line.
- The skin list is generated from `theme::SKIN_NAMES`; a new guard checks the composer hint and `/help` name the same keys, every skin is listed, `dark` is not, and the rows are indented (the `\` string-continuation trap that eats leading spaces is exactly what the assert catches).

```
commands
  chat      /clear (new conversation) · /sessions · /channels [N] (list/switch) · /channels N --follow (live-tail; bare --follow stops)
  look      /card · /open (outstanding items) · /memories
  settings  /model [N|name] · /effort [level] · /skin [ansi|light|mur] · /auto [on|off] · /verbose [on|off] (expand tool cards)
  agent     /mcp · /skill · /secret <KEY> [--delete] (hidden input, never enters the chat) · /login [anthropic|chatgpt] (OAuth health; not `mur auth login`)
  memory    /remember <text> · /forget <name|last>
  more      /panel [tab] (Hub companion window) · /help · /quit (or /exit)
  !cmd      run a local shell command (output shared with the agent)
keys        Enter send · Shift+Enter newline · Ctrl+V image · Ctrl+O transcript · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll
menus       ↑↓ move · Tab accept · Esc close
```

## Test plan
- [x] `help_matches_the_composer_hint_and_the_skin_list`, `every_command_is_parsed_documented_and_offered`
- [x] `clippy --all-targets -D warnings`, `fmt --check`
- [ ] `/help` in a real terminal (long rows wrap on narrow panes; acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)