### PR TITLE
fix(hub): fleet job counts refresh while the Fleets page stays open

### DIFF
--- a/mur-hub-gui/ui/src/components/detail/fleet/FleetDetailPane.tsx
+++ b/mur-hub-gui/ui/src/components/detail/fleet/FleetDetailPane.tsx
@@ -4,7 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useT } from "../../../i18n";
 import type { AgentEntry } from "../../../types";
-import type { FleetSummary, FleetDetail as Detail, JobRow, LabelView } from "../../fleet/types";
+import { JOBS_POLL_MS, type FleetSummary, type FleetDetail as Detail, type JobRow, type LabelView } from "../../fleet/types";
 import { Ico } from "../../agents/GridCard";
 import { DetailPage } from "../../shell/DetailPage";
 import { fleetStatusOf } from "../../shell/Status";
@@ -84,6 +84,13 @@ export function FleetDetailPane({
       if (focused) void load();
     });
     return () => { void un.then((f) => f()); };
+  }, [load]);
+
+  // Same reason as the list's poll: a job queued from the CLI or by an agent
+  // has no event, and the Jobs tab said "No jobs yet" until remount.
+  useEffect(() => {
+    const id = setInterval(() => void load(), JOBS_POLL_MS);
+    return () => clearInterval(id);
   }, [load]);
 
   function refresh() {

--- a/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useT } from "../../i18n";
 import type { AgentEntry } from "../../types";
-import type { FleetSummary, LabelView } from "./types";
+import { JOBS_POLL_MS, type FleetSummary, type LabelView } from "./types";
 import { UNGROUPED } from "./fleetLabels";
 import { FleetCreateModal } from "./FleetCreateModal";
 import { Ico } from "../agents/GridCard";
@@ -152,6 +152,16 @@ export function FleetView({ onSelect, requestedName, onRequestHandled }: {
       },
     );
     return () => { void unlisten.then((fn) => fn()); };
+  }, []);
+
+  // Jobs are queued by other processes too — the CLI, an agent's `fleet_run`
+  // — and nothing tells this window when a file lands in a fleet's jobs dir,
+  // so the count sat stale until the pane was remounted.
+  // ponytail: poll; a notify watcher on ~/.mur/fleets emitting one event is
+  // the upgrade if the interval ever shows in a profile.
+  useEffect(() => {
+    const id = setInterval(() => void loadList(), JOBS_POLL_MS);
+    return () => clearInterval(id);
   }, []);
 
   function handleRefresh() {

--- a/mur-hub-gui/ui/src/components/fleet/types.ts
+++ b/mur-hub-gui/ui/src/components/fleet/types.ts
@@ -1,3 +1,7 @@
+/** How often the fleet list and detail re-read job counts: other processes
+ *  (the CLI, an agent's `fleet_run`) queue jobs with no event to this window. */
+export const JOBS_POLL_MS = 5_000;
+
 export interface FleetSummary {
   name: string;
   display_name: string;


### PR DESCRIPTION
## Summary
- Staying on the Fleets page, a job queued by the CLI or by an agent's `fleet_run` never showed: the list's `active_jobs` badge and the detail pane's Jobs tab only reloaded on mount, `fleet:run_done`, or (detail only) window focus. Nothing emits an event when a job file lands, so a remount (navigate away and back) was the only refresh.
- Fix: both re-read every `JOBS_POLL_MS` (5 s, in `fleet/types.ts`) while mounted. `fleet_list` = one `fleet.yaml` read + one jobs-dir listing per fleet; cheap.
- `ponytail:` note left in place — a `notify` watcher on `~/.mur/fleets` (the Hub already uses `notify` for the preview) is the upgrade if the interval ever shows in a profile.

## Test plan
- [x] `tsc -b`, `eslint` (no warnings in the touched files), `vitest` 305 pass
- [ ] Live: open Fleets, `mur fleet run develop-rust "noop job"` from a shell, badge appears within 5 s without leaving the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)