### PR TITLE
fix(hub): agent cards' unread badge refreshes while the page stays open

### DIFF
--- a/mur-hub-gui/ui/src/components/CompanionInbox.tsx
+++ b/mur-hub-gui/ui/src/components/CompanionInbox.tsx
@@ -148,13 +148,22 @@ export function CompanionInbox({ agentName }: Props) {
 
 // ─── Unread badge hook ───────────────────────────────────────────────────────
 
+/** How often a card's unread badge re-reads its count. A companion message
+ *  arrives with no event to this window (the inbox subscribes per open
+ *  agent only), so a badge read once at mount sat stale until remount. */
+const UNREAD_POLL_MS = 5_000;
+
 export function useUnreadCount(agentName: string): number {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
-    invoke<number>("companion_unread_count", { agent: agentName })
-      .then(setCount)
-      .catch(() => {});
+    const load = () =>
+      invoke<number>("companion_unread_count", { agent: agentName })
+        .then(setCount)
+        .catch(() => {});
+    void load();
+    const id = setInterval(load, UNREAD_POLL_MS);
+    return () => clearInterval(id);
   }, [agentName]);
 
   return count;


### PR DESCRIPTION
## Summary
- Audit of the Agents page after #1257: agent list and running/idle come from the supervisor's 5-second scanners via `agents-updated` / `runtime-status-changed`; needs-you has an event plus a poll. The one stale reader was the card's **unread badge** — `useUnreadCount` invoked `companion_unread_count` once at mount and never again.
- Now re-read every 5 s while mounted (`UNREAD_POLL_MS`). No companion-message event exists to listen to; the inbox uses a per-open-agent Channel subscription instead.

## Test plan
- [x] `tsc -b`, eslint on the file, vitest 305 pass
- [ ] Live: open Agents, send a companion message to an agent from elsewhere, badge bumps within 5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)