### PR TITLE
feat(murmur): !cmd output is a turn; shell completion

### DIFF
--- a/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
+++ b/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
@@ -47,7 +47,7 @@ character) and updates `/help`.
 
 ### Steps
 
-- [ ] **1.1 Write the failing routing test** — append to the `#[cfg(test)] mod hitl_key_tests` block in `mod.rs` (the module that already has `image_does_not_ride_a_steer_and_stays_staged`), a new module right after it:
+- [x] **1.1 Write the failing routing test** — append to the `#[cfg(test)] mod hitl_key_tests` block in `mod.rs` (the module that already has `image_does_not_ride_a_steer_and_stays_staged`), a new module right after it:
 
 ```rust
 #[cfg(test)]
@@ -106,9 +106,9 @@ mod shell_turn_tests {
 }
 ```
 
-- [ ] **1.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(shell_turn_tests)'` (with the env). Expected: compile error `cannot find function route_shell_output` (and `shell_block`, `ShellRoute`).
+- [x] **1.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(shell_turn_tests)'` (with the env). Expected: compile error `cannot find function route_shell_output` (and `shell_block`, `ShellRoute`).
 
-- [ ] **1.3 Split `begin_turn` out of `begin_user_turn`** in `app.rs` — replace the whole `begin_user_turn` body with:
+- [x] **1.3 Split `begin_turn` out of `begin_user_turn`** in `app.rs` — replace the whole `begin_user_turn` body with:
 
 ```rust
     pub fn begin_user_turn(&mut self, text: &str) -> String {
@@ -143,7 +143,7 @@ mod shell_turn_tests {
     }
 ```
 
-- [ ] **1.4 Delete the stash** in `app.rs`: remove the field `pub pending_shell: Vec<String>,` (with its doc comment), its initialiser `pending_shell: Vec::new(),`, the line `self.pending_shell.push(text);` inside `push_shell`, the whole `take_pending_shell` fn (and its doc comment), and the test `shell_blocks_queue_and_drain_into_prefix`. `push_shell` becomes:
+- [x] **1.4 Delete the stash** in `app.rs`: remove the field `pub pending_shell: Vec<String>,` (with its doc comment), its initialiser `pending_shell: Vec::new(),`, the line `self.pending_shell.push(text);` inside `push_shell`, the whole `take_pending_shell` fn (and its doc comment), and the test `shell_blocks_queue_and_drain_into_prefix`. `push_shell` becomes:
 
 ```rust
     /// Record a completed `!command` run: show it and persist it. The block is
@@ -160,7 +160,7 @@ mod shell_turn_tests {
     }
 ```
 
-- [ ] **1.5 `start_turn` no longer prefixes** — in `mod.rs` replace the body of `fn start_turn` with:
+- [x] **1.5 `start_turn` no longer prefixes** — in `mod.rs` replace the body of `fn start_turn` with:
 
 ```rust
 fn start_turn(app: &mut App, trimmed: String, tx: &mpsc::Sender<StreamMsg>) {
@@ -188,7 +188,7 @@ fn start_turn(app: &mut App, trimmed: String, tx: &mpsc::Sender<StreamMsg>) {
 }
 ```
 
-- [ ] **1.6 Add the shell-turn helpers** directly below `start_turn` in `mod.rs`:
+- [x] **1.6 Add the shell-turn helpers** directly below `start_turn` in `mod.rs`:
 
 ```rust
 /// What the agent receives for a `!cmd` run. Singular, framed, nothing else:
@@ -266,7 +266,7 @@ fn steer_now(app: &mut App, task_id: String, msg: String, label: &str, tx: &mpsc
 }
 ```
 
-- [ ] **1.7 Make `submit` use `steer_now`** — in `submit`'s `if app.streaming {` branch, replace everything from `if let Some(task_id) = app.current_task_id.clone() {` through the matching `} else { app.push_system("still generating — press Ctrl+C to cancel first"); }` with:
+- [x] **1.7 Make `submit` use `steer_now`** — in `submit`'s `if app.streaming {` branch, replace everything from `if let Some(task_id) = app.current_task_id.clone() {` through the matching `} else { app.push_system("still generating — press Ctrl+C to cancel first"); }` with:
 
 ```rust
         if let Some(task_id) = app.current_task_id.clone() {
@@ -279,7 +279,7 @@ fn steer_now(app: &mut App, task_id: String, msg: String, label: &str, tx: &mpsc
 
   (The `↗ steering:` line now comes from `steer_now`; the old inline `tokio::spawn` block is gone.)
 
-- [ ] **1.8 Route `ShellDone`** — in `handle_stream`, replace `StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),` with:
+- [x] **1.8 Route `ShellDone`** — in `handle_stream`, replace `StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),` with:
 
 ```rust
         StreamMsg::ShellDone { cmd, output } => {
@@ -298,9 +298,9 @@ fn steer_now(app: &mut App, task_id: String, msg: String, label: &str, tx: &mpsc
 
   `handle_stream`'s early return drops events whose task id is not current; `ShellDone` has no task id (`msg.task_id()` is `None` for it), so it always reaches this arm — verify by reading `StreamMsg::task_id` in `stream.rs`; if `ShellDone` is not in its `None` list, add it there.
 
-- [ ] **1.9 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(shell_turn_tests) | test(/cmd::agent::cli::/)'`. Expected: all pass, including the whole `cli` module (the deleted stash test is gone, nothing else referenced `take_pending_shell`). Then fmt + clippy per Global Constraints.
+- [x] **1.9 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(shell_turn_tests) | test(/cmd::agent::cli::/)'`. Expected: all pass, including the whole `cli` module (the deleted stash test is gone, nothing else referenced `take_pending_shell`). Then fmt + clippy per Global Constraints.
 
-- [ ] **1.10 Commit** — `git add mur-core/src/cmd/agent/cli && git commit` with message:
+- [x] **1.10 Commit** — `git add mur-core/src/cmd/agent/cli && git commit` with message:
 
 ```
 feat(murmur): a !cmd's output is the user's next turn

--- a/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
+++ b/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
@@ -323,7 +323,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
 ### Steps
 
-- [ ] **2.1 Create the module with its tests first** — new file `mur-core/src/cmd/agent/cli/shell_complete.rs`:
+- [x] **2.1 Create the module with its tests first** — new file `mur-core/src/cmd/agent/cli/shell_complete.rs`:
 
 ```rust
 //! Completion for `!` lines in the composer: command names for the first
@@ -610,11 +610,11 @@ mod tests {
 }
 ```
 
-- [ ] **2.2 Register the module** — in `mur-core/src/cmd/agent/cli/mod.rs`, next to the existing `mod complete;` line add `mod shell_complete;`.
+- [x] **2.2 Register the module** — in `mur-core/src/cmd/agent/cli/mod.rs`, next to the existing `mod complete;` line add `mod shell_complete;`.
 
-- [ ] **2.3 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(shell_complete)'`. Expected: 8 tests pass. (They are written together with the code; the red step for this task is the `mod shell_complete;` line failing to compile before the file exists — run 2.3 once with the file empty if you want to see it.) If `scan_path_bins_reads_the_env_path` is flaky under nextest's process-per-test model it cannot be — each test is its own process — but if it is ever run under plain `cargo test`, mark it `#[serial]` only if the crate already depends on `serial_test`; otherwise leave it.
+- [x] **2.3 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(shell_complete)'`. Expected: 8 tests pass. (They are written together with the code; the red step for this task is the `mod shell_complete;` line failing to compile before the file exists — run 2.3 once with the file empty if you want to see it.) If `scan_path_bins_reads_the_env_path` is flaky under nextest's process-per-test model it cannot be — each test is its own process — but if it is ever run under plain `cargo test`, mark it `#[serial]` only if the crate already depends on `serial_test`; otherwise leave it.
 
-- [ ] **2.4 fmt + clippy**, then **commit**:
+- [x] **2.4 fmt + clippy**, then **commit**:
 
 ```
 feat(murmur): shell_complete — candidates for ! lines

--- a/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
+++ b/docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md
@@ -636,7 +636,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
 ### Steps
 
-- [ ] **3.1 Write the failing wiring test** — append to `mod shell_turn_tests` in `mod.rs`:
+- [x] **3.1 Write the failing wiring test** — append to `mod shell_turn_tests` in `mod.rs`:
 
 ```rust
     /// `!` lines open the shell menu through the same refresh path as `/`,
@@ -670,9 +670,9 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
     }
 ```
 
-- [ ] **3.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(bang_lines_get_the_shell_menu)'`. Expected: compile error `no field path_bins on App`.
+- [x] **3.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(bang_lines_get_the_shell_menu)'`. Expected: compile error `no field path_bins on App`.
 
-- [ ] **3.3 Cache PATH on `App`** — in `app.rs`, next to `pub menu_ctx: super::complete::MenuContext,` add:
+- [x] **3.3 Cache PATH on `App`** — in `app.rs`, next to `pub menu_ctx: super::complete::MenuContext,` add:
 
 ```rust
     /// Executable names on `$PATH` for `!` completion. `None` until the first
@@ -691,7 +691,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
     }
 ```
 
-- [ ] **3.4 Dispatch in `refresh_completion`** — in `mod.rs` replace the fn with:
+- [x] **3.4 Dispatch in `refresh_completion`** — in `mod.rs` replace the fn with:
 
 ```rust
 /// Recompute the completion menu from the current input. Called after every
@@ -738,7 +738,7 @@ fn shell_completion(app: &mut App, line: &str) -> Option<complete::CompletionSta
 
   If `PathBuf` is not already imported at the top of `mod.rs`, add `use std::path::PathBuf;`.
 
-- [ ] **3.5 `completion_accept` reuses the dispatch** — replace its tail (from `app.set_input(&insert);` to the end of the fn) with:
+- [x] **3.5 `completion_accept` reuses the dispatch** — replace its tail (from `app.set_input(&insert);` to the end of the fn) with:
 
 ```rust
     app.set_input(&insert);
@@ -750,15 +750,15 @@ fn shell_completion(app: &mut App, line: &str) -> Option<complete::CompletionSta
 }
 ```
 
-- [ ] **3.6 `/help` wording** — in `help_text()` change the `!cmd` row to:
+- [x] **3.6 `/help` wording** — in `help_text()` change the `!cmd` row to:
 
 ```rust
         "  !cmd      run a local shell command; its output is sent to the agent as your message · Tab completes commands and paths",
 ```
 
-- [ ] **3.7 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(bang_lines_get_the_shell_menu) | test(help_matches) | test(every_command_is_parsed) | test(/complete::/)'`. Expected: all pass. Then fmt + clippy.
+- [x] **3.7 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(bang_lines_get_the_shell_menu) | test(help_matches) | test(every_command_is_parsed) | test(/complete::/)'`. Expected: all pass. Then fmt + clippy.
 
-- [ ] **3.8 Commit**:
+- [x] **3.8 Commit**:
 
 ```
 feat(murmur): live shell completion on ! lines

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -438,9 +438,6 @@ pub struct App {
     /// Tools the user marked "always allow" for THIS session via the HITL
     /// modal's `[a]` key. Same lifetime rules as `auto_approve`.
     pub session_tool_allow: HashSet<String>,
-    /// `!command` blocks (command + output) not yet shown to the agent; they
-    /// are prefixed onto the next user message so the agent has the context.
-    pub pending_shell: Vec<String>,
     /// Set once we've warned the user that session writes are failing, so the
     /// warning isn't repeated every turn.
     persist_warned: bool,
@@ -650,7 +647,6 @@ impl App {
             should_quit: false,
             auto_approve: true,
             session_tool_allow: HashSet::new(),
-            pending_shell: Vec::new(),
             persist_warned: false,
             panel: None,
             panel_stream: false,
@@ -962,6 +958,13 @@ impl App {
     pub fn begin_user_turn(&mut self, text: &str) -> String {
         self.messages.push(ChatMsg::new(Role::User, text));
         self.persist_turn("user", text, None, &[]);
+        self.begin_turn()
+    }
+
+    /// Start a turn the transcript already shows — a `!cmd` whose Shell card
+    /// is its entry. Everything `begin_user_turn` does except the User bubble
+    /// and the `"user"` channel event.
+    pub fn begin_turn(&mut self) -> String {
         // A fresh client-side task id per turn (used for cancellation).
         let task_id = uuid::Uuid::now_v7().to_string();
         self.current_task_id = Some(task_id.clone());
@@ -1473,8 +1476,8 @@ impl App {
         );
     }
 
-    /// Record a completed `!command` run: show it, persist it, and queue it
-    /// for the agent's next turn.
+    /// Record a completed `!command` run: show it and persist it. The block is
+    /// sent to the agent by `handle_stream`'s `ShellDone` arm, not stashed.
     pub fn push_shell(&mut self, cmd: &str, output: &str) {
         let text = if output.is_empty() {
             format!("$ {cmd}")
@@ -1483,21 +1486,7 @@ impl App {
         };
         self.messages.push(ChatMsg::new(Role::Shell, text.clone()));
         self.persist_turn("shell", &text, None, &[]);
-        self.pending_shell.push(text);
         self.scroll_back = 0;
-    }
-
-    /// Drain queued `!command` blocks into a context prefix for the next
-    /// message, or `None` if there is nothing pending.
-    pub fn take_pending_shell(&mut self) -> Option<String> {
-        if self.pending_shell.is_empty() {
-            return None;
-        }
-        let blocks = self.pending_shell.join("\n\n");
-        self.pending_shell.clear();
-        Some(format!(
-            "[shell commands the user just ran locally in this chat]\n{blocks}\n[end of shell context]"
-        ))
     }
 
     pub fn load_history(&mut self, turns: Vec<TurnRecord>) {
@@ -1876,21 +1865,6 @@ mod tests {
             Some("  ✔ bash · cargo test"),
             "card must be carried separately so it can be drawn at the pane width"
         );
-    }
-
-    #[test]
-    fn shell_blocks_queue_and_drain_into_prefix() {
-        let mut a = app();
-        a.push_shell("ls", "foo\nbar");
-        a.push_shell("true", "");
-        assert_eq!(
-            a.messages.iter().filter(|m| m.role == Role::Shell).count(),
-            2
-        );
-        let ctx = a.take_pending_shell().expect("pending blocks");
-        assert!(ctx.contains("$ ls\nfoo\nbar"));
-        assert!(ctx.contains("$ true"));
-        assert!(a.take_pending_shell().is_none(), "drained");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -578,6 +578,9 @@ pub struct App {
     /// models, secret KEYs, note names. Rebuilt after every slash command;
     /// `compute` is pure, so this is where that I/O lives.
     pub menu_ctx: super::complete::MenuContext,
+    /// Executable names on `$PATH` for `!` completion. `None` until the first
+    /// `!` completion asks; scanned once per session after that.
+    pub path_bins: Option<Vec<String>>,
     /// Replies captured from a `suggest_replies` tool call this turn, revealed
     /// after the turn finishes (see `reveal_suggestions`).
     pub pending_suggestions: Vec<super::suggest::Suggestion>,
@@ -693,6 +696,7 @@ impl App {
             completion: None,
             skills: Vec::new(),
             menu_ctx: super::complete::MenuContext::default(),
+            path_bins: None,
             pending_suggestions: Vec::new(),
             suggestion_ghost: None,
             wants_screen_wipe: false,
@@ -777,6 +781,13 @@ impl App {
     }
 
     /// Current input text (joined multiline).
+    /// The `$PATH` executable list, scanned on first use.
+    pub fn path_bins(&mut self) -> &[String] {
+        self.path_bins
+            .get_or_insert_with(super::shell_complete::scan_path_bins)
+            .as_slice()
+    }
+
     /// The session half of what the settings menus mark as in force.
     pub fn current_values(&self) -> super::complete::Current {
         super::complete::Current {

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1838,30 +1838,8 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
             return;
         }
         if let Some(task_id) = app.current_task_id.clone() {
-            let (h, a) = (app.home.clone(), app.agent.clone());
-            let (msg, t) = (trimmed.clone(), tx.clone());
-            app.push_system(format!("↗ steering: {trimmed}"));
             app.clear_input();
-            tokio::spawn(async move {
-                if let Err(e) = stream::steer_turn(h, a, task_id.clone(), msg.clone()).await {
-                    let err = format!("{e:#}");
-                    let out = match recover::classify_steer_failure(&err) {
-                        // The runtime restarted (tasks live in memory only):
-                        // the steered task is gone. Drop the dead binding and
-                        // replay the user's text as a fresh turn on the same
-                        // channel so it is not lost (#713).
-                        recover::SteerFailure::TaskGone => StreamMsg::TurnLost {
-                            task_id,
-                            note: "agent restarted — continuing in this conversation".to_string(),
-                            resend: Some(msg),
-                        },
-                        recover::SteerFailure::Other => {
-                            StreamMsg::Note(format!("steer failed: {err}"))
-                        }
-                    };
-                    let _ = t.send(out).await;
-                }
-            });
+            steer_now(app, task_id, trimmed.clone(), &trimmed, tx);
         } else {
             app.push_system("still generating — press Ctrl+C to cancel first");
         }
@@ -1895,17 +1873,10 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
 /// must not be dropped silently (#714).
 fn start_turn(app: &mut App, trimmed: String, tx: &mpsc::Sender<StreamMsg>) {
     let task_id = app.begin_user_turn(&trimmed);
-    // Prefix any `!command` output the agent hasn't seen yet, so it has the
-    // same context the user is looking at. The transcript shows only the
-    // user's text; the shell blocks were already rendered when they ran.
     // The working directory is NOT prose here — it rides as `context.cwd`
     // in `build_params`, every turn.
-    let outgoing = match app.take_pending_shell() {
-        Some(ctx) => format!("{ctx}\n\n{trimmed}"),
-        None => trimmed,
-    };
     let params = build_params(
-        &outgoing,
+        &trimmed,
         &task_id,
         app.context_task_id.as_deref(),
         app.pending_image
@@ -1922,6 +1893,100 @@ fn start_turn(app: &mut App, trimmed: String, tx: &mpsc::Sender<StreamMsg>) {
         task_id,
         tx.clone(),
     );
+}
+
+/// What the agent receives for a `!cmd` run. Singular, framed, nothing else:
+/// the agent may answer with one line, and the block does not ask for more.
+fn shell_block(cmd: &str, output: &str) -> String {
+    if output.is_empty() {
+        format!("[shell command the user ran locally]\n$ {cmd}\n[end of shell output]")
+    } else {
+        format!("[shell command the user ran locally]\n$ {cmd}\n{output}\n[end of shell output]")
+    }
+}
+
+/// Where a finished `!cmd` block goes.
+#[derive(Debug)]
+enum ShellRoute {
+    /// Idle: start a turn with the block as the user's message.
+    Start,
+    /// A turn is live: steer it with the block.
+    Steer(String),
+    /// Nowhere; the note says why. The Shell card still renders.
+    Skip(&'static str),
+}
+
+/// Pure so the three routes are testable without pricing or a live agent.
+/// The budget gates a NEW turn only, exactly as `submit` does for typed text:
+/// a steer rides the turn already being paid for.
+fn route_shell_output(streaming: bool, task_id: Option<&str>, over_budget: bool) -> ShellRoute {
+    if streaming {
+        return match task_id {
+            Some(t) => ShellRoute::Steer(t.to_string()),
+            None => {
+                ShellRoute::Skip("shell output not sent — a turn is generating without a task id")
+            }
+        };
+    }
+    if over_budget {
+        return ShellRoute::Skip("↯ shell output not sent — session budget reached");
+    }
+    ShellRoute::Start
+}
+
+/// Start a turn whose transcript entry is the Shell card already pushed by
+/// `push_shell`: no User bubble, no second channel event. A staged image is
+/// left staged — it belongs to the user's next typed message.
+fn start_shell_turn(app: &mut App, block: String, tx: &mpsc::Sender<StreamMsg>) {
+    let task_id = app.begin_turn();
+    let params = build_params(
+        &block,
+        &task_id,
+        app.context_task_id.as_deref(),
+        None,
+        app.cwd.as_deref(),
+    );
+    app.inflight_params = Some(params.clone());
+    spawn_stream(
+        app.home.clone(),
+        app.agent.clone(),
+        params,
+        task_id,
+        tx.clone(),
+    );
+}
+
+/// Inject `msg` into the live turn `task_id`. `label` is what the transcript
+/// shows after "↗ steering:" — the typed text for a message, a short tag for
+/// a shell block that would otherwise fill the screen twice.
+fn steer_now(
+    app: &mut App,
+    task_id: String,
+    msg: String,
+    label: &str,
+    tx: &mpsc::Sender<StreamMsg>,
+) {
+    let (h, a) = (app.home.clone(), app.agent.clone());
+    let t = tx.clone();
+    app.push_system(format!("↗ steering: {label}"));
+    tokio::spawn(async move {
+        if let Err(e) = stream::steer_turn(h, a, task_id.clone(), msg.clone()).await {
+            let err = format!("{e:#}");
+            let out = match recover::classify_steer_failure(&err) {
+                // The runtime restarted (tasks live in memory only):
+                // the steered task is gone. Drop the dead binding and
+                // replay the text as a fresh turn on the same channel so
+                // it is not lost (#713).
+                recover::SteerFailure::TaskGone => StreamMsg::TurnLost {
+                    task_id,
+                    note: "agent restarted — continuing in this conversation".to_string(),
+                    resend: Some(msg),
+                },
+                recover::SteerFailure::Other => StreamMsg::Note(format!("steer failed: {err}")),
+            };
+            let _ = t.send(out).await;
+        }
+    });
 }
 
 async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>) {
@@ -2490,7 +2555,22 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
                 start_turn(app, text, tx);
             }
         }
-        StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),
+        StreamMsg::ShellDone { cmd, output } => {
+            app.push_shell(&cmd, &output);
+            let block = shell_block(&cmd, &output);
+            match route_shell_output(
+                app.streaming,
+                app.current_task_id.as_deref(),
+                app.over_budget(),
+            ) {
+                ShellRoute::Start => start_shell_turn(app, block, tx),
+                ShellRoute::Steer(task_id) => {
+                    let label = format!("$ {cmd} output");
+                    steer_now(app, task_id, block, &label, tx);
+                }
+                ShellRoute::Skip(why) => app.push_system(why),
+            }
+        }
         StreamMsg::StepStarted {
             step_id,
             name,
@@ -3495,6 +3575,120 @@ mod fallback_visibility_tests {
         assert!(
             a.pricing.in_per_1k.is_none(),
             "stale rates must not survive an unpriceable answer"
+        );
+    }
+}
+
+#[cfg(test)]
+mod shell_turn_tests {
+    use super::*;
+
+    #[test]
+    fn shell_output_routes_by_turn_state() {
+        assert!(matches!(
+            route_shell_output(false, None, false),
+            ShellRoute::Start
+        ));
+        assert!(
+            matches!(route_shell_output(true, Some("t1"), false), ShellRoute::Steer(ref t) if t == "t1")
+        );
+        assert!(matches!(
+            route_shell_output(true, None, false),
+            ShellRoute::Skip(_)
+        ));
+        // Budget gates a NEW turn only; a steer rides the turn already paid for.
+        assert!(matches!(
+            route_shell_output(false, None, true),
+            ShellRoute::Skip(_)
+        ));
+        assert!(matches!(
+            route_shell_output(true, Some("t1"), true),
+            ShellRoute::Steer(_)
+        ));
+    }
+
+    #[test]
+    fn shell_block_frames_command_and_output() {
+        assert_eq!(
+            shell_block("ls", "a\nb"),
+            "[shell command the user ran locally]\n$ ls\na\nb\n[end of shell output]"
+        );
+        assert_eq!(
+            shell_block("true", ""),
+            "[shell command the user ran locally]\n$ true\n[end of shell output]"
+        );
+    }
+
+    /// Idle: the block becomes the outgoing user message, the transcript keeps
+    /// the one Shell card and gains no User bubble.
+    #[tokio::test]
+    async fn shell_done_while_idle_starts_a_turn_without_a_user_bubble() {
+        let (tx, _rx) = mpsc::channel(16);
+        let mut app = App::test_fixture();
+        handle_stream(
+            &mut app,
+            StreamMsg::ShellDone {
+                cmd: "ls".into(),
+                output: "a\nb".into(),
+            },
+            &tx,
+        );
+        assert_eq!(
+            app.messages
+                .iter()
+                .filter(|m| m.role == Role::Shell)
+                .count(),
+            1
+        );
+        assert_eq!(
+            app.messages.iter().filter(|m| m.role == Role::User).count(),
+            0
+        );
+        assert!(app.streaming, "a turn started");
+        let params = app.inflight_params.clone().expect("params kept for replay");
+        let text = params["message"]["parts"][0]["text"].as_str().unwrap();
+        assert!(text.contains("$ ls\na\nb"), "{text}");
+        assert!(
+            text.starts_with("[shell command the user ran locally]"),
+            "{text}"
+        );
+    }
+
+    /// Streaming: the block steers the live turn; no second turn starts.
+    #[tokio::test]
+    async fn shell_done_while_streaming_steers_the_live_turn() {
+        let (tx, _rx) = mpsc::channel(16);
+        let mut app = App::test_fixture();
+        let before = app.begin_user_turn("working");
+        handle_stream(
+            &mut app,
+            StreamMsg::ShellDone {
+                cmd: "ls".into(),
+                output: "a".into(),
+            },
+            &tx,
+        );
+        assert_eq!(
+            app.current_task_id.as_deref(),
+            Some(before.as_str()),
+            "same turn"
+        );
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.text.contains("↗ steering: $ ls output")),
+            "{:?}",
+            app.messages
+                .iter()
+                .map(|m| m.text.clone())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            app.messages
+                .iter()
+                .filter(|m| m.role == Role::Shell)
+                .count(),
+            1
         );
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -211,7 +211,7 @@ fn help_text() -> String {
         "  agent     /mcp · /skill · /secret <KEY> [--delete] (hidden input, never enters the chat) · /login [anthropic|chatgpt] (OAuth health; not `mur auth login`)",
         "  memory    /remember <text> · /forget <name|last>",
         "  more      /panel [tab] (Hub companion window) · /help · /quit (or /exit)",
-        "  !cmd      run a local shell command (output shared with the agent)",
+        "  !cmd      run a local shell command; its output is sent to the agent as your message · Tab completes commands and paths",
         "keys        Enter send · Shift+Enter newline · Ctrl+V image · Ctrl+O transcript · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll",
         "menus       ↑↓ move · Tab accept · Esc close",
     ]
@@ -1554,14 +1554,44 @@ fn clipboard_png() -> Option<String> {
 }
 
 /// Recompute the completion menu from the current input. Called after every
-/// edit and when Tab is pressed with the menu closed.
+/// edit and when Tab is pressed with the menu closed. `/` lines get the
+/// command menu, `!` lines the shell menu, anything else none.
 fn refresh_completion(app: &mut App) {
-    app.completion = complete::compute(
-        &app.input_text(),
-        &app.skills,
-        &app.menu_ctx,
-        &app.current_values(),
+    let input = app.input_text();
+    app.completion = if input.trim_start().starts_with('!') {
+        shell_completion(app, input.trim_start())
+    } else {
+        complete::compute(&input, &app.skills, &app.menu_ctx, &app.current_values())
+    };
+}
+
+/// The shell menu for a `!` line: commands for the first word, paths after.
+/// Never marks a `current` row — a path has no value in force.
+fn shell_completion(app: &mut App, line: &str) -> Option<complete::CompletionState> {
+    let cwd = app
+        .cwd
+        .clone()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let home = dirs::home_dir();
+    let bins = app.path_bins().to_vec();
+    let items = shell_complete::candidates(
+        line,
+        &shell_complete::ShellCompleteCtx {
+            cwd: &cwd,
+            path_bins: &bins,
+            home: home.as_deref(),
+        },
     );
+    if items.is_empty() {
+        return None;
+    }
+    Some(complete::CompletionState {
+        items,
+        selected: 0,
+        spaced: false,
+        current: None,
+    })
 }
 
 /// Move the highlighted row by `delta`, wrapping.
@@ -1589,16 +1619,11 @@ fn completion_accept(app: &mut App) {
     let insert = cand.insert.clone();
     let descend = cand.has_children;
     app.set_input(&insert);
-    app.completion = if descend {
-        complete::compute(
-            &app.input_text(),
-            &app.skills,
-            &app.menu_ctx,
-            &app.current_values(),
-        )
+    if descend {
+        refresh_completion(app);
     } else {
-        None
-    };
+        app.completion = None;
+    }
 }
 
 /// Cancel the in-flight turn (if any) on a separate connection and mark the
@@ -3690,6 +3715,54 @@ mod shell_turn_tests {
                 .filter(|m| m.role == Role::Shell)
                 .count(),
             1
+        );
+    }
+
+    /// `!` lines open the shell menu through the same refresh path as `/`,
+    /// and accepting a directory keeps it open on that directory.
+    #[test]
+    fn bang_lines_get_the_shell_menu_and_directories_descend() {
+        let t = tempfile::tempdir().unwrap();
+        std::fs::create_dir(t.path().join("docs")).unwrap();
+        std::fs::write(t.path().join("docs/a.md"), "").unwrap();
+        let mut app = App::test_fixture();
+        app.cwd = Some(t.path().to_path_buf());
+        app.path_bins = Some(vec!["cargo".into(), "cat".into()]);
+
+        app.set_input("!ca");
+        refresh_completion(&mut app);
+        let items: Vec<String> = app
+            .completion
+            .as_ref()
+            .unwrap()
+            .items
+            .iter()
+            .map(|c| c.display.clone())
+            .collect();
+        assert_eq!(items, ["cargo", "cat"]);
+        assert_eq!(app.completion.as_ref().unwrap().current, None);
+
+        app.set_input("!ls ");
+        refresh_completion(&mut app);
+        assert_eq!(app.completion.as_ref().unwrap().items[0].display, "docs/");
+        completion_accept(&mut app);
+        assert_eq!(app.input_text(), "!ls docs/");
+        let inside = app
+            .completion
+            .as_ref()
+            .expect("menu stays open on a directory");
+        assert_eq!(inside.items[0].display, "a.md");
+
+        app.set_input("/skin ");
+        refresh_completion(&mut app);
+        assert!(
+            app.completion
+                .as_ref()
+                .unwrap()
+                .items
+                .iter()
+                .any(|c| c.display == "mur"),
+            "slash menu untouched"
         );
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -29,6 +29,7 @@ mod recover;
 mod render_card;
 mod secret_cmd;
 mod settlement;
+mod shell_complete;
 mod step;
 mod stream;
 mod suggest;

--- a/mur-core/src/cmd/agent/cli/shell_complete.rs
+++ b/mur-core/src/cmd/agent/cli/shell_complete.rs
@@ -1,0 +1,321 @@
+//! Completion for `!` lines in the composer: command names for the first
+//! word (from a PATH scan the caller owns and caches), cwd-relative paths for
+//! every later word. Pure over what it is handed, so the tests run on a
+//! tempdir and a literal command list.
+//!
+//! ponytail: inserted paths are not quoted. A name with a space goes in as-is
+//! and the user quotes it; escaping is the upgrade if that ever bites.
+
+// Wired into the composer by the next commit; until then nothing in the
+// binary calls it. Removed there.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use super::complete::{Candidate, MAX_MENU_ROWS};
+
+pub struct ShellCompleteCtx<'a> {
+    /// Directory relative paths resolve against (murmur's shell cwd).
+    pub cwd: &'a Path,
+    /// Executable names on `$PATH`, sorted, deduplicated.
+    pub path_bins: &'a [String],
+    /// What a leading `~` expands to. `None` leaves `~` alone.
+    pub home: Option<&'a Path>,
+}
+
+/// Split the text after `!` into the head (kept verbatim, trailing space
+/// included) and the last word (the one being completed).
+fn split_last_word(body: &str) -> (&str, &str) {
+    match body.rfind(' ') {
+        Some(i) => (&body[..=i], &body[i + 1..]),
+        None => ("", body),
+    }
+}
+
+/// Candidates for the composer line `line`, which must start with `!`.
+/// `insert` is the whole line with the last word replaced.
+pub fn candidates(line: &str, ctx: &ShellCompleteCtx<'_>) -> Vec<Candidate> {
+    if line.contains('\n') {
+        return Vec::new();
+    }
+    let Some(body) = line.strip_prefix('!') else {
+        return Vec::new();
+    };
+    let body = body.trim_start();
+    let (head, word) = split_last_word(body);
+    let mut out = if head.is_empty() {
+        command_candidates(word, ctx.path_bins)
+    } else {
+        path_candidates(word, ctx)
+    };
+    out.truncate(MAX_MENU_ROWS);
+    for c in &mut out {
+        c.insert = format!("!{head}{}", c.insert);
+    }
+    out
+}
+
+/// First word: command names by prefix. An empty prefix offers nothing —
+/// eight of two thousand commands is noise, not help.
+fn command_candidates(word: &str, bins: &[String]) -> Vec<Candidate> {
+    if word.is_empty() {
+        return Vec::new();
+    }
+    bins.iter()
+        .filter(|b| b.starts_with(word))
+        .map(|b| Candidate {
+            display: b.clone(),
+            insert: format!("{b} "),
+            desc: String::new(),
+            has_children: false,
+        })
+        .collect()
+}
+
+/// A later word: entries of the word's directory, by file-name prefix.
+/// Directories first with a trailing `/` and `has_children`, so accepting one
+/// keeps the menu open on its contents.
+fn path_candidates(word: &str, ctx: &ShellCompleteCtx<'_>) -> Vec<Candidate> {
+    let (dir_part, name_part) = match word.rfind('/') {
+        Some(i) => (&word[..=i], &word[i + 1..]),
+        None => ("", word),
+    };
+    let dir_fs = resolve_dir(dir_part, ctx);
+    let Ok(rd) = std::fs::read_dir(&dir_fs) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<(bool, String)> = rd
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            if !name.starts_with(name_part) {
+                return None;
+            }
+            if name.starts_with('.') && !name_part.starts_with('.') {
+                return None;
+            }
+            // `path().is_dir()` follows symlinks; `file_type()` would not.
+            Some((e.path().is_dir(), name))
+        })
+        .collect();
+    // Directories first, then by name.
+    entries.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    entries
+        .into_iter()
+        .map(|(is_dir, name)| Candidate {
+            display: if is_dir {
+                format!("{name}/")
+            } else {
+                name.clone()
+            },
+            insert: format!("{dir_part}{name}{}", if is_dir { "/" } else { " " }),
+            desc: String::new(),
+            has_children: is_dir,
+        })
+        .collect()
+}
+
+/// The directory `dir_part` (`""`, `src/`, `~/x/`, `/abs/`) names on disk.
+fn resolve_dir(dir_part: &str, ctx: &ShellCompleteCtx<'_>) -> PathBuf {
+    if dir_part.is_empty() {
+        return ctx.cwd.to_path_buf();
+    }
+    let expanded: PathBuf = match (dir_part.strip_prefix("~/"), ctx.home) {
+        (Some(rest), Some(home)) => home.join(rest),
+        _ => PathBuf::from(dir_part),
+    };
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        ctx.cwd.join(expanded)
+    }
+}
+
+/// Every executable file name on `$PATH`, sorted and deduplicated. Scanned
+/// once per session by the caller; a new install needs a new murmur, the
+/// same as a new shell.
+pub fn scan_path_bins() -> Vec<String> {
+    let Some(path) = std::env::var_os("PATH") else {
+        return Vec::new();
+    };
+    let mut set = std::collections::BTreeSet::new();
+    for dir in std::env::split_paths(&path) {
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            if is_executable_file(&p) {
+                set.insert(e.file_name().to_string_lossy().into_owned());
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+#[cfg(unix)]
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(windows)]
+fn is_executable_file(p: &Path) -> bool {
+    p.is_file()
+        && p.extension().and_then(|e| e.to_str()).is_some_and(|e| {
+            matches!(
+                e.to_ascii_lowercase().as_str(),
+                "exe" | "cmd" | "bat" | "com"
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// tempdir with: dirs `docs/`, `src/` (holding `main.rs`); files
+    /// `Cargo.toml`, `README.md`, `.hidden`.
+    fn tree() -> tempfile::TempDir {
+        let t = tempfile::tempdir().unwrap();
+        std::fs::create_dir(t.path().join("docs")).unwrap();
+        std::fs::create_dir(t.path().join("src")).unwrap();
+        std::fs::write(t.path().join("src/main.rs"), "").unwrap();
+        std::fs::write(t.path().join("Cargo.toml"), "").unwrap();
+        std::fs::write(t.path().join("README.md"), "").unwrap();
+        std::fs::write(t.path().join(".hidden"), "").unwrap();
+        t
+    }
+
+    fn bins() -> Vec<String> {
+        ["cargo", "cat", "ls"].map(String::from).to_vec()
+    }
+
+    fn ctx<'a>(t: &'a tempfile::TempDir, bins: &'a [String]) -> ShellCompleteCtx<'a> {
+        ShellCompleteCtx {
+            cwd: t.path(),
+            path_bins: bins,
+            home: Some(t.path()),
+        }
+    }
+
+    fn inserts(v: &[Candidate]) -> Vec<String> {
+        v.iter().map(|c| c.insert.clone()).collect()
+    }
+
+    #[test]
+    fn first_word_completes_command_names_by_prefix() {
+        let t = tree();
+        let b = bins();
+        assert_eq!(
+            inserts(&candidates("!ca", &ctx(&t, &b))),
+            ["!cargo ", "!cat "]
+        );
+        assert!(
+            candidates("!", &ctx(&t, &b)).is_empty(),
+            "no prefix, no list"
+        );
+        assert!(candidates("!zz", &ctx(&t, &b)).is_empty());
+    }
+
+    #[test]
+    fn later_words_list_the_cwd_directories_first_with_a_slash() {
+        let t = tree();
+        let b = bins();
+        let out = candidates("!ls ", &ctx(&t, &b));
+        assert_eq!(
+            inserts(&out),
+            ["!ls docs/", "!ls src/", "!ls Cargo.toml ", "!ls README.md "]
+        );
+        assert!(out[0].has_children && !out[2].has_children);
+        assert_eq!(out[0].display, "docs/");
+    }
+
+    #[test]
+    fn hidden_entries_only_when_the_prefix_starts_with_a_dot() {
+        let t = tree();
+        let b = bins();
+        assert!(
+            candidates("!ls ", &ctx(&t, &b))
+                .iter()
+                .all(|c| !c.display.starts_with('.'))
+        );
+        assert_eq!(
+            inserts(&candidates("!ls .", &ctx(&t, &b))),
+            ["!ls .hidden "]
+        );
+    }
+
+    #[test]
+    fn descends_into_a_directory_and_keeps_the_head() {
+        let t = tree();
+        let b = bins();
+        assert_eq!(
+            inserts(&candidates("!cat src/", &ctx(&t, &b))),
+            ["!cat src/main.rs "]
+        );
+        assert_eq!(
+            inserts(&candidates("!cat -n src/m", &ctx(&t, &b))),
+            ["!cat -n src/main.rs "]
+        );
+    }
+
+    #[test]
+    fn tilde_expands_to_home() {
+        let t = tree();
+        let b = bins();
+        assert_eq!(
+            inserts(&candidates("!ls ~/d", &ctx(&t, &b))),
+            ["!ls ~/docs/"]
+        );
+    }
+
+    #[test]
+    fn an_absolute_directory_is_used_as_is() {
+        let t = tree();
+        let b = bins();
+        let abs = format!("!ls {}/s", t.path().display());
+        let out = candidates(&abs, &ctx(&t, &b));
+        assert_eq!(out.len(), 1);
+        assert!(out[0].insert.ends_with("/src/"), "{}", out[0].insert);
+    }
+
+    #[test]
+    fn the_list_is_capped_and_multiline_input_has_none() {
+        let t = tree();
+        let b = bins();
+        for i in 0..12 {
+            std::fs::write(t.path().join(format!("f{i:02}")), "").unwrap();
+        }
+        assert_eq!(candidates("!ls f", &ctx(&t, &b)).len(), MAX_MENU_ROWS);
+        assert!(candidates("!ls\nf", &ctx(&t, &b)).is_empty());
+        assert!(candidates("ls f", &ctx(&t, &b)).is_empty(), "no leading !");
+    }
+
+    #[test]
+    fn scan_path_bins_reads_the_env_path() {
+        let t = tempfile::tempdir().unwrap();
+        let exe = t.path().join("mytool");
+        std::fs::write(&exe, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        std::fs::write(t.path().join("notes.txt"), "").unwrap();
+        // Process-wide env: this test owns PATH for its duration.
+        let saved = std::env::var_os("PATH");
+        unsafe { std::env::set_var("PATH", t.path()) };
+        let bins = scan_path_bins();
+        unsafe {
+            match saved {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        #[cfg(unix)]
+        assert_eq!(bins, ["mytool"]);
+        #[cfg(windows)]
+        assert!(bins.is_empty(), "no .exe in the dir");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/shell_complete.rs
+++ b/mur-core/src/cmd/agent/cli/shell_complete.rs
@@ -6,10 +6,6 @@
 //! ponytail: inserted paths are not quoted. A name with a space goes in as-is
 //! and the user quotes it; escaping is the upgrade if that ever bites.
 
-// Wired into the composer by the next commit; until then nothing in the
-// binary calls it. Removed there.
-#![allow(dead_code)]
-
 use std::path::{Path, PathBuf};
 
 use super::complete::{Candidate, MAX_MENU_ROWS};


### PR DESCRIPTION
Executes `docs/superpowers/plans/2026-09-11-murmur-bang-turn-and-shell-completion-plan.md` (spec + plan merged in #1259). Three commits, one per task.

## What changes

**`379adb81` — a `!cmd`'s output is the user's next turn.** Claude Code's `!` shape: the block goes out as soon as the command finishes. Idle starts a turn, a live turn is steered, over budget notes and keeps the Shell card. The next-message stash (`App::pending_shell`) and the prefix it added to typed messages are deleted — a typed message is now exactly what the user typed.

- `App::begin_turn` split out of `begin_user_turn`: same turn setup, no User bubble and no second channel event, because the Shell card is already the transcript entry.
- `route_shell_output(streaming, task_id, over_budget)` is pure, so the three routes are tested without pricing or a live agent. The budget gates a NEW turn only; a steer rides the turn already paid for.
- `steer_now` extracted from `submit`, so the typed-message steer and the shell steer are one code path with different transcript labels.

**`de723314` — `shell_complete.rs`.** Pure over a cwd, a command list and a home. First word completes PATH command names, later words complete paths: directories first with a trailing `/` and `has_children`, hidden entries only behind a leading dot, `~` expanded, capped at `MAX_MENU_ROWS`.

**`8f44f5d3` — wiring.** `refresh_completion` dispatches on the first character; `completion_accept` reuses it, so accepting a directory descends through the existing `has_children` path. PATH is scanned once per session into `App::path_bins`. `/help` says `!cmd` output goes to the agent and that Tab completes.

## Test plan
- [x] `shell_turn_tests`: routing table, block framing, idle starts a turn with no User bubble, streaming steers the same turn, `!` menu + directory descent + slash menu untouched
- [x] `shell_complete` 8 unit tests on a tempdir
- [x] whole `cmd::agent::cli` module: 376 pass; `clippy --all-targets -D warnings`; `fmt --check`
- [ ] Real terminal after `build.sh --install`: `!ls` idle → agent replies to the listing; `!ls` mid-reply → `↗ steering: $ ls output`; `!ca<Tab>`, `!ls <Tab>`, Tab on a directory descends

Docs (README, docs-site agent-cli) follow via the `update-docs` skill after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)