### PR TITLE
chore(release): bump workspace version to 2.78.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.77.5"
+version = "2.78.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.77.5"
+version = "2.78.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release 2.78.0. Merging this PR tags `v2.78.0` and dispatches `release.yml` — this is the release approval.

## Since 2.77.5

**murmur**
- `!cmd` output is the user's next turn, and `!` lines get live shell completion — commands then paths (#1260)
- Settings menus (`/model`, `/effort`, `/skin`, `/auto`, `/verbose`) mark the value in force (#1255)
- `/help` laid out as grouped rows; the skin list is generated, so it can no longer go stale (#1256)
- New `clay` skin: warm terracotta on dark (#1254)
- The SETTLEMENT card is unmistakable on every skin — badge chip title with ✔/✘/⚠ counts and an accent rail (#1253)
- An image-bearing message is held instead of steering with it, so the image is never dropped (#1252)

**deep research**
- Preflight never re-pins a running worker, and an unchanged pin writes nothing — an agent-triggered `mur deep-research` no longer dies on a sibling's `profile.yaml` (#1251)

**Hub**
- Fleet job counts and agent unread badges refresh while the page stays open (#1257, #1258)

🤖 Generated with [Claude Code](https://claude.com/claude-code)