### PR TITLE
fix(update): stop the 120s request timeout from killing a 152 MB download

### DIFF
--- a/mur-core/src/update/mod.rs
+++ b/mur-core/src/update/mod.rs
@@ -86,9 +86,18 @@ pub fn run(opts: UpdateOptions) -> Result<()> {
     })?;
     let asset = release::select_asset(&release, asset_name)?;
 
+    // A total-request timeout is a throughput floor, and the release tarball
+    // is 150 MB and growing: 120 s total demanded 1.3 MB/s or the download
+    // died with "operation timed out" (seen twice on 2.78.0 while curl pulled
+    // the same asset fine at 2.6 MB/s). `reqwest::blocking` has no idle-read
+    // timeout, so the ceiling has to cover the whole body: 30 min is ~85 kB/s
+    // on today's asset — slow enough to be generous, bounded enough that a
+    // wedged connection cannot hang the CLI forever. `connect_timeout` keeps
+    // an unreachable host failing fast, which is the common case.
     let client = reqwest::blocking::Client::builder()
         .user_agent(concat!("mur-update/", env!("CARGO_PKG_VERSION")))
-        .timeout(std::time::Duration::from_secs(120))
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(1800))
         .build()?;
 
     println!("Downloading {asset_name}…");


### PR DESCRIPTION
## The bug
`mur update` built its HTTP client with reqwest's **total request timeout** at 120 s. That covers the whole body read, so it is a throughput floor: `mur-aarch64-apple-darwin.tar.gz` is 152,643,389 bytes, which demands 1.3 MB/s sustained or the download dies with `error decoding response body: operation timed out`.

Reproduced upgrading 2.77.5 → 2.78.0 on a normal connection: **three attempts, each failing at 2:03**, while `curl` pulled the same asset in 59 s at 2.6 MB/s. The floor rises with every byte the tarball gains, so this is on its way from flaky to certain.

## The fix
- `connect_timeout(30s)` — an unreachable host still fails fast, which is the case the old 120 s was really serving.
- Total ceiling raised to 30 min. `reqwest::blocking` has no idle-read timeout, so the ceiling must cover the whole body; 30 min is ~85 kB/s on today's asset — generous for a slow link, bounded enough that a wedged connection cannot hang the CLI.

## Test plan
- [x] `cargo check -p mur-core --lib`, `clippy --all-targets -D warnings`, `fmt --check`
- [ ] Cannot be tested against the fix itself until the next release ships it — the timeout only bites on a real >100 MB download. Verified the diagnosis instead: the failure is at exactly the configured 120 s, three times, and curl succeeds on the same URL.

Recovery for anyone stuck on this today: `curl` the tarball and `checksums.txt` from the release, verify the sha256, extract, and `mv` (not `cp`) each binary into `~/.local/bin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)