### PR TITLE
fix(agent): report and repair launchers pinned to a runtime nobody refreshes

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -366,6 +366,11 @@ pub enum AgentAction {
         /// Emit JSON array instead of human text
         #[arg(long)]
         json: bool,
+        /// Re-point launchers that resolve to a runtime no installer refreshes
+        /// (a Homebrew keg copy). Changes which binary the next start runs, so
+        /// it never happens without this flag.
+        #[arg(long)]
+        fix: bool,
     },
     /// Install missing curated program dependencies for this agent (consent-gated)
     #[command(name = "install-deps")]

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -139,7 +139,7 @@ fn probe_volumes(path: &std::path::Path) -> std::io::Result<()> {
 /// Enumerates all agents that have a `running.lock`, compares each one's
 /// recorded `build_sha` against the on-disk runtime binary, and reports
 /// which ones are stale.  Exits non-zero when at least one agent is stale.
-pub fn cmd_doctor(json: bool) -> Result<()> {
+pub fn cmd_doctor(json: bool, fix: bool) -> Result<()> {
     let mur_home = resolve_mur_home()?;
     let agents_dir = mur_home.join("agents");
 
@@ -269,6 +269,32 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                 );
             } else {
                 println!("{}: running, current", r.name);
+            }
+            // A launcher into the keg is why an agent can be "current" and
+            // still never upgrade: the keg copy is a path no installer
+            // refreshes, and on macOS a Full Disk Access grant on the
+            // canonical path never applies because TCC keys on the binary
+            // actually executed (#1247).
+            if let Some(d) = stale::link_drift(&r.name) {
+                println!(
+                    "  launcher runs {} \u{2192} no installer refreshes that path",
+                    d.points_at.display()
+                );
+                if fix {
+                    match stale::repoint(&r.name) {
+                        Ok(now) => println!(
+                            "  re-pointed at {} \u{2192} run 'mur agent restart {}'",
+                            now.display(),
+                            r.name
+                        ),
+                        Err(e) => println!("  could not re-point: {e:#}"),
+                    }
+                } else {
+                    println!(
+                        "  fix with: mur agent runtime-doctor --fix && mur agent restart {}",
+                        r.name
+                    );
+                }
             }
             for (kind, p) in dead(&r.name) {
                 println!(

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -98,6 +98,79 @@ pub fn is_stale(lock: &LockFile, on_disk: &str) -> bool {
     }
 }
 
+/// Where an agent's launcher symlink resolves, when that is not the canonical
+/// runtime in the same bin dir.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkDrift {
+    /// What `mur_agent_<name>` actually resolves to today.
+    pub points_at: PathBuf,
+    /// `<bin_dir>/mur-agent-runtime` — the copy every installer refreshes.
+    pub canonical: PathBuf,
+}
+
+/// Report an agent whose launcher points somewhere other than the canonical
+/// runtime beside it, given an explicit `bin_dir` (the testable core).
+///
+/// `None` when there is nothing to say: no launcher yet, no canonical copy to
+/// point at, or the launcher already resolves to it. Both sides are resolved
+/// through symlinks before comparing, because the Homebrew path is itself a
+/// symlink into the versioned keg — comparing the literal link targets would
+/// call two names for the same file a drift.
+///
+/// Why this matters beyond tidiness: a launcher pinned into the keg is a path
+/// no installer refreshes, so the agent silently never upgrades, and on macOS
+/// a Full Disk Access grant on the sensible path never applies because TCC
+/// keys on the binary actually executed (issue #1247).
+pub fn link_drift_in(bin_dir: &Path, agent: &str) -> Option<LinkDrift> {
+    let link = bin_dir.join(format!("mur_agent_{agent}"));
+    link.symlink_metadata().ok()?;
+    let canonical = bin_dir.join(if cfg!(windows) {
+        "mur-agent-runtime.exe"
+    } else {
+        "mur-agent-runtime"
+    });
+    let canonical_real = std::fs::canonicalize(&canonical).ok()?;
+    let points_at = std::fs::canonicalize(&link).ok()?;
+    (points_at != canonical_real).then_some(LinkDrift {
+        points_at,
+        canonical,
+    })
+}
+
+/// Point `agent`'s launcher back at the canonical runtime in `bin_dir`.
+///
+/// Replaces the link rather than editing it in place, and returns the path it
+/// now names. The caller decides when this runs: re-pointing changes which
+/// binary the next start executes, which is a trust boundary, so it never
+/// happens without the user asking.
+pub fn repoint_in(bin_dir: &Path, agent: &str) -> std::io::Result<PathBuf> {
+    let link = bin_dir.join(format!("mur_agent_{agent}"));
+    let canonical = bin_dir.join(if cfg!(windows) {
+        "mur-agent-runtime.exe"
+    } else {
+        "mur-agent-runtime"
+    });
+    if link.symlink_metadata().is_ok() {
+        std::fs::remove_file(&link)?;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&canonical, &link)?;
+    #[cfg(windows)]
+    std::fs::copy(&canonical, &link)?;
+    Ok(canonical)
+}
+
+/// [`link_drift_in`] against the installed bin dir.
+pub fn link_drift(agent: &str) -> Option<LinkDrift> {
+    link_drift_in(&resolve_bin_dir().ok()?, agent)
+}
+
+/// [`repoint_in`] against the installed bin dir.
+pub fn repoint(agent: &str) -> anyhow::Result<PathBuf> {
+    let dir = resolve_bin_dir()?;
+    Ok(repoint_in(&dir, agent)?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,5 +221,55 @@ mod tests {
     fn is_stale_empty_lock_sha_with_known_on_disk_is_true() {
         let lock = make_lock("");
         assert!(is_stale(&lock, "abc123def456"));
+    }
+
+    /// #1247: a launcher pinned into the keg is a path no installer refreshes,
+    /// so the agent never upgrades and a TCC grant on the canonical path never
+    /// applies. Report it, and repair only when asked.
+    #[test]
+    fn link_drift_is_reported_only_when_there_is_somewhere_better_to_point() {
+        let t = tempfile::tempdir().unwrap();
+        let bin = t.path().join("bin");
+        let keg = t.path().join("keg");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&keg).unwrap();
+        let keg_rt = keg.join("mur-agent-runtime");
+        std::fs::write(&keg_rt, b"old").unwrap();
+
+        // A launcher into the keg, with no canonical copy yet: nothing better
+        // to point at, so nothing to report.
+        let link = bin.join("mur_agent_qa");
+        std::os::unix::fs::symlink(&keg_rt, &link).unwrap();
+        assert_eq!(link_drift_in(&bin, "qa"), None, "no canonical copy yet");
+
+        // Canonical copy lands (an install or `mur update`): now it is drift.
+        let canonical = bin.join("mur-agent-runtime");
+        std::fs::write(&canonical, b"new").unwrap();
+        let d = link_drift_in(&bin, "qa").expect("drift reported");
+        assert_eq!(d.points_at, std::fs::canonicalize(&keg_rt).unwrap());
+        assert_eq!(d.canonical, canonical);
+
+        // Repair, then silence.
+        let now = repoint_in(&bin, "qa").unwrap();
+        assert_eq!(now, canonical);
+        assert_eq!(link_drift_in(&bin, "qa"), None, "repaired");
+
+        // An agent with no launcher at all is not drift.
+        assert_eq!(link_drift_in(&bin, "nobody"), None);
+    }
+
+    /// The Homebrew path is itself a symlink into the versioned keg, so two
+    /// names for one file must not read as drift.
+    #[test]
+    fn two_names_for_the_same_file_are_not_drift() {
+        let t = tempfile::tempdir().unwrap();
+        let bin = t.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let canonical = bin.join("mur-agent-runtime");
+        std::fs::write(&canonical, b"rt").unwrap();
+        let alias = t.path().join("alias-runtime");
+        std::os::unix::fs::symlink(&canonical, &alias).unwrap();
+        std::os::unix::fs::symlink(&alias, bin.join("mur_agent_qa")).unwrap();
+        assert_eq!(link_drift_in(&bin, "qa"), None, "same file, different name");
     }
 }

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -226,6 +226,9 @@ mod tests {
     /// #1247: a launcher pinned into the keg is a path no installer refreshes,
     /// so the agent never upgrades and a TCC grant on the canonical path never
     /// applies. Report it, and repair only when asked.
+    /// Unix-only: the fixture needs real symlinks, which is also the only shape
+    /// this bug takes — on Windows the launcher is a copy, not a link.
+    #[cfg(unix)]
     #[test]
     fn link_drift_is_reported_only_when_there_is_somewhere_better_to_point() {
         let t = tempfile::tempdir().unwrap();
@@ -260,6 +263,8 @@ mod tests {
 
     /// The Homebrew path is itself a symlink into the versioned keg, so two
     /// names for one file must not read as drift.
+    /// Unix-only for the same reason: the fixture builds a symlink chain.
+    #[cfg(unix)]
     #[test]
     fn two_names_for_the_same_file_are_not_drift() {
         let t = tempfile::tempdir().unwrap();

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -2054,7 +2054,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             Some(name) => cmd::doctor::run_agent(&name, json)?,
             None => cmd::doctor::run(&format, json)?,
         },
-        AgentAction::RuntimeDoctor { json } => cmd::agent::cmd_doctor(json)?,
+        AgentAction::RuntimeDoctor { json, fix } => cmd::agent::cmd_doctor(json, fix)?,
         AgentAction::InstallDeps { name, program, yes } => {
             let mur_home = cmd::agent::resolve_mur_home()?;
             let deps = cmd::deps::aggregate_agent(&mur_home, &name)?;

--- a/mur-core/src/update/resign.rs
+++ b/mur-core/src/update/resign.rs
@@ -40,6 +40,7 @@ pub fn post_upgrade(restart_agents: bool, fresh_runtime: Option<&std::path::Path
 
     let daemon_running = crate::cmd::murmurd::murmurd_running();
     print_checklist(restart_agents, daemon_running);
+    warn_pinned_launchers();
 
     let agents_result = if restart_agents {
         crate::cmd::agent::restart_stale_excluding(&restart_exclusions())
@@ -91,6 +92,38 @@ fn restart_exclusions() -> Vec<String> {
 /// to re-pin MCP servers after an upgrade is gone on purpose: the bundled
 /// server re-pins itself at agent start (`mur-agent-runtime/src/mcp_repin.rs`,
 /// #793) and third-party pins cover binaries an upgrade never touches.
+/// Name the agents whose launcher resolves to a runtime this upgrade did not
+/// touch — a Homebrew keg copy, typically — and say how to repair it.
+///
+/// Reports only. Re-pointing a launcher changes which binary the next start
+/// executes, and on macOS it moves which path a Full Disk Access grant has to
+/// name (#1247), so it waits for `runtime-doctor --fix` rather than happening
+/// inside an upgrade the user asked for something else.
+fn warn_pinned_launchers() {
+    let Ok(home) = crate::cmd::resolve_mur_home() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(home.join("agents")) else {
+        return;
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| crate::cmd::agent::stale::link_drift(n).is_some())
+        .collect();
+    if names.is_empty() {
+        return;
+    }
+    names.sort();
+    println!();
+    println!(
+        "note: {} agent(s) launch a runtime this upgrade did not touch: {}",
+        names.len(),
+        names.join(", ")
+    );
+    println!("      repair with: mur agent runtime-doctor --fix");
+}
+
 fn print_checklist(restart_agents: bool, daemon_running: bool) {
     if restart_agents {
         return;


### PR DESCRIPTION
Closes #1247.

## The bug
`mur agent create` already prefers `<bin_dir>/mur-agent-runtime`, but an agent created before that copy existed got a launcher into the Homebrew keg — and **nothing ever moves it back**:

- `mur update`'s `post_upgrade` restarts stale agents; it never re-points them.
- `runtime-doctor` uses the launcher's target as the per-agent baseline, so it reports such an agent **"current"** — current with a keg copy no installer refreshes.

On macOS this also silently revokes Full Disk Access: TCC keys on the binary actually executed, so a grant on the canonical path never applies. The user sees `Operation not permitted` on a volume that worked yesterday, while `perm list-paths` prints ✓.

## The change
- `stale::link_drift_in(bin_dir, agent)` — pure, tempdir-testable. Both sides resolved through symlinks (the Homebrew path is itself a symlink into the versioned keg, so two names for one file must not read as drift). Silent when there is no launcher, or no canonical copy to point at.
- `stale::repoint_in` — replaces the link.
- `runtime-doctor` prints the real path and the fix; `--fix` performs it.
- `mur update` names the affected agents and stops. Re-pointing changes which binary the next start runs and which path a TCC grant must name, so it waits to be asked rather than happening inside an upgrade requested for something else.

## Test plan
- [x] `link_drift_is_reported_only_when_there_is_somewhere_better_to_point` — no canonical copy → silent; copy lands → drift with the keg path; repoint → silent; no launcher → silent
- [x] `two_names_for_the_same_file_are_not_drift`
- [x] 105 stale/doctor/update tests pass; `clippy --all-targets -D warnings`; `fmt --check`
- [x] **Live on a real install**: flipped `mur_agent_aura` into the keg → doctor named the exact keg path and the fix → `--fix` re-pointed it → report went quiet, machine restored. The flipped agent also showed the false-verdict half of the bug: it read as `STALE` against the keg binary and returned to `current` once re-pointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)