### PR TITLE
fix(delegate): a delegated turn declares it cannot answer an approval

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
+++ b/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
@@ -154,15 +154,20 @@ impl MethodHandler for ChannelDelegateHandler {
             .and_then(|c| c.get("task_id"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // Minted here when the caller did not supply one, because the turn has
+        // to be marked unattended BEFORE it runs and the mark is keyed by task
+        // id. `run_sync` honours a supplied id, so this is the same id the
+        // reply carries.
         let task_id = p
             .get("task_id")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
         let spec = TaskSpec {
             cwd: None,
             input: message,
             context_task_id,
-            task_id,
+            task_id: Some(task_id.clone()),
             // A fleet's shared channel is `fleet-<name>`; derive (and verify
             // membership of) the active fleet so the runtime injects only this
             // agent's own fleet's fleet-scoped skills. Untrusted/non-member/
@@ -180,9 +185,17 @@ impl MethodHandler for ChannelDelegateHandler {
             output_artifact_path: None,
         };
 
+        // Synchronous is not attended: the caller is a fleet router waiting on
+        // a reply, not a human who can answer an approval prompt. Say so before
+        // the turn runs, or a gated tool waits out `hitl.timeout_secs` against
+        // a notifier nobody reads and the turn returns empty with nothing
+        // naming approval as the cause.
+        self.runner.mark_unattended(&task_id).await;
+
         // Run the turn (non-streaming path; v3d-2 does not need per-delta
         // forwarding for delegated specialist replies).
         let outcome = self.runner.run_sync(spec).await;
+        self.runner.unregister_client_notifier(&task_id).await;
         // Only a Completed turn carries a genuine agent reply (`messages` =
         // [input, reply]); Failed/Cancelled tasks carry only the user input, so
         // appending their "last message" would sign the user's own text as the
@@ -228,6 +241,112 @@ impl MethodHandler for ChannelDelegateHandler {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    struct NeverRunsTool {
+        ran: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::ToolExecutor for NeverRunsTool {
+        fn name(&self) -> &str {
+            "bash"
+        }
+        fn def(&self) -> crate::llm::ToolDef {
+            crate::llm::ToolDef {
+                name: "bash".into(),
+                description: "test tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
+            self.ran.store(true, std::sync::atomic::Ordering::Relaxed);
+            Ok(crate::tools::ToolOutput {
+                text: "ran".into(),
+                status: crate::tools::ToolStatus::Ok,
+                images: Vec::new(),
+            })
+        }
+    }
+
+    /// The wiring, not the flag: `channel/delegate` must MARK its turn
+    /// unattended, not merely be capable of it.
+    ///
+    /// The signal is time. The runner below has an agent-wide notifier and a
+    /// 600 s approval timeout, so an unmarked turn parks on that notifier for
+    /// ten minutes — which is the bug as users met it: a delegated step that
+    /// returns empty with nothing naming approval. Marked, the gate answers
+    /// before a prompt is ever built, so the whole call finishes inside the
+    /// two-second budget here.
+    #[tokio::test]
+    async fn a_delegated_turn_marks_itself_unattended() {
+        let tmp = TempDir::new().unwrap();
+        let ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let tool_call = crate::llm::LlmResponse {
+            text: String::new(),
+            input_tokens: 1,
+            output_tokens: 1,
+            model: "test".into(),
+            tool_calls: vec![crate::llm::ToolCallResult {
+                call_id: "c-1".into(),
+                tool_name: "bash".into(),
+                input: serde_json::json!({"command": "echo hi"}),
+            }],
+            stop_reason: crate::llm::StopReason::ToolUse,
+        };
+        let done = crate::llm::LlmResponse {
+            text: "DONE".into(),
+            input_tokens: 1,
+            output_tokens: 1,
+            model: "test".into(),
+            tool_calls: vec![],
+            stop_reason: crate::llm::StopReason::EndTurn,
+        };
+        // A notifier nobody reads: exactly the shape that turned the missing
+        // mark into a ten-minute wait instead of an immediate refusal.
+        let (ntx, _nrx) = tokio::sync::mpsc::channel(8);
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(crate::llm::stub::SequenceLlm::new(vec![
+                tool_call, done,
+            ])))
+            .with_tools(vec![Arc::new(NeverRunsTool { ran: ran.clone() })])
+            .with_tools_policy(vec![mur_common::agent::ToolRule {
+                pattern: "bash".into(),
+                policy: mur_common::agent::ToolPolicy::Ask,
+                risk: None,
+            }])
+            .with_pending_approvals(Arc::new(tokio::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )))
+            .with_notifier(ntx)
+            .with_hitl_timeout_secs(600),
+        );
+        let handler = ChannelDelegateHandler::new(
+            runner,
+            Arc::new(AgentIdentity::generate()),
+            "specialist".into(),
+            1,
+            tmp.path().to_path_buf(),
+        );
+        let params = serde_json::json!({
+            "channel_id": "fleet-nope",
+            "message": {"role": "user", "parts": [{"kind": "text", "text": "go"}]},
+        });
+
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            handler.handle(Some(params), &RequestContext::none()),
+        )
+        .await
+        .expect("must not park on an approval nobody can answer");
+        assert!(out.is_ok(), "the turn still returns a Task: {out:?}");
+        assert!(
+            !ran.load(std::sync::atomic::Ordering::Relaxed),
+            "the gated tool must not execute"
+        );
+    }
 
     #[test]
     fn append_self_reply_is_signed_by_the_specialist() {

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -817,6 +817,30 @@ impl TaskRunner {
             .insert(task_id.to_string(), (tx, can_approve));
     }
 
+    /// Declare that nobody can answer an approval prompt for this turn.
+    ///
+    /// A delegated turn (`channel/delegate`) is synchronous — a fleet router is
+    /// waiting on the reply — but "synchronous" is not "attended": the caller
+    /// is a program. Registering nothing left the gate with no routed entry, so
+    /// it fell through to asking and waited out `hitl.timeout_secs` against the
+    /// agent-wide notifier that nobody was reading. The turn then returned with
+    /// no agent message and nothing naming approval as the cause.
+    ///
+    /// The sink here is never written to: with `can_approve: false` every
+    /// `Ask` call is decided by `decide_without_asking` before a prompt is
+    /// built, so `pending` is always empty and the gate never runs. It exists
+    /// only because the flag lives beside a sender in the same map.
+    pub async fn mark_unattended(&self, task_id: &str) {
+        // The receiver is dropped immediately: a send on this sink returns
+        // `Err`, which is the correct fail-closed answer if a future change
+        // ever routes a prompt here, and leaks nothing.
+        let (tx, _) = tokio::sync::mpsc::channel(1);
+        self.client_notifiers
+            .lock()
+            .await
+            .insert(task_id.to_string(), (tx, false));
+    }
+
     /// Drop the per-turn HITL sink once the turn completes.
     pub async fn unregister_client_notifier(&self, task_id: &str) {
         self.client_notifiers.lock().await.remove(task_id);
@@ -5058,6 +5082,57 @@ mod tests {
             sys.contains("mur skill install"),
             "names the register command"
         );
+    }
+
+    /// A delegated turn has no human on the other end: the fleet router that
+    /// dialled `channel/delegate` is a program waiting on a reply, not someone
+    /// who can answer an approval prompt. Before this it registered nothing, so
+    /// the gate fell through to asking and burned the whole `hitl.timeout_secs`
+    /// on an agent-wide notifier nobody was reading — the turn came back empty
+    /// with approval never named as the cause.
+    #[tokio::test]
+    async fn an_unattended_turn_is_refused_at_once_with_a_readable_reason() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let runner = Arc::new(
+            TaskRunner::new_stub_echo()
+                .with_tools(vec![Arc::new(CountingBashTool {
+                    calls: calls.clone(),
+                })])
+                .with_tools_policy(vec![mur_common::agent::ToolRule {
+                    pattern: "bash".into(),
+                    policy: mur_common::agent::ToolPolicy::Ask,
+                    risk: None,
+                }]),
+        );
+        let call = crate::llm::ToolCallResult {
+            call_id: "c-1".into(),
+            tool_name: "bash".into(),
+            input: serde_json::json!({"command": "echo hi"}),
+        };
+
+        // Marked unattended → the readable refusal, before any prompt is sent.
+        runner.mark_unattended("t-delegated").await;
+        let (out, _) = runner
+            .gate_response("t-delegated", std::slice::from_ref(&call))
+            .await;
+        let d = out.get("c-1").expect("a decision for the gated call");
+        assert!(!d.allow);
+        let why = d.reason.clone().unwrap_or_default();
+        assert!(why.contains("bash"), "must name the tool: {why}");
+        assert!(why.contains("tool-allow"), "must name the way out: {why}");
+        assert_eq!(calls.load(Ordering::Relaxed), 0, "nothing may execute");
+
+        // Negative control: an unmarked turn takes the old no-sink path, whose
+        // refusal names neither the tool nor a remedy. If this ever matches the
+        // assertions above, the test has stopped distinguishing the two paths.
+        let (out, _) = runner
+            .gate_response("t-unmarked", std::slice::from_ref(&call))
+            .await;
+        let why = out
+            .get("c-1")
+            .and_then(|d| d.reason.clone())
+            .unwrap_or_default();
+        assert!(!why.contains("tool-allow"), "different path: {why}");
     }
 }
 


### PR DESCRIPTION
## The bug
`channel/delegate` runs a turn whose caller is a **program** — a fleet router synchronously waiting on the reply. Synchronous is not attended, but the handler registered nothing in the map the HITL gate reads, so a gated tool fell through to asking.

What the user then saw depended on configuration, which is why this was hard to name:

| agent-wide notifier | symptom |
|---|---|
| configured | the turn parks for the whole `hitl.timeout_secs` against a sink nobody reads, then returns with no agent message and nothing naming approval |
| absent | the no-sink path denies at once, with a reason that names neither the tool nor a remedy |

The signal already existed — `decide_without_asking` short-circuits on `can_approve: false` with a readable reason, and `mur agent send` has passed that for a while. `channel/delegate` simply never sent it.

## The change
- `TaskRunner::mark_unattended(task_id)` registers the flag. The sink is never written to (with `can_approve: false` every `Ask` call is decided before a prompt is built, so `pending` stays empty); the receiver is dropped, so a send would fail closed rather than leak.
- The handler marks the turn before running it and unregisters afterwards. The task id is minted when the caller supplied none, because the mark is keyed by id and must exist before the turn starts.

## Test plan
- [x] `an_unattended_turn_is_refused_at_once_with_a_readable_reason` — drives `gate_response` itself, not the map, because the map says nothing about whether the gate reads it. Carries a negative control: an unmarked turn takes the no-sink path, whose reason differs.
- [x] `a_delegated_turn_marks_itself_unattended` — the wiring. 600 s approval timeout + a notifier nobody reads, asserted to finish inside 2 s.
- [x] **Mutation-verified both**: flipping `mark_unattended` to claim it *can* approve reddens the first; deleting the handler's call reddens the second at 2.019 s with `Elapsed` — the bug reproduced.
- [x] 696 runtime tests pass; `clippy --all-targets -D warnings`; `fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)