### PR TITLE
docs: execution limits — spec + step-1 plan (stop reasons reach the user)

### DIFF
--- a/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
+++ b/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
@@ -50,7 +50,7 @@ worktree to avoid a cold build.
 
 ### Steps
 
-- [ ] **1.1 Write the failing tests** — in `mur-core/src/cmd/fleet/loop_run.rs`, inside the existing `#[cfg(test)] mod tests`, right after `progress_file_written_with_outcome_on_guard_stop`:
+- [x] **1.1 Write the failing tests** — in `mur-core/src/cmd/fleet/loop_run.rs`, inside the existing `#[cfg(test)] mod tests`, right after `progress_file_written_with_outcome_on_guard_stop`:
 
 ```rust
     /// Every stop has a remedy except the two that mean "done". The remedy
@@ -134,9 +134,9 @@ worktree to avoid a cold build.
     }
 ```
 
-- [ ] **1.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/every_stop_short_of_done|stop_maps_to_a_channel|a_guard_stop_is_written/)'`. Expected: compile error `cannot find function stop_remedy` (and `terminal_state_for`).
+- [x] **1.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/every_stop_short_of_done|stop_maps_to_a_channel|a_guard_stop_is_written/)'`. Expected: compile error `cannot find function stop_remedy` (and `terminal_state_for`).
 
-- [ ] **1.3 Add the two pure functions** — in `loop_run.rs` directly below `fn outcome_label`:
+- [x] **1.3 Add the two pure functions** — in `loop_run.rs` directly below `fn outcome_label`:
 
 ```rust
 /// The one-line way out for each stop, in the words of the commands that exist
@@ -186,7 +186,7 @@ fn terminal_state_for(stop: LoopStop) -> &'static str {
 }
 ```
 
-- [ ] **1.4 Write the event at the end of `run_guarded`** — replace the block that begins `// Stamp the terminal state onto the progress file` and ends `Ok((stop, iteration, spent))` with:
+- [x] **1.4 Write the event at the end of `run_guarded`** — replace the block that begins `// Stamp the terminal state onto the progress file` and ends `Ok((stop, iteration, spent))` with:
 
 ```rust
     // Stamp the terminal state onto the progress file — kept as the last-run
@@ -246,9 +246,9 @@ fn emit_stop_event(
 
   `svc` and `fleet` are already in scope in `run_guarded` (`let svc = mur_channel::ChannelService::open(mur_home)?;` and the loaded `fleet`). If `fleet` is a `Fleet` value rather than a reference at that point, pass `&fleet`.
 
-- [ ] **1.5 Watch it pass** — same filter as 1.2, plus the neighbours: `cargo nextest run -p mur-core --lib -E 'test(/loop_run::/)'`. Expected: all pass, including `progress_file_written_with_outcome_on_guard_stop` (the progress write is unchanged).
+- [x] **1.5 Watch it pass** — same filter as 1.2, plus the neighbours: `cargo nextest run -p mur-core --lib -E 'test(/loop_run::/)'`. Expected: all pass, including `progress_file_written_with_outcome_on_guard_stop` (the progress write is unchanged).
 
-- [ ] **1.6 fmt + clippy** (`cargo clippy -p mur-core --all-targets -- -D warnings`), then **commit**:
+- [x] **1.6 fmt + clippy** (`cargo clippy -p mur-core --all-targets -- -D warnings`), then **commit**:
 
 ```
 feat(fleet): the loop writes its stop reason and remedy to the channel
@@ -273,7 +273,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
 ### Steps
 
-- [ ] **2.1 Write the failing tests** — append to `mur-core/src/cmd/agent/cli/fleet_rail/tests.rs`:
+- [x] **2.1 Write the failing tests** — append to `mur-core/src/cmd/agent/cli/fleet_rail/tests.rs`:
 
 ```rust
 #[test]
@@ -330,9 +330,9 @@ fn summary_names_the_stop_under_the_headline_except_when_converged() {
 
   `agent(..)` and `ev(..)` already exist in this file. If `StopNotice` / `fold_stop` are not brought in by the file's existing `use super::*;`, add `use super::{fold_stop, StopNotice};` at the top.
 
-- [ ] **2.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/fold_stop_reads|summary_names_the_stop/)'`. Expected: compile error `cannot find function fold_stop` / `no field stop`.
+- [x] **2.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/fold_stop_reads|summary_names_the_stop/)'`. Expected: compile error `cannot find function fold_stop` / `no field stop`.
 
-- [ ] **2.3 Add the type and the fold** — in `fleet_rail.rs`, directly below `pub fn fold_members`'s closing brace:
+- [x] **2.3 Add the type and the fold** — in `fleet_rail.rs`, directly below `pub fn fold_members`'s closing brace:
 
 ```rust
 /// Why the last run stopped and the way out, from the System `state-change`
@@ -361,7 +361,7 @@ pub fn fold_stop(events: &[ChannelEvent]) -> Option<StopNotice> {
 }
 ```
 
-- [ ] **2.4 Carry it in the view and render it** — add the field to `RailView`:
+- [x] **2.4 Carry it in the view and render it** — add the field to `RailView`:
 
 ```rust
     /// The last run's stop, rendered under the headline. `None` while a run is
@@ -388,9 +388,9 @@ pub fn fold_stop(events: &[ChannelEvent]) -> Option<StopNotice> {
 
   In `FleetRail::poll`, where `let view = RailView { jobs_line: …, members, notice: … }` is built, add `stop: fold_stop(&events),` after `members,`. `events` is the verified vector already in scope.
 
-- [ ] **2.5 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/fleet_rail/)'`. Expected: all pass. If a test elsewhere constructs `RailView { .. }` literally and now fails to compile, add `stop: None,` to that literal (search: `command grep -rn "RailView {" mur-core/src`).
+- [x] **2.5 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/fleet_rail/)'`. Expected: all pass. If a test elsewhere constructs `RailView { .. }` literally and now fails to compile, add `stop: None,` to that literal (search: `command grep -rn "RailView {" mur-core/src`).
 
-- [ ] **2.6 fmt + clippy**, then **commit**:
+- [x] **2.6 fmt + clippy**, then **commit**:
 
 ```
 feat(murmur): the fleet rail shows why the last run stopped
@@ -412,7 +412,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
 ### Steps
 
-- [ ] **3.1 Write the failing test** — in `mur-core/src/cmd/agent/cli/app.rs`, right after `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires`:
+- [x] **3.1 Write the failing test** — in `mur-core/src/cmd/agent/cli/app.rs`, right after `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires`:
 
 ```rust
     /// A run that hit a cap is not "finished". The headline takes the rail's
@@ -447,9 +447,9 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
   If `App::test_fixture` / `app()` gives an `App` whose `home` is not a writable tempdir, read the fixture (`grep -n "fn test_fixture" -A20 app.rs`) and use the same tempdir it holds; do not create a second home.
 
-- [ ] **3.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(the_headline_says_stopped)'`. Expected: assertion failure `got: ⛴ fleet dev finished (4s)…`.
+- [x] **3.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(the_headline_says_stopped)'`. Expected: assertion failure `got: ⛴ fleet dev finished (4s)…`.
 
-- [ ] **3.3 Use the rail's stop in the headline** — in `finish_auto_fleet`, the block that builds `head` becomes:
+- [x] **3.3 Use the rail's stop in the headline** — in `finish_auto_fleet`, the block that builds `head` becomes:
 
 ```rust
         let mut fleet = String::new();
@@ -485,9 +485,9 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
         let head = format!("⛴ fleet {fleet} {verdict} ({took})");
 ```
 
-- [ ] **3.4 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/finish_auto_fleet|auto_armed_fleet|headline_says_stopped/)'`. Expected: the new test and `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires` both pass (that one has no stop event, so it still reads `finished`).
+- [x] **3.4 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/finish_auto_fleet|auto_armed_fleet|headline_says_stopped/)'`. Expected: the new test and `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires` both pass (that one has no stop event, so it still reads `finished`).
 
-- [ ] **3.5 fmt + clippy**, then **commit**:
+- [x] **3.5 fmt + clippy**, then **commit**:
 
 ```
 fix(murmur): a capped fleet run is "stopped: <reason>", not "finished"
@@ -509,7 +509,7 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
 ### Steps
 
-- [ ] **4.1 Write the failing test** — in `mur-agent-runtime/src/turn_ledger.rs`'s test module, next to the existing test that asserts `"output may be incomplete"`:
+- [x] **4.1 Write the failing test** — in `mur-agent-runtime/src/turn_ledger.rs`'s test module, next to the existing test that asserts `"output may be incomplete"`:
 
 ```rust
     /// Every unclean stop says what to do about it, next to the fact. Naming
@@ -537,9 +537,9 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
 
   If `TurnLedger` has no `stop` field but a setter, use the setter the existing "output may be incomplete" test uses; mirror that test's construction exactly.
 
-- [ ] **4.2 Watch it fail** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(every_unclean_stop_names_its_remedy)'`. Expected: compile error `no method named remedy`.
+- [x] **4.2 Watch it fail** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(every_unclean_stop_names_its_remedy)'`. Expected: compile error `no method named remedy`.
 
-- [ ] **4.3 Add the remedy and render it** — in `impl StopKind`, after `as_str`:
+- [x] **4.3 Add the remedy and render it** — in `impl StopKind`, after `as_str`:
 
 ```rust
     /// What to do about it, in today's knobs. `hitl.max_iterations` and
@@ -573,9 +573,9 @@ Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
     }
 ```
 
-- [ ] **4.4 Watch it pass** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(/turn_ledger/)'`. Expected: all pass. The murmur card parser (`mur-core/src/cmd/agent/cli/settlement.rs`) treats the line as a `⚠` row and wraps it; no change there.
+- [x] **4.4 Watch it pass** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(/turn_ledger/)'`. Expected: all pass. The murmur card parser (`mur-core/src/cmd/agent/cli/settlement.rs`) treats the line as a `⚠` row and wraps it; no change there.
 
-- [ ] **4.5 fmt + clippy** (`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings`), then **commit**:
+- [x] **4.5 fmt + clippy** (`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings`), then **commit**:
 
 ```
 feat(runtime): the settlement card's stop row names the knob that bit

--- a/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
+++ b/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
@@ -161,7 +161,7 @@ pub fn stop_remedy(stop: LoopStop, fleet: &str) -> Option<String> {
         ),
         LoopStop::Stopped => format!("cleared by: mur fleet start {fleet}"),
         LoopStop::CommanderKilled => format!(
-            "a commander directive halted {fleet} — inspect it: mur commander status {fleet}"
+            "a commander directive halted {fleet} — inspect it: mur commander status"
         ),
         LoopStop::AwaitingApproval => format!(
             "a member is waiting on you: mur channel approve fleet-{fleet} <hitl_id>"

--- a/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
+++ b/docs/superpowers/plans/2026-09-12-stop-reasons-reach-the-user-plan.md
@@ -1,0 +1,596 @@
+# Plan: stop reasons reach the settlement card and the fleet rail
+
+> Execute with **`mur-executing-plans`**. Spec:
+> `docs/superpowers/specs/2026-09-12-execution-limits-design.md` §3.7 and §9 step 1.
+> Base: `main` at or after `b30221c8` (2.78.0). No schema change; nothing here
+> depends on the `limits:` work in later steps.
+
+**Goal.** When a fleet loop or a single task stops short, the user sees *why*
+and *what to do*, in the transcript they are already reading — never a bare
+`finished (0s)` or an empty turn.
+
+**Architecture.** The fleet loop already knows its `LoopStop` and writes it
+only to `progress.json`; Task 1 also writes it as a signed System
+`state-change` channel event carrying `stop_reason` and `remedy`. Task 2
+folds that event in the fleet rail (`RailView.stop`) and renders it. Task 3
+makes murmur's fleet headline say `stopped: <reason>` instead of
+`finished`. Task 4 adds the remedy to the settlement card's existing
+`⚠ stopped at …` row for single tasks, which the runtime already emits.
+
+**Tech stack.** Rust 2024, `cargo nextest`. Env for `mur-core`:
+`ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUST_MIN_STACK=33554432`.
+Use `CARGO_TARGET_DIR=/Volumes/Firecuda4tb/Projects/mur/target` from a
+worktree to avoid a cold build.
+
+## Global Constraints (from the spec)
+
+- Every stop names its reason **and** its remedy, where the user is looking (settlement card, fleet rail, murmur headline). `progress.json` keeps `outcome` as today.
+- The word `finished` is reserved for `Converged`.
+- The stop event is written **signed as the channel's writer** through `crate::channel_writer::append_as_writer`, the same path the DAG uses; never an unsigned append when a key exists.
+- No new user-facing setting. Remedies name the knobs that exist **today** (`mur fleet settings … --max-iterations/--deadline/--budget-usd`, `hitl.max_iterations`/`hitl.max_tokens` in the profile); step 3 of the rollout rewrites them.
+- Before every commit: `cargo fmt -p <crate>`, `cargo clippy -p <crate> --all-targets -- -D warnings` clean, the named tests green. Any `std::os::unix::` in a test fixture sits under `#[cfg(unix)]`.
+
+## File structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `mur-core/src/cmd/fleet/loop_run.rs` | `stop_remedy()`, `terminal_state_for()`, `emit_stop_event()` called once at the end of `run_guarded`; tests | 1 |
+| `mur-core/src/cmd/agent/cli/fleet_rail.rs` | `StopNotice`, `fold_stop()`, `RailView.stop`, `summary()` renders it | 2 |
+| `mur-core/src/cmd/agent/cli/fleet_rail/tests.rs` | fold + summary tests | 2 |
+| `mur-core/src/cmd/agent/cli/app.rs` | `finish_auto_fleet` headline uses the rail's stop | 3 |
+| `mur-agent-runtime/src/turn_ledger.rs` | `StopKind::remedy()`, rendered on the `⚠ stopped at` row | 4 |
+
+---
+
+## Task 1 — the fleet loop writes its stop reason to the channel
+
+**Interfaces.**
+- Consumes: `LoopStop` (exists, 9 variants), `outcome_label(LoopStop) -> &'static str` (exists), `crate::channel_writer::append_as_writer(svc, home, channel_id, router_agent, actor, kind, payload, idem) -> anyhow::Result<ChannelEvent>` (exists), `Fleet::router_or_concierge()` (exists), `STUCK_LIMIT` (exists, 2).
+- Produces: `pub fn stop_remedy(stop: LoopStop, fleet: &str) -> Option<String>`; `fn terminal_state_for(stop: LoopStop) -> &'static str`; a System `EventKind::StateChange` event at the end of every `run_guarded` with payload `{ "from": "working", "to": <terminal_state_for>, "stop_reason": <outcome_label>, "remedy": <stop_remedy or null>, "iterations": <u32>, "spent_usd": <f64>, "run_id": <String> }`.
+
+### Steps
+
+- [ ] **1.1 Write the failing tests** — in `mur-core/src/cmd/fleet/loop_run.rs`, inside the existing `#[cfg(test)] mod tests`, right after `progress_file_written_with_outcome_on_guard_stop`:
+
+```rust
+    /// Every stop has a remedy except the two that mean "done". The remedy
+    /// names a command that exists today; the spec's later steps rewrite it.
+    #[test]
+    fn every_stop_short_of_done_names_a_remedy() {
+        for stop in [
+            LoopStop::MaxIterations,
+            LoopStop::Deadline,
+            LoopStop::Stuck,
+            LoopStop::Budget,
+            LoopStop::Stopped,
+            LoopStop::CommanderKilled,
+            LoopStop::AwaitingApproval,
+        ] {
+            let r = stop_remedy(stop, "dev").unwrap_or_else(|| panic!("{stop:?} has no remedy"));
+            assert!(r.contains("dev"), "{stop:?}: remedy must name the fleet: {r}");
+        }
+        assert_eq!(stop_remedy(LoopStop::Converged, "dev"), None);
+        assert_eq!(stop_remedy(LoopStop::QueueDrained, "dev"), None);
+        assert!(stop_remedy(LoopStop::MaxIterations, "dev").unwrap().contains("--max-iterations"));
+        assert!(stop_remedy(LoopStop::Deadline, "dev").unwrap().contains("--deadline"));
+        assert!(stop_remedy(LoopStop::Budget, "dev").unwrap().contains("--budget-usd"));
+        assert!(stop_remedy(LoopStop::Stopped, "dev").unwrap().contains("mur fleet start dev"));
+        assert!(stop_remedy(LoopStop::AwaitingApproval, "dev").unwrap().contains("mur channel approve"));
+    }
+
+    /// The map from "why we stopped" to the channel's terminal state. Done is
+    /// completed; a kill is canceled; waiting on a person is input-required;
+    /// a guard trip is failed — the goal was not reached.
+    #[test]
+    fn stop_maps_to_a_channel_terminal_state() {
+        assert_eq!(terminal_state_for(LoopStop::Converged), "completed");
+        assert_eq!(terminal_state_for(LoopStop::QueueDrained), "completed");
+        assert_eq!(terminal_state_for(LoopStop::Stopped), "canceled");
+        assert_eq!(terminal_state_for(LoopStop::CommanderKilled), "canceled");
+        assert_eq!(terminal_state_for(LoopStop::AwaitingApproval), "input-required");
+        for stop in [LoopStop::MaxIterations, LoopStop::Deadline, LoopStop::Stuck, LoopStop::Budget] {
+            assert_eq!(terminal_state_for(stop), "failed", "{stop:?}");
+        }
+    }
+
+    /// The stop reaches the channel, not only progress.json: one System
+    /// state-change at the end of the run carrying reason and remedy.
+    #[tokio::test]
+    async fn a_guard_stop_is_written_to_the_channel_with_reason_and_remedy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let fleet = Fleet {
+            name: "dev".into(),
+            display_name: String::new(),
+            goal: "g".into(),
+            router: None,
+            members: vec!["pm".into()],
+            team_id: None,
+            channel_id: "fleet-dev".into(),
+            rules: vec![],
+            skills: vec![],
+            loop_cfg: None,
+            parallel: None,
+            hitl: None,
+            requires_programs: vec![],
+        };
+        crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
+        let svc = mur_channel::ChannelService::open(home).unwrap();
+        svc.create_for_fleet("dev", "mur", &["pm".into()]).unwrap();
+        // Kill-switch: the loop stops before any delegation, no live agent needed.
+        crate::cmd::fleet::control::cmd_fleet_stop(home, "dev").unwrap();
+
+        let stop = run_loop_for_test(home).await;
+        assert_eq!(stop, LoopStop::Stopped);
+
+        let events = svc.load_events("fleet-dev").unwrap();
+        let last = events.last().expect("the stop event is the last thing written");
+        assert_eq!(last.kind, mur_common::channel::EventKind::StateChange);
+        assert_eq!(last.actor, ChannelActor::System);
+        assert_eq!(last.payload["to"], "canceled");
+        assert_eq!(last.payload["stop_reason"], "stopped");
+        assert_eq!(last.payload["remedy"], "cleared by: mur fleet start dev");
+        assert!(last.payload["run_id"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+```
+
+- [ ] **1.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/every_stop_short_of_done|stop_maps_to_a_channel|a_guard_stop_is_written/)'`. Expected: compile error `cannot find function stop_remedy` (and `terminal_state_for`).
+
+- [ ] **1.3 Add the two pure functions** — in `loop_run.rs` directly below `fn outcome_label`:
+
+```rust
+/// The one-line way out for each stop, in the words of the commands that exist
+/// today (`mur fleet settings`, `mur fleet start`, `mur channel approve`). The
+/// spec's step 3 rewrites these when `limits:` lands; until then a user who
+/// hits a cap must at least be told which knob it was. `None` for the two
+/// stops that mean the work is done.
+pub fn stop_remedy(stop: LoopStop, fleet: &str) -> Option<String> {
+    Some(match stop {
+        LoopStop::Converged | LoopStop::QueueDrained => return None,
+        LoopStop::MaxIterations => format!(
+            "raise it: mur fleet settings {fleet} --max-iterations <N>  (fleet.yaml loop.max_iterations)"
+        ),
+        LoopStop::Deadline => format!(
+            "raise it: mur fleet settings {fleet} --deadline <2h>  (fleet.yaml loop.deadline)"
+        ),
+        LoopStop::Stuck => format!(
+            "no member activity for {STUCK_LIMIT} iterations — see what they are waiting on: mur fleet status {fleet}"
+        ),
+        LoopStop::Budget => format!(
+            "raise it: mur fleet settings {fleet} --budget-usd <USD>  (fleet.yaml loop.budget_usd)"
+        ),
+        LoopStop::Stopped => format!("cleared by: mur fleet start {fleet}"),
+        LoopStop::CommanderKilled => format!(
+            "a commander directive halted {fleet} — inspect it: mur commander status {fleet}"
+        ),
+        LoopStop::AwaitingApproval => format!(
+            "a member is waiting on you: mur channel approve fleet-{fleet} <hitl_id>"
+        ),
+    })
+}
+
+/// The channel terminal state a stop implies, in the kebab-case wire form
+/// `channel_terminal_status` and the rail already fold. Done is `completed`; a
+/// kill is `canceled`; waiting on a person is `input-required`; a guard trip
+/// is `failed`, because the goal was not reached — the run ending is not the
+/// same as the work being done.
+fn terminal_state_for(stop: LoopStop) -> &'static str {
+    match stop {
+        LoopStop::Converged | LoopStop::QueueDrained => "completed",
+        LoopStop::Stopped | LoopStop::CommanderKilled => "canceled",
+        LoopStop::AwaitingApproval => "input-required",
+        LoopStop::MaxIterations | LoopStop::Deadline | LoopStop::Stuck | LoopStop::Budget => {
+            "failed"
+        }
+    }
+}
+```
+
+- [ ] **1.4 Write the event at the end of `run_guarded`** — replace the block that begins `// Stamp the terminal state onto the progress file` and ends `Ok((stop, iteration, spent))` with:
+
+```rust
+    // Stamp the terminal state onto the progress file — kept as the last-run
+    // record (overwritten by the next run). Best-effort.
+    let run_id = {
+        let mut g = lock_progress(&progress);
+        g.finished_at = Some(chrono::Utc::now().to_rfc3339());
+        g.outcome = Some(outcome_label(stop).to_string());
+        g.iteration = iteration;
+        g.spend_usd = spent;
+        g.save(mur_home, name);
+        g.run_id.clone()
+    };
+    // And onto the channel, where the rail, murmur and the Hub are looking.
+    // Until this existed the reason lived only in progress.json, and every
+    // surface said "finished" for a run that had hit a cap. Signed as the
+    // writer like every other event this run wrote; best-effort like the
+    // progress file — a stop must never fail because its announcement did.
+    emit_stop_event(&svc, mur_home, &fleet, stop, iteration, spent, &run_id);
+    Ok((stop, iteration, spent))
+}
+
+/// One System `state-change` carrying why the loop stopped and the way out.
+/// `from` is always `working`: a loop that is ending was running.
+fn emit_stop_event(
+    svc: &mur_channel::ChannelService,
+    mur_home: &Path,
+    fleet: &Fleet,
+    stop: LoopStop,
+    iterations: u32,
+    spent_usd: f64,
+    run_id: &str,
+) {
+    let payload = serde_json::json!({
+        "from": "working",
+        "to": terminal_state_for(stop),
+        "stop_reason": outcome_label(stop),
+        "remedy": stop_remedy(stop, &fleet.name),
+        "iterations": iterations,
+        "spent_usd": spent_usd,
+        "run_id": run_id,
+    });
+    if let Err(e) = crate::channel_writer::append_as_writer(
+        svc,
+        mur_home,
+        &fleet.channel_id,
+        fleet.router_or_concierge(),
+        ChannelActor::System,
+        mur_common::channel::EventKind::StateChange,
+        payload,
+        None,
+    ) {
+        tracing::warn!(fleet = %fleet.name, error = %e, "could not write the stop reason to the channel");
+    }
+}
+```
+
+  `svc` and `fleet` are already in scope in `run_guarded` (`let svc = mur_channel::ChannelService::open(mur_home)?;` and the loaded `fleet`). If `fleet` is a `Fleet` value rather than a reference at that point, pass `&fleet`.
+
+- [ ] **1.5 Watch it pass** — same filter as 1.2, plus the neighbours: `cargo nextest run -p mur-core --lib -E 'test(/loop_run::/)'`. Expected: all pass, including `progress_file_written_with_outcome_on_guard_stop` (the progress write is unchanged).
+
+- [ ] **1.6 fmt + clippy** (`cargo clippy -p mur-core --all-targets -- -D warnings`), then **commit**:
+
+```
+feat(fleet): the loop writes its stop reason and remedy to the channel
+
+`LoopStop` reached only progress.json, so every surface said "finished" for
+a run that had hit a cap — the user spent an evening guessing why nothing
+continued. One System state-change at the end of `run_guarded` now carries
+`stop_reason` and `remedy`, signed as the writer like every other event.
+Guard trips map to `failed` (the goal was not reached), kills to
+`canceled`, an unanswered approval to `input-required`.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+```
+
+---
+
+## Task 2 — the fleet rail folds and renders the stop
+
+**Interfaces.**
+- Consumes: the Task 1 event shape (`System` + `StateChange` + `stop_reason` + `remedy` payload keys).
+- Produces: `pub struct StopNotice { pub reason: String, pub remedy: Option<String> }`; `pub fn fold_stop(events: &[ChannelEvent]) -> Option<StopNotice>`; `RailView.stop: Option<StopNotice>`; `RailView::summary()` emits `  ■ stopped: <reason> — <remedy>` (or without ` — <remedy>` when none) as the second line when `reason != "converged"`.
+
+### Steps
+
+- [ ] **2.1 Write the failing tests** — append to `mur-core/src/cmd/agent/cli/fleet_rail/tests.rs`:
+
+```rust
+#[test]
+fn fold_stop_reads_the_last_system_stop_event() {
+    let evs = vec![
+        ev(1, agent("qa"), EventKind::StateChange, json!({"to": "working"})),
+        ev(
+            2,
+            ChannelActor::System,
+            EventKind::StateChange,
+            json!({"from": "working", "to": "failed",
+                   "stop_reason": "max-iterations",
+                   "remedy": "raise it: mur fleet settings dev --max-iterations <N>"}),
+        ),
+    ];
+    let s = fold_stop(&evs).expect("a stop notice");
+    assert_eq!(s.reason, "max-iterations");
+    assert_eq!(s.remedy.as_deref(), Some("raise it: mur fleet settings dev --max-iterations <N>"));
+
+    // A member's state-change is not a stop; a System one without the key is
+    // the DAG's ordinary transition, also not a stop.
+    let plain = vec![
+        ev(1, ChannelActor::System, EventKind::StateChange, json!({"from": "working", "to": "completed"})),
+    ];
+    assert!(fold_stop(&plain).is_none());
+    assert!(fold_stop(&[]).is_none());
+}
+
+#[test]
+fn summary_names_the_stop_under_the_headline_except_when_converged() {
+    let mut view = RailView {
+        jobs_line: "fleet · dev   job 2/2".into(),
+        members: vec![],
+        notice: None,
+        stop: Some(StopNotice {
+            reason: "deadline".into(),
+            remedy: Some("raise it: mur fleet settings dev --deadline <2h>".into()),
+        }),
+    };
+    let lines = view.summary();
+    assert_eq!(lines[0], "fleet · dev   job 2/2");
+    assert_eq!(lines[1], "  ■ stopped: deadline — raise it: mur fleet settings dev --deadline <2h>");
+
+    view.stop = Some(StopNotice { reason: "stuck".into(), remedy: None });
+    assert_eq!(view.summary()[1], "  ■ stopped: stuck");
+
+    view.stop = Some(StopNotice { reason: "converged".into(), remedy: None });
+    assert_eq!(view.summary().len(), 1, "converged is not a stop to announce");
+
+    view.stop = None;
+    assert_eq!(view.summary().len(), 1);
+}
+```
+
+  `agent(..)` and `ev(..)` already exist in this file. If `StopNotice` / `fold_stop` are not brought in by the file's existing `use super::*;`, add `use super::{fold_stop, StopNotice};` at the top.
+
+- [ ] **2.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(/fold_stop_reads|summary_names_the_stop/)'`. Expected: compile error `cannot find function fold_stop` / `no field stop`.
+
+- [ ] **2.3 Add the type and the fold** — in `fleet_rail.rs`, directly below `pub fn fold_members`'s closing brace:
+
+```rust
+/// Why the last run stopped and the way out, from the System `state-change`
+/// the fleet loop writes at its end (`loop_run::emit_stop_event`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StopNotice {
+    /// The `outcome_label` word: `max-iterations`, `deadline`, `stuck`, …
+    pub reason: String,
+    pub remedy: Option<String>,
+}
+
+/// The most recent stop event, if any. Only System-authored state-changes
+/// that carry `stop_reason` count: a member's own state-change is progress,
+/// and the DAG's plain `completed` transition is a step ending, not the run.
+pub fn fold_stop(events: &[ChannelEvent]) -> Option<StopNotice> {
+    events.iter().rev().find_map(|ev| {
+        if ev.kind != EventKind::StateChange || ev.actor != ChannelActor::System {
+            return None;
+        }
+        let reason = field(ev, &["stop_reason"])?.to_string();
+        Some(StopNotice {
+            reason,
+            remedy: field(ev, &["remedy"]).map(str::to_string),
+        })
+    })
+}
+```
+
+- [ ] **2.4 Carry it in the view and render it** — add the field to `RailView`:
+
+```rust
+    /// The last run's stop, rendered under the headline. `None` while a run is
+    /// in flight or before the first run.
+    pub stop: Option<StopNotice>,
+```
+
+  In `RailView::summary`, replace `let mut out = vec![head];` with:
+
+```rust
+        let mut out = vec![head];
+        // "finished" is reserved for a converged run; every other stop is
+        // announced with its reason and remedy, because the headline alone
+        // reads as "done" for a run that hit a cap.
+        if let Some(s) = &self.stop
+            && s.reason != "converged"
+        {
+            out.push(match &s.remedy {
+                Some(r) => format!("  ■ stopped: {} — {r}", s.reason),
+                None => format!("  ■ stopped: {}", s.reason),
+            });
+        }
+```
+
+  In `FleetRail::poll`, where `let view = RailView { jobs_line: …, members, notice: … }` is built, add `stop: fold_stop(&events),` after `members,`. `events` is the verified vector already in scope.
+
+- [ ] **2.5 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/fleet_rail/)'`. Expected: all pass. If a test elsewhere constructs `RailView { .. }` literally and now fails to compile, add `stop: None,` to that literal (search: `command grep -rn "RailView {" mur-core/src`).
+
+- [ ] **2.6 fmt + clippy**, then **commit**:
+
+```
+feat(murmur): the fleet rail shows why the last run stopped
+
+Folds the System stop event the loop now writes into `RailView.stop` and
+renders it under the headline as `■ stopped: <reason> — <remedy>`.
+"finished" stays reserved for a converged run.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+```
+
+---
+
+## Task 3 — murmur's headline says `stopped: <reason>`, not `finished`
+
+**Interfaces.**
+- Consumes: `RailView.stop` (Task 2).
+- Produces: `App::finish_auto_fleet` headline is `⛴ fleet <name> finished (took)` only when the run succeeded **and** the rail reports no stop or `converged`; `⛴ fleet <name> stopped: <reason> (took)` when the rail reports any other stop; `⛴ fleet <name> failed (took)` when the step itself failed and there is no stop notice.
+
+### Steps
+
+- [ ] **3.1 Write the failing test** — in `mur-core/src/cmd/agent/cli/app.rs`, right after `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires`:
+
+```rust
+    /// A run that hit a cap is not "finished". The headline takes the rail's
+    /// stop word so the transcript's first line already says why.
+    #[test]
+    fn the_headline_says_stopped_when_the_rail_reports_a_stop() {
+        let mut a = app();
+        a.arm_auto_fleet("s1", "dev", std::time::Instant::now());
+        // Plant a stop event in the fleet's channel so the rail's final poll
+        // folds it. The fixture home has no channel yet; create it.
+        let svc = mur_channel::ChannelService::open(&a.home).unwrap();
+        svc.create_for_fleet("dev", "mur", &["qa".to_string()]).unwrap();
+        svc.append(
+            "fleet-dev",
+            mur_common::channel::ChannelActor::System,
+            mur_common::channel::EventKind::StateChange,
+            serde_json::json!({"from": "working", "to": "failed",
+                               "stop_reason": "max-iterations",
+                               "remedy": "raise it: mur fleet settings dev --max-iterations <N>"}),
+            None,
+        )
+        .unwrap();
+
+        a.finish_auto_fleet("s1", true, 4000);
+
+        let last = a.messages.last().expect("outcome message").text.clone();
+        assert!(last.starts_with("⛴ fleet dev stopped: max-iterations ("), "got: {last}");
+        assert!(!last.lines().next().unwrap().contains("finished"), "got: {last}");
+        assert!(last.contains("■ stopped: max-iterations — raise it"), "rail line missing: {last}");
+    }
+```
+
+  If `App::test_fixture` / `app()` gives an `App` whose `home` is not a writable tempdir, read the fixture (`grep -n "fn test_fixture" -A20 app.rs`) and use the same tempdir it holds; do not create a second home.
+
+- [ ] **3.2 Watch it fail** — `cargo nextest run -p mur-core --lib -E 'test(the_headline_says_stopped)'`. Expected: assertion failure `got: ⛴ fleet dev finished (4s)…`.
+
+- [ ] **3.3 Use the rail's stop in the headline** — in `finish_auto_fleet`, the block that builds `head` becomes:
+
+```rust
+        let mut fleet = String::new();
+        let mut summary = Vec::new();
+        let mut retire = false;
+        let mut stop_word: Option<String> = None;
+        if let Some(rail) = self.fleet.as_mut() {
+            rail.set_run_in_flight(false);
+            // A view up to POLL_INTERVAL stale would freeze the wrong states
+            // into history. `set_run_in_flight` already busted the poll gate.
+            rail.poll(&home, std::time::Instant::now());
+            fleet = rail.fleet().to_string();
+            summary = rail.view().summary();
+            retire = rail.is_auto();
+            stop_word = rail
+                .view()
+                .stop
+                .as_ref()
+                .filter(|s| s.reason != "converged")
+                .map(|s| s.reason.clone());
+        }
+        if retire {
+            self.fleet = None;
+        }
+        let took = super::follow::fmt_elapsed(chrono::Duration::milliseconds(duration_ms as i64));
+        // "finished" is reserved for a run that converged. A cap, a kill or an
+        // unanswered approval is a stop, and the first line says so.
+        let verdict = match (&stop_word, ok) {
+            (Some(reason), _) => format!("stopped: {reason}"),
+            (None, true) => "finished".to_string(),
+            (None, false) => "failed".to_string(),
+        };
+        let head = format!("⛴ fleet {fleet} {verdict} ({took})");
+```
+
+- [ ] **3.4 Watch it pass** — `cargo nextest run -p mur-core --lib -E 'test(/finish_auto_fleet|auto_armed_fleet|headline_says_stopped/)'`. Expected: the new test and `an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires` both pass (that one has no stop event, so it still reads `finished`).
+
+- [ ] **3.5 fmt + clippy**, then **commit**:
+
+```
+fix(murmur): a capped fleet run is "stopped: <reason>", not "finished"
+
+The headline took its word from the step's ok flag alone, so a run that
+hit max-iterations read as finished. It now takes the rail's stop when
+there is one; "finished" is reserved for a converged run.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+```
+
+---
+
+## Task 4 — the settlement card's stop row carries a remedy
+
+**Interfaces.**
+- Consumes: `StopKind` (exists: `EndTurn`, `MaxIterations`, `TokenBudget`, `LoopDetected`, `MaxTokens`), `render(&TurnLedger)` (exists, emits `  ⚠ stopped at {kind} ({n} iterations) — output may be incomplete`).
+- Produces: `impl StopKind { pub fn remedy(self) -> Option<&'static str> }`; the row becomes `  ⚠ stopped at {kind} ({n} iterations) — output may be incomplete · {remedy}`.
+
+### Steps
+
+- [ ] **4.1 Write the failing test** — in `mur-agent-runtime/src/turn_ledger.rs`'s test module, next to the existing test that asserts `"output may be incomplete"`:
+
+```rust
+    /// Every unclean stop says what to do about it, next to the fact. Naming
+    /// the knob is the difference between "the agent gave up" and "raise
+    /// hitl.max_tokens".
+    #[test]
+    fn every_unclean_stop_names_its_remedy() {
+        assert_eq!(StopKind::EndTurn.remedy(), None);
+        for k in [StopKind::MaxIterations, StopKind::TokenBudget, StopKind::LoopDetected, StopKind::MaxTokens] {
+            assert!(k.remedy().is_some(), "{k:?}");
+        }
+        assert!(StopKind::MaxIterations.remedy().unwrap().contains("hitl.max_iterations"));
+        assert!(StopKind::TokenBudget.remedy().unwrap().contains("hitl.max_tokens"));
+
+        let mut ledger = TurnLedger::default();
+        ledger.stop = StopKind::TokenBudget;
+        ledger.iterations = 17;
+        let card = render(&ledger);
+        assert!(
+            card.contains("⚠ stopped at token budget (17 iterations) — output may be incomplete · raise hitl.max_tokens"),
+            "{card}"
+        );
+    }
+```
+
+  If `TurnLedger` has no `stop` field but a setter, use the setter the existing "output may be incomplete" test uses; mirror that test's construction exactly.
+
+- [ ] **4.2 Watch it fail** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(every_unclean_stop_names_its_remedy)'`. Expected: compile error `no method named remedy`.
+
+- [ ] **4.3 Add the remedy and render it** — in `impl StopKind`, after `as_str`:
+
+```rust
+    /// What to do about it, in today's knobs. `hitl.max_iterations` and
+    /// `hitl.max_tokens` live in the agent's profile.yaml until the `limits:`
+    /// schema replaces them; the settlement card is where the user learns
+    /// which one bit, so it names it.
+    pub fn remedy(self) -> Option<&'static str> {
+        match self {
+            StopKind::EndTurn => None,
+            StopKind::MaxIterations => Some("raise hitl.max_iterations in the agent's profile.yaml and restart it"),
+            StopKind::TokenBudget => Some("raise hitl.max_tokens in the agent's profile.yaml and restart it"),
+            StopKind::LoopDetected => Some("the last tool call repeated with identical arguments — change the ask, or the tool's input"),
+            StopKind::MaxTokens => Some("the model's output limit — ask it to continue from where it stopped"),
+        }
+    }
+```
+
+  In `render`, replace the `if !ledger.stop.is_clean() { … }` block with:
+
+```rust
+    if !ledger.stop.is_clean() {
+        out.push_str(&format!(
+            "  ⚠ stopped at {} ({} iterations) — output may be incomplete",
+            ledger.stop.as_str(),
+            ledger.iterations
+        ));
+        if let Some(r) = ledger.stop.remedy() {
+            out.push_str(&format!(" · {r}"));
+        }
+        out.push('\n');
+    }
+```
+
+- [ ] **4.4 Watch it pass** — `cargo nextest run -p mur-agent-runtime --lib -E 'test(/turn_ledger/)'`. Expected: all pass. The murmur card parser (`mur-core/src/cmd/agent/cli/settlement.rs`) treats the line as a `⚠` row and wraps it; no change there.
+
+- [ ] **4.5 fmt + clippy** (`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings`), then **commit**:
+
+```
+feat(runtime): the settlement card's stop row names the knob that bit
+
+"stopped at token budget (17 iterations)" told the user the agent gave up;
+it did not say that hitl.max_tokens is the ceiling or where it lives. Each
+unclean StopKind now carries a one-line remedy, rendered on the same row.
+
+Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+```
+
+---
+
+## After the last task
+
+- One PR for the branch: `feat: stop reasons reach the settlement card and the fleet rail (spec §3.7, step 1)`. Body lists the four commits and the manual check below.
+- Manual check after `build.sh --install`: run `mur fleet run <fleet> --loop --max-iterations 1` on a fleet whose members are up; murmur (with `--fleet <fleet>`) shows `⛴ fleet <fleet> stopped: max-iterations (…)` and the `■ stopped: max-iterations — raise it: …` line; `~/.mur/channels/fleet-<fleet>/events.jsonl` ends with a System `state-change` carrying `stop_reason`.
+- Docs: the `update-docs` skill — the agent-cli page's fleet-progress section gains one sentence on the `■ stopped:` line. No README change (behaviour, not surface).

--- a/docs/superpowers/specs/2026-09-12-execution-limits-design.md
+++ b/docs/superpowers/specs/2026-09-12-execution-limits-design.md
@@ -205,7 +205,6 @@ A local-model fleet is bounded by its deadline. A billable fleet with neither kn
 
 - Context-window management (compaction) for very long attended sessions — a separate design; this spec only stops the runtime from *killing* such a session.
 - Per-tool cost attribution.
-- Hub UI for `limits:` — follows once the CLI shape has settled.
 - Removing `hitl.timeout_secs` — it is a real HITL knob and stays.
 
 ## 9. Rollout
@@ -218,3 +217,98 @@ A local-model fleet is bounded by its deadline. A billable fleet with neither kn
 6. Dispatch preflight + non-retryable authorization (§3.8).
 
 Each step is its own plan and PR.
+
+## 10. Hub surface
+
+The Hub already has the three places these settings belong — the global
+Settings page, the fleet detail's Settings tab (today: trigger / max
+iterations / deadline / budget / done-when), and the agent detail's
+Overview. No new page. One rule above all: **the Hub renders what the CLI
+resolves.** A single Tauri command `limits_resolve(scope) -> LimitsView`
+wraps the same `mur_common::limits` resolver `mur limits` uses, and
+returns per knob `{ value, source, applies, note }`. The Hub never
+re-derives a default or an applicability rule in TypeScript — the two
+surfaces disagreeing about "what is in force" is the disease this whole
+spec treats.
+
+### 10.1 One `LimitsPanel`, rendered at three scopes
+
+| scope | where | what it edits |
+|---|---|---|
+| global | Settings → General → "Execution limits" | `~/.mur/config.yaml limits:` |
+| fleet | Fleet detail → Settings tab, **replacing** the loop-guards block (max iterations / budget go away; trigger, cron and done-when stay) | `fleet.yaml limits:` |
+| agent | Agent detail → Overview, a "Limits" card with Edit (no fifth tab) | `profile.yaml limits:` |
+
+Each row is `knob · effective value · source chip · action`:
+
+```
+deadline   2h      this fleet          [Reset to inherited]
+stuck      10m     built-in default    [Override here]
+cost_usd   —       Local model — no cost cap applies
+```
+
+- An **inherited** value renders dimmed with its source chip
+  (`built-in default` / `config.yaml` / `this fleet`); its action is
+  *Override here*. A **local** value renders solid; its action is *Reset to
+  inherited*, which deletes the key rather than writing the parent's value
+  (so a later change upstream still flows down).
+- `cost_usd` follows D4: shown as an editable row only when
+  `applies == true` (the scope's model is `UsageBilled`). Otherwise the row
+  is a single line of text naming why, never a disabled input — a disabled
+  field reads as "you are not allowed", and the truth is "this does not
+  exist for you".
+- Duration inputs accept `30m`, `2h`, `1h30m`; validation is the same
+  parser as the CLI, exposed through the resolve command's error, not
+  reimplemented.
+
+### 10.2 The fleet Overview stat cards
+
+The four cards today read `never / Last auto-run · 0 / Max iterations ·
+$2 / Budget · Router decides each iteration / Done when`. They become:
+
+```
+never          2h            10m           Router decides…
+Last auto-run  Deadline      Stuck         Done when
+```
+
+with a fifth element on the header line next to the trigger: **`bounded ✓`**
+or **`unbounded — will not auto-run`**. That badge is §5 made visible: it
+is green when `deadline` is set or `cost_usd` applies and is set, and it
+links to the Settings tab otherwise. On a billable fleet the third card
+shows `$5.00 / Cost cap` instead of stuck when a cap is set; stuck moves to
+the panel.
+
+### 10.3 Stop reasons where the Hub user is looking
+
+The Jobs tab and the Overview job rows show the `stop_reason` from the
+channel `state-change` event (§3.7) as the row's status —
+`■ stopped: deadline 1h` — with one inline action that opens `LimitsPanel`
+at the fleet scope with that knob focused. `finished` appears only for
+`Converged`, same word rule as the CLI.
+
+### 10.4 Migration warnings and attended state
+
+- A stale key (`hitl.max_iterations`, `loop.max_iterations`,
+  `loop.budget_usd` once migrated) shows as an amber row at the top of the
+  panel: `hitl.max_iterations: 800 in profile.yaml is ignored — Remove`.
+  Remove deletes the key through the same write path as an edit.
+- The agent-scope panel says whether a save needs a restart. Fleet and
+  global do not (read per run); an agent profile does, and the row uses
+  the existing "restart required" affordance rather than a new one.
+- The Hub's chat pane is an **attended** surface exactly like murmur:
+  while it holds a task, the live band shows elapsed / steps / tokens, the
+  `stuck` threshold shows a warning banner with a Stop button, and no hard
+  stop fires. Hub chat is in scope for D3.
+
+### 10.5 Wiring notes
+
+- `limits_resolve`, `limits_set(scope, patch)` and `limits_remove_stale
+  (scope, key)` are the only three commands; `fleet_set_loop` keeps
+  trigger / cron / done-when and drops the guard fields.
+- The Hub is workspace-excluded: `LimitsView` is a DTO owned by the Tauri
+  side, so a later change to `mur_common::limits` must grep the Hub
+  (`gotcha_workspace_excluded_addonref_literals`).
+- Hub work is rollout step 3b, after `mur limits` (§9 step 3) has settled
+  the shape, and before step 4 flips the runtime — so users can see the
+  new model before it starts governing their runs.
+

--- a/docs/superpowers/specs/2026-09-12-execution-limits-design.md
+++ b/docs/superpowers/specs/2026-09-12-execution-limits-design.md
@@ -1,0 +1,220 @@
+# Execution limits: one bounded model instead of fifteen gates
+
+**Status:** Approved in conversation 2026-09-12 (including the safety-triad change in §5); awaiting plan.
+**Scope:** `mur-common` (schema), `mur-agent-runtime` (loop guards, stop reasons, tool timeouts), `mur-core` (fleet loop, `mur limits`, murmur settlement), `mur-daemon` (auto-run gate). No protocol change on the wire.
+
+## 1. Problem
+
+A user on a local model, watching a fleet from murmur, was stopped by five
+different mechanisms in one evening — none of which named itself:
+
+| What stopped the work | Where it lives | Default | Visible anywhere? |
+|---|---|---|---|
+| per-task iteration cap | `hitl.max_iterations` (profile) | `None` → 25 | no |
+| per-task token budget | `hitl.max_tokens` (profile) | `None` → 750 000 cumulative *input* tokens | no |
+| fleet iteration cap | `loop.max_iterations` (fleet.yaml) | `0` → 8 | no |
+| fleet stuck detector | hardcoded | 2 consecutive quiet iterations | no |
+| MCP tool-call timeout | per server, default | 120 s | no |
+| A2A dial read timeout | hardcoded `a2a_dial.rs` | 600 s | not configurable |
+| unattended auto-run | `MUR_FLEET_AUTORUN` + `budget_usd > 0` | off | no |
+
+Three things are wrong with the model, not the numbers:
+
+1. **Counting is used as a proxy for progress.** 25 iterations and 750k
+   tokens measure nothing real; they guess whether the agent is still
+   useful. Proxies fail both ways: they kill long productive work and let a
+   short idle loop run to the cap. Worse, `max_tokens` counts cumulative
+   *input* tokens, and every iteration re-sends the whole context, so it
+   grows quadratically with steps — a 30-step task with a 25k context is
+   750k. rustsmith died at iteration 17 because its context got long, not
+   because it did too much.
+2. **The real axis is attended vs unattended, not local vs cloud.** When a
+   human is watching murmur, the human is the guard: progress is visible
+   and `Esc` stops it. Mechanical guards only earn their place when nobody
+   is watching — and even then the right guards are time, progress and
+   (when it exists) money, not step counts.
+3. **Every layer adds its own smaller cap.** fleet 8 × agent 25 × tokens ×
+   MCP 120 s × dial 600 s. The user raised two of these to 800 and
+   1 000 000 and was stopped by a third. Nobody can reason about the
+   product.
+
+Also: `hitl.max_iterations` lives under `hitl:` and has nothing to do with
+a human in the loop; `max_tokens` collides with the LLM's max output
+tokens. The names say these were bolted on.
+
+## 2. Decisions
+
+| # | Decision | Rejected alternative |
+|---|---|---|
+| D1 | **The scope the user launched owns the budget; inner scopes inherit and never add a smaller one.** A task delegated by a fleet run has no cap of its own. | Keep per-task caps as a "safety net" under the fleet cap — that is the product-of-caps problem restated. |
+| D2 | **Three knobs, one schema, three scopes** (`config.yaml` → `fleet.yaml` → profile/task): `deadline`, `stuck`, `cost_usd`. Iteration and token caps are removed as user-facing settings. | Rename and document the existing six knobs — leaves the proxy model in place. |
+| D3 | **Attended runs have no hard stops.** murmur shows elapsed / steps / tokens live; `stuck` only warns; `Esc` is the stop. | Apply the same caps attended and unattended "for consistency" — punishes the case where a human is already the guard. |
+| D4 | **Unattended runs must be bounded, and a bound is `deadline` OR `cost_usd`.** A local model (`BillingMode::Local`) has no `cost_usd` knob at all, so its bound is a deadline. | Keep "positive `budget_usd` required" — forces local users to invent a dollar figure that means nothing (see §5). |
+| D5 | **Stuck measures progress, in minutes.** Stuck = N minutes with no file write, no channel event, and no tool call whose arguments differ from the previous iteration's. Default 10 min. | Keep "2 iterations without agent activity" — an iteration is not a unit of time or progress. |
+| D6 | **Long-running tools return a handle, never block.** `parallel_jobs` and `fleet_run` return `run_id` at once; progress comes from `mur_job_status` (already exists). The MCP call timeout stays short because nothing legitimate needs it long. | Raise the MCP default from 120 s — the next tool that takes 20 minutes hits it again. |
+| D7 | **Liveness is heartbeats, not a bigger read timeout.** The runtime emits a heartbeat frame while the model is thinking; the dial's idle timeout stays short and never fires on a thinking router. | Raise `DEFAULT_DIAL_IO_TIMEOUT` past 600 s — same failure, later. |
+| D8 | **Every stop names its reason and its remedy, where the user is looking.** `LoopStop` already has the reasons; they reach the settlement card and the fleet rail, not only `progress.json`. | Point users at `progress.json`. |
+| D9 | **Authorization gates are untouched** (`fleet_run` allowlist, `parallel_jobs.targets`, tool Ask/Deny, path grants) — they are security, not budget. Two behaviours change: a missing capability fails **at dispatch**, and authorization errors are **non-retryable** so the model cannot spin on them. | Fold authorization into `limits:` — conflates safety with cost. |
+| D10 | **`mur limits <agent\|fleet>` prints every knob's effective value and its source.** | A doc page listing defaults — stale the day it ships. |
+
+## 3. The model
+
+### 3.1 Schema (identical at every scope)
+
+```yaml
+limits:
+  deadline: 2h        # wall clock for the whole unit of work. Duration string.
+  stuck: 10m          # minutes of no progress before stopping (unattended)
+                      # or warning (attended). `off` disables.
+  cost_usd: 5.00      # ONLY when the model's BillingMode is UsageBilled.
+                      # Absent/ignored for Subscription and Local.
+```
+
+Resolution: `config.yaml limits:` → `fleet.yaml limits:` → agent `profile.yaml limits:` → per-call override (`--deadline`, `--cost-usd`). Inner scopes **replace** a key; they never combine. A key absent at every scope takes the built-in default (§3.3).
+
+Removed as settings: `hitl.max_iterations`, `hitl.max_tokens`, `loop.max_iterations`, `loop.budget_usd` (renamed `cost_usd`). See §6 for migration.
+
+### 3.2 Attended vs unattended
+
+A run is **attended** when a murmur session holds its task (the same fact `can_approve` already carries for HITL). Everything else — `mur agent send`, cron fires, `fleet_run` from an agent, daemon auto-run, `--loop` — is unattended.
+
+| | attended | unattended |
+|---|---|---|
+| `deadline` | ignored | **required** to start (built-in default if none set) |
+| `stuck` | warns in the live band, never stops | stops with `LoopStop::Stuck` |
+| `cost_usd` | ignored | enforced when present and billable |
+| hard stop | `Esc` | deadline / stuck / cost / kill-switch |
+
+### 3.3 Built-in defaults
+
+| knob | attended | unattended |
+|---|---|---|
+| `deadline` | — | 1h fleet run, 30m single task |
+| `stuck` | 10m (warn) | 10m (stop) |
+| `cost_usd` | — | none (bounded by deadline) |
+
+Defaults are constants in `mur_common::limits`, and `mur limits` prints them labelled `(built-in default)`.
+
+### 3.4 Where the budget lives per unit of work
+
+| unit | owner of `limits` | inner scopes |
+|---|---|---|
+| murmur turn | attended: none | tools inherit "no cap" |
+| `mur agent send` | agent profile → config | — |
+| `mur fleet run` / `--loop` | fleet.yaml → config | delegated tasks inherit the fleet's remaining deadline; no per-task cap |
+| `fleet_run` tool from an agent | the fleet's | same |
+| workflow step | the run's | same |
+
+"Inherit the remaining deadline" means a task delegated with 12 minutes left on the fleet clock gets a 12-minute deadline, not a fresh one.
+
+### 3.5 Stuck detection
+
+Progress signals, any one of which resets the clock:
+
+- a file write through any tool,
+- a channel event authored by an agent (message, delegation, tool result),
+- a tool call whose `(name, arguments)` differ from the previous iteration's set.
+
+Not progress: another LLM turn that produces only text with no tool call and no channel event (that is the "reasoning in circles" case), a tool call identical to the last one (the "retrying the same thing" case — which is exactly what happened with `parallel_jobs not authorized` ×3).
+
+Attended: at the threshold the live band shows `⚠ no progress for 10m — Esc to stop`. Unattended: `LoopStop::Stuck` with the last three tool calls in the reason.
+
+### 3.6 Timeouts
+
+Two kinds, and they stop sharing a number:
+
+- **Liveness** (is the peer alive?): the runtime emits a heartbeat frame on the A2A stream at least every 30 s while a turn is in progress, including during model inference. The dial's idle timeout becomes 90 s. A router that thinks for ten minutes is alive the whole time.
+- **Work duration**: not a timeout at all. `parallel_jobs` and `fleet_run` return `{run_id, status: "dispatched"}` within a second; the caller polls `mur_job_status`. The MCP per-call default stays 120 s and is documented as "a tool that needs longer must return a handle".
+
+### 3.7 Stop reasons reach the user
+
+`LoopStop` gains `Deadline`, `Stuck { last_calls }`, `Cost { spent, cap }` detail, and the runtime's task loop gains the same enum for single tasks (replacing the silent "graceful exit with summary" that today looks like the agent simply had nothing to say). The reason is written as a channel `state-change` event with a `stop_reason` payload, so:
+
+- the murmur settlement card shows a `■ stopped` row: `stopped: deadline 1h — mur fleet limits develop-rust --deadline 3h`,
+- the fleet rail shows it under the fleet line instead of `finished (0s)`,
+- `progress.json` keeps `outcome` as today.
+
+Every reason carries the one-line remedy. The `finished` word is reserved for `Converged`.
+
+### 3.8 Fail at dispatch, not after the budget
+
+Before a delegated task starts, the runtime checks the task brief's declared needs against the agent's tool policy: a coding task (`write_file`/`edit_file`/`bash` requested or implied by the fleet role) on an agent whose policy denies them fails immediately with `cannot start: rustsmith has no write_file — mur agent perm tool-allow rustsmith write_file`. The check reads the same `ToolRule` list the gate reads; no new source of truth.
+
+Authorization errors (`not authorized for parallel_jobs`, `not in fleet_run.agents`, tool `Deny`) become a distinct `ToolError::NotAuthorized` that the loop treats as terminal for that tool: the model is told once and the tool is removed from its list for the rest of the turn.
+
+### 3.9 `mur limits`
+
+```
+$ mur limits develop-rust
+scope: fleet develop-rust (unattended when run by daemon/agent; attended in murmur)
+deadline   2h     ← ~/.mur/fleets/develop-rust/fleet.yaml
+stuck      10m    ← built-in default
+cost_usd   —      ← router model is Local; knob does not apply
+members inherit: rustsmith, pm, qa, repomanager (no per-task cap)
+
+$ mur limits rustsmith
+scope: agent rustsmith
+deadline   30m    ← built-in default (unattended single task)
+stuck      10m    ← ~/.mur/config.yaml
+cost_usd   —      ← model claude_haiku is Subscription; knob does not apply
+note: hitl.max_iterations: 800 in profile.yaml is IGNORED since 2.79 — remove it
+```
+
+`--json` for the Hub. `mur fleet limits <name> --deadline 3h` and `mur agent limits <name> --stuck off` write the scope's `limits:` block (dual-write pattern where a live agent must pick it up).
+
+## 4. Error handling
+
+- A `limits:` block with an unknown key or an unparsable duration is a load error with the path and line, not a silent default.
+- `cost_usd` set on a scope whose model is not `UsageBilled` loads fine and is reported by `mur limits` as "does not apply" — a fleet may mix models.
+- Heartbeat missing for 90 s → the dial fails with `agent X stopped responding` (not "went idle"), and the reason names the last heartbeat time.
+- A stuck stop always includes the last three `(tool, args-hash)` so the user can see the loop.
+
+## 5. Safety triad — what changes and what does not
+
+The rule "unattended auto-run is OFF unless `MUR_FLEET_AUTORUN=1`, also requires a positive `loop.budget_usd`, kill-switch honoured, governance fail-closed" was set deliberately. Its intent is **no unbounded unattended run**. This spec keeps every property and generalises one:
+
+| property | before | after |
+|---|---|---|
+| opt-in | `MUR_FLEET_AUTORUN=1` | unchanged |
+| bounded | `budget_usd > 0` | **`deadline` set, or `cost_usd` set on a billable model** — at least one, checked in `fleet_tick::due_fleets` exactly where `has_budget` is today |
+| kill-switch | `.stopped` sentinel | unchanged |
+| governance | fail-closed on Err | unchanged |
+| approvals | `yes:false` everywhere | unchanged |
+
+A local-model fleet is bounded by its deadline. A billable fleet with neither knob does not auto-run, same as today. **Approved by the user in conversation on 2026-09-12**; the `feedback_autonomous_loop_safety_audit` memory is updated to match.
+
+## 6. Migration
+
+- `hitl.max_iterations` / `hitl.max_tokens` in a profile: loaded, ignored, and reported once at agent start and by `mur limits` ("IGNORED since 2.79 — remove it"). Not an error: nobody's agent stops starting because of a stale key.
+- `loop.max_iterations`: same treatment.
+- `loop.budget_usd`: read as `limits.cost_usd` when `limits:` is absent, so existing billable fleets keep their bound; `mur fleet limits` writes the new key.
+- The runtime-internal iteration counter stays as a **diagnostic** (it appears in the stop reason and the live band) with an absurd ceiling (10 000) that exists only to turn a runaway bug into a stop instead of a hang. It is not a setting.
+
+## 7. Testing
+
+- `mur_common::limits`: resolution across three scopes, replace-not-combine, duration parsing, `cost_usd` applicability by `BillingMode`.
+- Runtime loop: attended run passes the old 25-iteration mark without stopping; unattended stuck stop fires on three identical tool calls and does not fire when a file was written; deadline inherited from the fleet is the remaining time, not a fresh one.
+- Fleet loop: `LoopStop::Deadline`/`Stuck`/`Cost` each land as a channel `state-change` with a `stop_reason` and the remedy string; the rail renders it.
+- `fleet_tick::due_fleets`: local-model fleet with a deadline auto-runs; billable fleet with neither knob does not; kill-switch still wins. These three replace the current "positive budget" test rather than sit beside it.
+- Dispatch preflight: a coding brief on an agent with `write_file` denied fails before the first LLM call.
+- `parallel_jobs` returns within 2 s with a `run_id` for a job that takes 60 s.
+- `mur limits` snapshot test: source labels per row.
+- Migration: a profile with `hitl.max_iterations: 800` starts, warns once, and the value has no effect.
+
+## 8. Out of scope
+
+- Context-window management (compaction) for very long attended sessions — a separate design; this spec only stops the runtime from *killing* such a session.
+- Per-tool cost attribution.
+- Hub UI for `limits:` — follows once the CLI shape has settled.
+- Removing `hitl.timeout_secs` — it is a real HITL knob and stays.
+
+## 9. Rollout
+
+1. Stop reasons reach the settlement card and fleet rail (§3.7) — no schema change, immediate relief.
+2. `cost_usd` applicability by `BillingMode` + the §5 gate change — small, isolated, unblocks local users.
+3. `mur_common::limits` schema, resolution, `mur limits` (§3.1, §3.9) with migration warnings (§6).
+4. Runtime loop switch: caps → deadline/stuck, inheritance from fleet (§3.4, §3.5).
+5. Heartbeats + handle-returning tools (§3.6).
+6. Dispatch preflight + non-retryable authorization (§3.8).
+
+Each step is its own plan and PR.


### PR DESCRIPTION
Design approved in conversation 2026-09-12, including the safety-triad change in §5 (**"bounded" replaces "positive `budget_usd`"** as the unattended auto-run requirement — a deadline, or a cost cap on a billable model).

Ten decisions, each with the alternative it rejects. The short version: the scope the user launched owns the budget and inner scopes never add a smaller one; three knobs (`deadline`, `stuck`, `cost_usd`) replace six; attended runs have no hard stops; unattended runs must be bounded; stuck measures progress in minutes, not iterations; long tools return handles; liveness is heartbeats; every stop names its reason and remedy where the user is looking; authorization gates stay but fail at dispatch and are non-retryable.

§10 covers the Hub: one `LimitsPanel` at three scopes (Settings, fleet Settings tab, agent Overview card), rendering what a single `limits_resolve` Tauri command returns from the same resolver `mur limits` uses; inherited vs overridden shown with source chips; `cost_usd` absent (not disabled) for local models; a `bounded ✓ / unbounded — will not auto-run` badge on the fleet header; stop reasons on job rows with a one-click "raise" action; stale-key removal.

Six-step rollout in §9 (Hub is step 3b), each its own plan and PR. Step 1 (stop reasons reach the settlement card) needs no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)