### PR TITLE
chore(release): bump workspace version to 2.79.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.78.0"
+version = "2.79.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.78.0"
+version = "2.79.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Merging this PR **is** the release: `tag.yml` tags `v2.79.0` and dispatches `release.yml` (crates.io publish is irreversible).

## ⚠ Behaviour change — execution limits (#1268 #1271 #1273 #1275, spec #1267)
- **Unattended** runs (`mur agent send`, `channel/delegate`, schedulers, fleet loops, daemon auto-run) no longer stop at 25 iterations / 750k input tokens. They stop on a **deadline** — built-in **30m** for a single task, **1h** for a fleet run — or after **10m with no progress** (`stuck`), unless a `limits:` block says otherwise. A fleet's members inherit the fleet's *remaining* deadline.
- **Attended** murmur turns no longer stop on their own; the stuck clock only writes one `⚠ no progress for 10m — Esc to stop` line.
- `hitl.max_iterations` / `hitl.max_tokens` / `loop.max_iterations` / `--max-iterations` are loaded and **ignored** (one notice each, never an error). `loop.budget_usd` is read as `limits.cost_usd`; a cost cap applies only to metered models (local / subscription fleets are bounded by the deadline).
- Daemon auto-run: "positive budget" is replaced by "the fleet's `limits:` resolve" — every fleet is bounded by its deadline; opt-in env and kill-switch unchanged.
- New: `mur limits <fleet|agent> [--json]`, `mur fleet limits`, `mur agent limits`, `mur limits --global …` (edits `config.yaml` textually). Every stop reaches the settlement card / fleet rail with its reason and remedy.

## Also since v2.78.0
- fix(update): 120s request timeout no longer kills a 152 MB download (#1263)
- fix(agent): report and repair launchers pinned to a runtime nobody refreshes (#1264)
- fix(delegate): a delegated turn declares it cannot answer an approval (#1265)
- fix(channel): an append never leaves a channel without a manifest (#1266)
- docs(readme): the `!` shell escape sends its output to the agent (#1262)

## After release
`mur update --restart-agents` — agents must restart to pick up the new runtime (`running.lock` build_sha is the judge, not `--version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)