### PR TITLE
chore(release): bump workspace version to 2.80.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6707,7 +6707,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.79.0"
+version = "2.80.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "mur-browser"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.79.0"
+version = "2.80.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Merging this PR **is** the release: `tag.yml` tags `v2.80.0` and dispatches `release.yml` (crates.io publish is irreversible).

## ⚠ Behaviour changes — execution limits steps 5 and 6 (#1279, #1281; spec #1267)
- **`fleet_run` (agent tool) and `parallel_jobs` (MCP tool) no longer return the work's output.** They return `{run_id, status: "dispatched"}` within a second; progress and the result come from `mur_job_status <run_id>` / `mur fleet status <fleet>` / the fleet channel. The murmur fleet rail and the `deep-research` panel show the run live. A `parallel_jobs` run lives inside the MCP server process that dispatched it. `fleet_run`'s `timeout_secs` is ignored (noted) and its old "positive budget or refuse" gate is gone.
- **Heartbeats:** the runtime emits `turn/heartbeat` every 30 s during a turn (`A2A_PROTO_VERSION` 2). The dial gives a peer at proto ≥ 2 a **90 s** idle timeout and reports a silent one as `stopped responding — no frame for 90s (last: …)`; older peers keep 600 s. **Restart agents after upgrading** to get on proto 2.
- **`needs:`** in `fleet.yaml` names the tools the work requires; a member missing one fails at dispatch with `cannot start: <agent> has no <tool> — mur agent perm tool-allow <agent> <tool>` before any model call. No `needs`, no preflight. Any authorization refusal (`not authorized:`) withdraws that tool for the rest of the turn instead of being retried ×N.
- New: `mur fleet run --run-id`, `mur deep-research --run-id`; the fleet loop is one `RunKind::Fleet` run that `mur_job_status` can follow.

## Also since v2.79.0
- docs(readme): bounded, not budgeted — the `limits:` schema and `mur limits` (#1277)

## After release
`mur update --restart-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)